### PR TITLE
# ADD - SignerPool에 Signer 추가 및 Signer에게 Accept 메시지 송신 구현

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -10,6 +10,8 @@ InputQueue &Application::getInputQueue() { return m_input_queue; }
 
 OutputQueue &Application::getOutputQueue() { return m_output_queue; }
 
+SignerPool &Application::getSignerPool() { return *m_signer_pool; }
+
 SignerPoolManager &Application::getSignerPoolManager() {
   return *m_signer_pool_manager;
 }
@@ -48,6 +50,7 @@ Application::Application() {
   m_io_serv = make_shared<boost::asio::io_service>();
   m_input_queue = make_shared<queue<InputMessage>>();
   m_output_queue = make_shared<queue<OutputMessage>>();
+  m_signer_pool = make_shared<SignerPool>();
   m_signer_pool_manager = make_shared<SignerPoolManager>();
   m_transaction_pool = make_shared<TransactionPool>();
   m_signature_pool = make_shared<SignaturePool>();

--- a/src/application.hpp
+++ b/src/application.hpp
@@ -38,6 +38,8 @@ public:
 
   OutputQueue &getOutputQueue();
 
+  SignerPool &getSignerPool();
+
   SignerPoolManager &getSignerPoolManager();
 
   TransactionPool &getTransactionPool();
@@ -54,7 +56,8 @@ private:
   shared_ptr<boost::asio::io_service> m_io_serv;
   InputQueue m_input_queue;
   OutputQueue m_output_queue;
-  shared_ptr<gruut::SignerPoolManager> m_signer_pool_manager;
+  shared_ptr<SignerPool> m_signer_pool;
+  shared_ptr<SignerPoolManager> m_signer_pool_manager;
   shared_ptr<TransactionPool> m_transaction_pool;
   shared_ptr<SignaturePool> m_signature_pool;
 

--- a/src/chain/signer.hpp
+++ b/src/chain/signer.hpp
@@ -2,7 +2,6 @@
 #define GRUUT_ENTERPRISE_MERGER_SIGNER_HPP
 
 #include <botan/secmem.h>
-#include <ctime>
 #include <string>
 
 #include "types.hpp"
@@ -12,7 +11,7 @@ struct Signer {
   signer_id_type user_id{0};
   std::string pk_cert;
   hmac_key_type hmac_key;
-  std::time_t last_update{0};
+  uint64_t last_update{0};
   SignerStatus status{SignerStatus::UNKNOWN};
 
   // TODO: Storage에서 signer가 신규인지 아닌지 검색할 수 있는 기능 추가되면

--- a/src/services/message_proxy.cpp
+++ b/src/services/message_proxy.cpp
@@ -14,7 +14,8 @@ void MessageProxy::deliverInputMessage(InputMessage &input_message) {
 
   switch (message_type) {
   case MessageType::MSG_JOIN:
-  case MessageType::MSG_RESPONSE_1: {
+  case MessageType::MSG_RESPONSE_1:
+  case MessageType::MSG_SUCCESS: {
     Application::app().getSignerPoolManager().handleMessage(
         message_type, receiver_id, message_body_json);
   } break;

--- a/src/services/signer_pool.cpp
+++ b/src/services/signer_pool.cpp
@@ -48,7 +48,8 @@ bool SignerPool::updateHmacKey(signer_id_type user_id,
   } else {
     std::lock_guard<std::mutex> guard(m_update_mutex);
     m_signer_pool[signer_index].hmac_key = hmac_key;
-    m_signer_pool[signer_index].last_update = std::time(nullptr);
+    m_signer_pool[signer_index].last_update =
+        static_cast<uint64_t>(std::time(nullptr));
     m_update_mutex.unlock();
 
     return true;

--- a/src/services/signer_pool_manager.hpp
+++ b/src/services/signer_pool_manager.hpp
@@ -32,6 +32,7 @@ private:
 
   bool isJoinable();
   std::string m_merger_nonce;
+  std::string m_signer_cert;
   vector<uint8_t> m_shared_secret_key;
 
   std::shared_ptr<SignerPool> m_signer_pool;

--- a/src/utils/type_converter.hpp
+++ b/src/utils/type_converter.hpp
@@ -1,6 +1,7 @@
 #ifndef GRUUT_ENTERPRISE_MERGER_TYPE_CONVERTER_HPP
 #define GRUUT_ENTERPRISE_MERGER_TYPE_CONVERTER_HPP
 
+#include <botan/secmem.h>
 #include <string>
 #include <vector>
 
@@ -8,6 +9,11 @@ class TypeConverter {
 public:
   static std::vector<uint8_t> toBytes(std::string str) {
     return std::vector<uint8_t>(str.begin(), str.end());
+  }
+
+  static Botan::secure_vector<uint8_t>
+  toSecureVector(std::vector<uint8_t> vec) {
+    return Botan::secure_vector<uint8_t>(vec.begin(), vec.end());
   }
 };
 

--- a/tests/services/test.cpp
+++ b/tests/services/test.cpp
@@ -17,6 +17,7 @@
 #include "../../include/nlohmann/json.hpp"
 
 #include "../../src/utils/compressor.hpp"
+#include "../../src/utils/type_converter.hpp"
 
 using namespace gruut;
 using namespace nlohmann;
@@ -57,6 +58,22 @@ BOOST_AUTO_TEST_SUITE(Test_MessageFactory)
 //
 //        result = message.data == j_string2;
 //        BOOST_TEST(result);
+    }
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(Test_SignerPool)
+
+    BOOST_AUTO_TEST_CASE(pushSigner) {
+      SignerPool signer_pool;
+
+      signer_id_type id = 1;
+      string test_cert = "MIIC7zCCAdegAwIBAgIBADANBgkqhkiG9w0BAQsFADBhMRQwEgYDVQQDEwt0aGVWYXVsdGVyczELMAkGA1UEBhMCS1IxCTAHBgNVBAgTADEQMA4GA1UEBxMHSW5jaGVvbjEUMBIGA1UEChMLdGhlVmF1bHRlcnMxCTAHBgNVBAsTADAeFw0xODExMjgwNTM1NDFaFw0xOTExMjgwNTM1NDFaMBUxEzARBgNVBAMMCkdSVVVUX0FVVEgwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDV2RKC+oo6sBeAoSJn55ZZJ+U9bRh4z/TOsc4V/92NsV5qXpiWhUMTqPfNGHTjR7ScI57ZH9lqltcBJ2mcqhBWY1A/lQfdWAJf+3/eh+H/ZvDcZW8s9PFeuJcftmEDtUMlh9xMUoL5a74dS5lhrdbH0tXRMfhB3w02fmkuvqW+MCsUubhL7mu0PDbJeWjqqu8P+c+6PWO0CRgkMmry1f1VksXTzp54wARW2O3Zut6Z56VknrMOP2f4IYGiLy8zC/oO/JRCPCFvW1cM5UDdjVaq8UkIZ7B/z4zqFjwT3gXHHdMp+RLS8t+tA15rhZ2iRtKPcSwlpV95BTBG3Jpbm7xTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAEAzwa2yTQMR6nRUgafc/v0z7PylG4ohkXljBzMxfFipYju1/AKse1PCBq2H9DSnSbeL/BI4lQjsXXJLCDSnWXNnJSt1oatOHv4JeJ2Ob88EBVkx7G0aK2S2yijfMx5Bpptp8FIYxZX0QuOJ2oNK73j1Dx9Xax+5ZkBE8wxYYXpsZ0R/BGw8Es1bNFyFcbNYWd3iQOwoXOenWWa6YOyzRhZ2EAw+l7C7LB6I68xIIAP0BBSMTOfq4Smdizdd3qWYJyouUcv83AZn8KWBJjRKNJgHQvnYzCCGnhOwekbh9WlrGVEUvr/b6yV/aXX6kMqsCAfLhloqQ7Ai24QvOfdOAEQ=";
+      vector<uint8_t> secret_key(32, 0);
+      auto secret_key_vector = TypeConverter::toSecureVector(secret_key);
+      signer_pool.pushSigner(4, test_cert, secret_key_vector, SignerStatus::GOOD);
+
+      BOOST_CHECK_EQUAL(signer_pool.size(), 1);
     }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## 추가사항
- MSG_SUCCESS 처리
  * `signer_pool_manager` 에서 SignerPool 에 signer 정보를 넣고, MSG_ACCEPT 에 대한 응답을 보냄
- 전역으로 관리하는 SignerPool 를 Application 클래스에 멤버변수로 추가
- SignerPool#pushSigner 테스트 코드 추가

## TODO(다음 PR에서 진행할 것)
- 현재 SignerPoolManager는 Application 클래스의 멤버변수로 관리되고 있다. SignerPoolManager는 join하려고 하는 signer 와 통신하면서 merger_nonce, shared_secret_key 등을 저장하고 있기 때문에 다수의 Signer가 SignerPoolManager를 접근하면 의도하지 않은 값으로 상태 변수들이 overwrite 될 수 있다. MSG_JOIN 부터 MSG_ACCEPT 까지 통신에 필요한 값들을 적절하게 관리할 수 있어야 한다.
- connection table를 생성해서 signer 당 하나의 entry로 관리해서 MSG_ERROR 또는 MSG_ACCEPT 단계에서 그 entry를 제거하도록 구현 예정

