### PR TITLE
# EDIT - PartialBlock 생성시 머클트리 저장하도록 수정

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,6 @@ language: cpp
 os: linux
 compiler:
 - clang
-cache:
-  directories:
-  - ${TRAVIS_BUILD_DIR}/grpc
-  - ${TRAVIS_BUILD_DIR}/leveldb
-  - ${TRAVIS_BUILD_DIR}/botan
 addons:
   apt:
     sources:

--- a/src/chain/merkle_tree.cpp
+++ b/src/chain/merkle_tree.cpp
@@ -2,7 +2,7 @@
 #include "../utils/sha256.hpp"
 
 namespace gruut {
-    sha256 MerkleTree::generate(std::vector<sha256> transaction_ids) {
+    sha256 MerkleTree::generate(std::vector<sha256> &transaction_ids) {
         if (transaction_ids.empty()) return sha256();
 
         while (transaction_ids.size() > 1) {
@@ -10,7 +10,12 @@ namespace gruut {
                 transaction_ids.push_back(transaction_ids.back());
 
             for (auto i = 0; i < transaction_ids.size() / 2; i++) {
-                transaction_ids[i] = makeParentNode(transaction_ids[2 * i], transaction_ids[2 * i + 1]);
+                auto left = transaction_ids[2 * i];
+                auto right = transaction_ids[2 * i + 1];
+                auto parent_node = makeParentNode(left, right);
+
+                m_tree.emplace(parent_node, std::make_pair(left, right));
+                transaction_ids[i] = parent_node;
             }
 
             transaction_ids.resize(transaction_ids.size() / 2);
@@ -23,6 +28,8 @@ namespace gruut {
         const sha256 parent_node = l + r;
         return Sha256::encrypt(parent_node);
     }
+
+    const unordered_map<sha256, pair<sha256, sha256>> &MerkleTree::getTree() const {
+        return m_tree;
+    }
 }
-
-

--- a/src/chain/merkle_tree.hpp
+++ b/src/chain/merkle_tree.hpp
@@ -2,14 +2,20 @@
 #define GRUUT_ENTERPRISE_MERGER_MERKLE_TREE_HPP
 
 #include <vector>
+#include <unordered_map>
+#include <utility>
 #include "types.hpp"
+
+using namespace std;
 
 namespace gruut {
     class MerkleTree {
     public:
-        sha256 generate(std::vector<sha256> ids);
+        sha256 generate(vector<sha256> &ids);
+        const unordered_map<sha256, pair<sha256, sha256>> &getTree() const;
     private:
         sha256 makeParentNode(const sha256& l, const sha256& r);
+        unordered_map<sha256, pair<sha256, sha256>> m_tree;
     };
 }
 #endif

--- a/src/services/block_generator.cpp
+++ b/src/services/block_generator.cpp
@@ -1,9 +1,8 @@
-#include "../chain/types.hpp"
 #include "block_generator.hpp"
 #include "../chain/merkle_tree.hpp"
 
 namespace gruut {
-    PartialBlock BlockGenerator::generatePartialBlock(Transactions transactions) {
+    PartialBlock BlockGenerator::generatePartialBlock(sha256 transaction_root_id) {
         PartialBlock block;
 
         auto sent_time = to_string(std::time(0));
@@ -15,13 +14,7 @@ namespace gruut {
         // TODO: 위와 같은 이유로 sent_time
         block.height = sent_time;
 
-        MerkleTree tree;
-        vector<transaction_id_type> transaction_ids_list;
-        std::for_each(transactions.begin(), transactions.end(), [&transaction_ids_list](Transaction &transaction) {
-            transaction_ids_list.push_back(transaction.transaction_id);
-        });
-
-        block.transaction_root = tree.generate(transaction_ids_list);
+        block.transaction_root = transaction_root_id;
 
         return block;
     }

--- a/src/services/block_generator.hpp
+++ b/src/services/block_generator.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include "../chain/block.hpp"
 #include "../chain/transaction.hpp"
+#include "../chain/types.hpp"
 
 #include "signature_requester.hpp"
 
@@ -13,7 +14,7 @@ namespace gruut {
     using Transactions = vector<Transaction>;
     class BlockGenerator {
     public:
-        PartialBlock generatePartialBlock(Transactions transactions);
+        PartialBlock generatePartialBlock(sha256 transaction_root_id);
     };
 }
 

--- a/src/services/signature_requester.hpp
+++ b/src/services/signature_requester.hpp
@@ -7,6 +7,7 @@
 
 #include "../chain/block.hpp"
 #include "../chain/message.hpp"
+#include "../chain/merkle_tree.hpp"
 #include "../application.hpp"
 
 namespace gruut {
@@ -22,15 +23,16 @@ namespace gruut {
         bool requestSignatures();
 
     private:
-        void startSignatureCollectTimer();
+        void startSignatureCollectTimer(Transactions &transactions);
 
         Transactions fetchTransactions();
 
-        PartialBlock makePartialBlock(Transactions& transactions);
+        PartialBlock makePartialBlock(Transactions &transactions);
 
         Message makeMessage(PartialBlock &block);
 
         std::unique_ptr<boost::asio::deadline_timer> m_timer;
+        MerkleTree m_merkle_tree;
     };
 }
 #endif

--- a/tests/chain/test.cpp
+++ b/tests/chain/test.cpp
@@ -1,6 +1,7 @@
 #define BOOST_TEST_MODULE
 
 #include <boost/test/unit_test.hpp>
+#include <utility>
 
 #include "../../src/chain/merkle_tree.hpp"
 
@@ -34,6 +35,11 @@ BOOST_AUTO_TEST_SUITE(Test_MerkleTree)
 
         bool result = transaction_root == "63CD9C509AA5F6B9B3257123C01D2D1037797271BD4294CA74763F65E4B84812";
         BOOST_TEST(result);
+
+        auto &tree = t.getTree();
+        auto childs = *tree.find("63CD9C509AA5F6B9B3257123C01D2D1037797271BD4294CA74763F65E4B84812");
+        BOOST_TEST(childs.second.first == "CC220774E4FA38B49110107C4DE38DF2C28328B00345E403EF415A577C476E90");
+        BOOST_TEST(childs.second.second == "614FBDFCE3A9A8A500A369369FC98B3AB96F34E62A604B0D1FFA8C9611363066");
     }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/services/test.cpp
+++ b/tests/services/test.cpp
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_SUITE(Test_BlockGenerator)
 
         BlockGenerator generator;
 
-        auto block = generator.generatePartialBlock(transactions);
+        auto block = generator.generatePartialBlock("1");
 
         bool result = stoi(block.sent_time) > 0;
         BOOST_TEST(result);


### PR DESCRIPTION
## 수정사항
- 종전의 코드에서는 머클트리의 루트만 계산하고, 트리는 저장하지 않았다.
- 블럭에 들어갈 머클트리를 저장하기 위해 머클트리 전체를 unordered_map에 저장함