### PR TITLE
 # ADD - hmac 검증 및 추가 사용

### DIFF
--- a/src/modules/communication/grpc_merger.cpp
+++ b/src/modules/communication/grpc_merger.cpp
@@ -6,7 +6,7 @@
 
 namespace gruut {
 
-void MergerRpcServer::runMergerServ(char *port_for_merger) {
+void MergerRpcServer::runMergerServ(char const *port_for_merger) {
   std::string port_num(port_for_merger);
   std::string server_address("0.0.0.0:");
   server_address += port_num;
@@ -40,14 +40,23 @@ void MergerRpcServer::runSignerServ(char const *port_for_signer) {
       MessageType msg_type = get<0>(msg);
       if (checkSignerMsgType(msg_type)) {
         output_queue->pop();
-        uint64_t receiver_id = get<1>(msg)[0];
         nlohmann::json json_data = get<2>(msg);
         MessageHeader msg_header;
         msg_header.message_type = msg_type;
+        //TODO: 압축 알고리즘 종류에따라 수정 될 수 있음.
         msg_header.compression_algo_type = CompressionAlgorithmType::NONE;
         std::string header_added_data =
             HeaderController::makeHeaderAddedData(msg_header, json_data);
-        sendDataToSigner(header_added_data, receiver_id, msg_type);
+        //TODO: hmac을 붙히는 부분. key를 가져오게되면 주석 해제
+        /*if(msg_type == MessageType::MSG_ACCEPT || msg_type == MessageType::MSG_REQ_SSIG){
+          std::vector<uint8_t> key;
+          std::vector<uint8_t> hmac = Hmac::generateHMAC(header_added_data, key);
+          std::string str_hmac(hmac.begin(), hmac.end());
+          header_added_data += str_hmac;
+        }*/
+        for(uint64_t receiver_id : get<1>(msg)) {
+          sendDataToSigner(header_added_data, receiver_id, msg_type);
+        }
       }
     }
   }
@@ -213,7 +222,6 @@ Status MergerRpcServer::SignerService::sigSend(ServerContext *context,
 
 void MergerRpcClient::run() {
   auto &output_queue = Application::app().getOutputQueue();
-  // TODO: 아래 if문을 포함하는 무한루프 필요
   while (true) {
     std::this_thread::sleep_for(std::chrono::milliseconds(150));
     if (!output_queue->empty()) {

--- a/src/modules/communication/grpc_merger.hpp
+++ b/src/modules/communication/grpc_merger.hpp
@@ -35,7 +35,7 @@ public:
 
     m_server_signer->Shutdown();
   }
-  void runMergerServ(char *port_for_merger);
+  void runMergerServ(char const *port_for_merger);
   void runSignerServ(char const *port_for_signer);
 
 private:

--- a/src/modules/communication/grpc_util.hpp
+++ b/src/modules/communication/grpc_util.hpp
@@ -3,6 +3,7 @@
 #include "../../application.hpp"
 #include <cstring>
 #include <grpcpp/impl/codegen/status.h>
+#include "../../utils/hmac.hpp"
 #include <iostream>
 #include <lz4.h>
 #include <string>
@@ -17,6 +18,7 @@ constexpr uint8_t LOCAL_CHAIN_ID[8] = {'1', '2', '3', '4', '5', '6', '7', '8'};
 constexpr uint8_t SENDER_ID[8] = {'1', '2', '3', '4', '5', '6', '7', '8'};
 constexpr uint8_t RESERVED[6] = {'1', '2', '3', '4', '5', '6'};
 
+constexpr size_t HMAC_LENGTH = 32;
 constexpr size_t HEADER_LENGTH = 32;
 
 class HeaderController {
@@ -24,7 +26,7 @@ public:
   static std::string
   attachHeader(std::string &compressed_json, MessageType msg_type,
                CompressionAlgorithmType compression_algo_type);
-  static std::string detachHeader(std::string &raw_data);
+  static std::string getMsgBody(std::string &raw_data, int body_size);
   static bool validateMessage(MessageHeader &msg_header);
   static int getMsgBodySize(MessageHeader &msg_header);
   static nlohmann::json

--- a/tests/modules/test.cpp
+++ b/tests/modules/test.cpp
@@ -40,12 +40,12 @@ BOOST_AUTO_TEST_SUITE(Test_HeaderController)
         BOOST_TEST(header_added_data == header_added_data_test);
     }
 
-    BOOST_AUTO_TEST_CASE(detachHeader) {
+    BOOST_AUTO_TEST_CASE(getMsgBody) {
         string header_added_data = "11111111111111111111111111111111data";
         string data = "data";
-        string header_detached_data = HeaderController::detachHeader(header_added_data);
+        string msg_body = HeaderController::getMsgBody(header_added_data, data.length());
 
-        BOOST_TEST(header_detached_data == data);
+        BOOST_TEST(msg_body == data);
     }
 
     BOOST_AUTO_TEST_CASE(validateMessage) {


### PR DESCRIPTION
- message type에 따라 hmac을 붙히거나 검증하는 부분 추가.
- hmac이 뒤에 붙으므로 body 사이즈가 필요하다고 생각하여 grpc_util의 detachHeader함수 수정
  * detachHeader -> getMsgBody 로 이름 수정