### PR TITLE
Patch/ecdh

### DIFF
--- a/src/utils/hmac_key_maker.hpp
+++ b/src/utils/hmac_key_maker.hpp
@@ -43,9 +43,15 @@ public:
 
   std::pair<std::string, std::string> getPublicKey() {
     Botan::ECDH_PrivateKey my_secret_key(m_rng, m_group_domain, m_secret_key);
-    Botan::PointGFp my_private_key_point = my_secret_key.public_point();
-    return std::make_pair(my_private_key_point.get_x().to_hex_string(),
-                          my_private_key_point.get_y().to_hex_string());
+
+    std::string uncomp_point = Botan::hex_encode(my_secret_key.public_value());
+    size_t point_size = uncomp_point.size() - 2; // because of first 04 = means uncompressed point coordinator
+    size_t point_len = point_size / 2;
+
+    std::string my_public_key_x(uncomp_point.begin()+2,uncomp_point.begin()+point_len+2);
+    std::string my_public_key_y(uncomp_point.begin()+point_len+2, uncomp_point.end());
+
+    return std::make_pair(my_public_key_x, my_public_key_y);
   }
 
   Botan::secure_vector<uint8_t>

--- a/src/utils/hmac_key_maker.hpp
+++ b/src/utils/hmac_key_maker.hpp
@@ -8,6 +8,7 @@
 #include <botan/curve_gfp.h>
 #include <botan/ecdh.h>
 #include <botan/pubkey.h>
+#include <botan/hex.h>
 
 class HmacKeyMaker {
 private:

--- a/tests/utils/test.cpp
+++ b/tests/utils/test.cpp
@@ -8,6 +8,7 @@
 #include "../../src/utils/sig_manager.hpp"
 #include "../../src/utils/random_number_generator.hpp"
 #include "../../src/utils/hmac.hpp"
+#include "../../src/utils/hmac_key_maker.hpp"
 
 using namespace std;
 
@@ -130,5 +131,33 @@ BOOST_AUTO_TEST_CASE(verifyHMAC) {
 
   BOOST_TEST(Hmac::verifyHMAC(msg, hmac, key));
 }
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(Test_ECDH)
+
+  BOOST_AUTO_TEST_CASE(genrateSharedKey) {
+
+    std::string alice_sk_str = "0x2b0e4495ec270d7875311cd728ea946b11a1e587d1e21b314d5cd6f9831fa434";
+
+    HmacKeyMaker bob_ecdh;
+    bob_ecdh.genRandomSecretKey();
+    std::pair<std::string,std::string> bob_xy = bob_ecdh.getPublicKey();
+
+    std::string bob_x_str = "0x" + bob_xy.first;
+    std::string bob_y_str = "0x" + bob_xy.second;
+
+    HmacKeyMaker alice_ecdh;
+    alice_ecdh.setSecretKey(alice_sk_str);
+    std::pair<std::string,std::string> alice_xy = alice_ecdh.getPublicKey();
+
+    std::string alice_x_str = "0x" + alice_xy.first;
+    std::string alice_y_str = "0x" + alice_xy.second;
+
+    Botan::secure_vector<uint8_t> alice_ssk = alice_ecdh.getSharedSecretKey(bob_x_str, bob_y_str);
+    Botan::secure_vector<uint8_t> bob_ssk = bob_ecdh.getSharedSecretKey(alice_x_str, alice_y_str);
+
+    BOOST_TEST(Botan::hex_encode(alice_ssk) == Botan::hex_encode(bob_ssk));
+  }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
SK로부터 PK의 좌표를 구하는데 버그가 있었습니다. 구조적인 문제로 보여서 

기존: sk -> pk Point -> get_x, get_y -> hex_x, hex_y
현재: sk -> pk bytes -> hex_x. hex_y

로 바꾸었습니다.

하는 김에 테스트 코드도 같이 넣었고, 이상이 없음을 확인했습니다.
