### PR TITLE
# ADD - 서명 요청할 Signers의 리스트를 저장하도록 함

### DIFF
--- a/src/services/signature_requester.cpp
+++ b/src/services/signature_requester.cpp
@@ -19,6 +19,7 @@ namespace gruut {
         auto partial_block = makePartialBlock(transactions);
         auto message = makeMessage(partial_block);
 
+        Application::app().getOutputQueue()->push(message);
         startSignatureCollectTimer();
         return true;
     }

--- a/src/services/signer_pool_manager.cpp
+++ b/src/services/signer_pool_manager.cpp
@@ -7,15 +7,19 @@ namespace gruut {
     const unsigned int REQUEST_NUM_OF_SIGNER = 5;
 
     SignerPool SignerPoolManager::getSigners() {
-        SignerPool random_signers;
+        m_selected_signers_pool = std::make_shared<SignerPool>();
 
         const auto requested_signers_size = min(static_cast<unsigned int>(m_signer_pool.size()), REQUEST_NUM_OF_SIGNER);
         auto chosen_signers_index_set = generateRandomNumbers(requested_signers_size);
 
         for(auto index : chosen_signers_index_set)
-            random_signers.emplace_back(m_signer_pool[index]);
+            m_selected_signers_pool->emplace_back(m_signer_pool[index]);
 
-        return random_signers;
+        return *m_selected_signers_pool;
+    }
+
+    SignerPool SignerPoolManager::getSelectedSigners() {
+        return *m_selected_signers_pool;
     }
 
     void SignerPoolManager::putSigner(Signer &&s) {

--- a/src/services/signer_pool_manager.hpp
+++ b/src/services/signer_pool_manager.hpp
@@ -13,10 +13,12 @@ namespace gruut {
     class SignerPoolManager {
     public:
         SignerPool getSigners();
+        SignerPool getSelectedSigners();
         void putSigner(Signer&& s);
     private:
         RandomSignerIndices generateRandomNumbers(unsigned int size);
         SignerPool m_signer_pool;
+        shared_ptr<SignerPool> m_selected_signers_pool;
     };
 }
 #endif

--- a/tests/services/test.cpp
+++ b/tests/services/test.cpp
@@ -3,6 +3,8 @@
 #include <boost/test/unit_test.hpp>
 #include <vector>
 
+#include "../../src/application.hpp"
+
 #include "../../src/services/message_fetcher.hpp"
 #include "../../src/services/transaction_fetcher.hpp"
 #include "../../src/services/signer_pool_manager.hpp"
@@ -74,6 +76,25 @@ BOOST_AUTO_TEST_SUITE(Test_SignerPoolManager)
         BOOST_TEST(signers.size() == 1);
     }
 
+    BOOST_AUTO_TEST_CASE(getSelectedSigners) {
+            SignerPoolManager manager;
+
+            auto signers = manager.getSigners();
+            BOOST_TEST(signers.size() == 0);
+
+            Signer signer;
+            signer.cert = "1234";
+            signer.address = "1234";
+
+            manager.putSigner(std::move(signer));
+
+            BOOST_TEST(manager.getSelectedSigners().size() == 0);
+
+            manager.getSigners();
+
+            BOOST_TEST(manager.getSelectedSigners().size() == 1);
+    }
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(Test_SignatureRequester)
@@ -82,6 +103,9 @@ BOOST_AUTO_TEST_SUITE(Test_SignatureRequester)
         SignatureRequester requester;
 
         auto result = requester.requestSignatures();
+        BOOST_TEST(result);
+
+        result = Application::app().getOutputQueue()->size() > 0;
         BOOST_TEST(result);
     }
 


### PR DESCRIPTION
## 추가 사항
- 종전의 코드에서는 서명 요청할 Signers 들의 정보를 따로 저장하고 있지 않아서, 통신 모듈에서 누구에게 서명 요청할지 알수가 없었다.
- `SignerPoolManager` 에서 랜덤하게 Signers들을 뽑아올때 그것들을 따로 저장해서 나중에 통신 모듈에서 랜덤하게 뽑은 Signers들을 가져갈 수 있도록 구현
- 테스트 케이스 추가
  * `getSigners -> getSelectedSigners` 순서 종속성이 있어서 테스트 코드에 추가
  * `SignatureRequester` 가 request를 보내면 OutputQueue에 사이즈가 0 초과임을 테스트코드에 남김.