### PR TITLE
# ADD - Transaction ID 위치 검색, DB 디렉토리 삭제

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,9 +60,3 @@ lib/leveldb/libleveldb\.a
 CTestTestfile\.cmake
 
 lib/leveldb/leveldbConfigVersion\.cmake
-
-tests/modules/blk/*
-tests/modules/blkhash/*
-tests/modules/block_meta/*
-tests/modules/cert/*
-tests/modules/secure/*

--- a/src/modules/storage/storage.hpp
+++ b/src/modules/storage/storage.hpp
@@ -24,6 +24,8 @@ public:
 
   json findBy(const string &what, const string &id, const string &field);
 
+  json findTxIdPos(const string &blk_id, const string &tx_id);
+
 private:
   void handleCriticalError(const leveldb::Status &status);
 

--- a/tests/modules/test.cpp
+++ b/tests/modules/test.cpp
@@ -141,6 +141,13 @@ BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE(Test_Storage)
 
     BOOST_AUTO_TEST_CASE(write_block) {
+        string tx_list;
+        for (unsigned int idx = 0; idx < block["tx"].size() - 1; ++idx) {
+          tx_list += block["tx"][idx]["txID"];
+          tx_list += '_';
+        }
+        block["block"]["txList"] = tx_list;
+
         Storage storage;
         storage.openDB("./block");
 
@@ -148,9 +155,12 @@ BOOST_AUTO_TEST_SUITE(Test_Storage)
         string block_id = block["block"]["bID"];
 
         storage.write(block_json, "block", block_id);
-        auto data = storage.findBy("block", block_id, "ver").get<string>();
 
-        bool result = data == "4";
+        auto data1 = storage.findBy("block", block_id, "ver").get<string>();
+        auto data2 = storage.findTxIdPos("3fffffffffffffffffff", "bbbbbbbbb").get<string>();
+
+        bool result = (data1 == "4") && (data2 == "2");
+
         BOOST_TEST(result);
     }
 
@@ -210,12 +220,5 @@ BOOST_AUTO_TEST_SUITE(Test_Storage)
         bool result = data == "oosdmkbjectTobinary";
         BOOST_TEST(result);
     }
-
-    /*BOOST_AUTO_TEST_CASE(find_txid_pos) {
-
-    }*/
-    /*BOOST_AUTO_TEST_CASE(find_sibling){
-
-    }*/
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
  - 먼저 블록헤더에 Transaction List를 저장
  - Block ID와 Transaction ID가 주어지면 해당
 Transaction ID가 몇번째로 위치하는지 검색한다.
  - Test가 끝난 후 소멸자에서 DB 디렉토리를 삭제시켜준다.