### PR TITLE
# ADD - MessageChallenge 스펙에 맞춰서 Signer에게 전달 구현

### DIFF
--- a/src/services/signer_pool_manager.cpp
+++ b/src/services/signer_pool_manager.cpp
@@ -1,9 +1,13 @@
 #include <algorithm>
 #include <nlohmann/json.hpp>
 #include <random>
+#include <ctime>
 
 #include "message_proxy.hpp"
 #include "signer_pool_manager.hpp"
+#include "../chain/types.hpp"
+#include "../utils/sha256.hpp"
+#include "../utils/random_number_generator.hpp"
 
 using namespace nlohmann;
 
@@ -41,8 +45,17 @@ void SignerPoolManager::handleMessage(MessageType &message_type,
           make_tuple(MessageType::MSG_ERROR, receiver_list, json({}));
       proxy.deliverOutputMessage(output_message);
     } else {
+      json message_body;
+      // TODO: Merger id 가 아직 결정 안되어서 임시값 할당
+      sender_id_type sender_id = Sha256::hash("1");
+      time_t now = time(nullptr);
+
+      message_body["sender"] = Sha256::toString(sender_id);
+      message_body["time"] = ctime(&now);
+      message_body["mN"] = RandomNumGenerator::toString(RandomNumGenerator::randomize(64));
+
       OutputMessage output_message =
-          make_tuple(MessageType::MSG_CHALLENGE, receiver_list, json({}));
+          make_tuple(MessageType::MSG_CHALLENGE, receiver_list, message_body);
       proxy.deliverOutputMessage(output_message);
     }
   } break;

--- a/src/utils/random_number_generator.hpp
+++ b/src/utils/random_number_generator.hpp
@@ -2,8 +2,9 @@
 #define GRUUT_ENTERPRISE_MERGER_RANDOM_NUM_GENERATOR_HPP
 
 #include <botan/rng.h>
+#include <botan/base64.h>
 #include <vector>
-#include <botan/botan.h>
+#include <botan/auto_rng.h>
 
 using namespace std;
 
@@ -19,6 +20,10 @@ public:
       vector<uint8_t> random_number(&buffer[0], &buffer[random_number_bytes]);
 
       return random_number;
+    }
+
+    static string toString(vector<uint8_t> random_number_list) {
+      return Botan::base64_encode(random_number_list);
     }
 };
 


### PR DESCRIPTION
## 구현 사항
- 종전의 코드에서는 MSG_CHALLENGE 를 송신할때 빈 object의 json을 보냈음
- 기획서에 명시되어있는 스펙에 맞춰서 전송하도록 구현