### PR TITLE
# FIX - 다수의 Signers가 동시에 SignerPoolManager를 접근할때 생길 수 있는 문제 해결

### DIFF
--- a/src/chain/join_temporary_data.hpp
+++ b/src/chain/join_temporary_data.hpp
@@ -1,0 +1,16 @@
+#ifndef GRUUT_ENTERPRISE_MERGER_JOINTEMPORARYDATA_HPP
+#define GRUUT_ENTERPRISE_MERGER_JOINTEMPORARYDATA_HPP
+
+#include <string>
+#include <vector>
+
+using namespace std;
+
+namespace gruut {
+struct JoinTemporaryData {
+  string merger_nonce;
+  string signer_cert;
+  vector<uint8_t> shared_secret_key;
+};
+} // namespace gruut
+#endif // GRUUT_ENTERPRISE_MERGER_JOINTEMPORARYDATA_HPP

--- a/src/services/signer_pool_manager.hpp
+++ b/src/services/signer_pool_manager.hpp
@@ -4,8 +4,10 @@
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <set>
+#include <unordered_map>
 #include <vector>
 
+#include "../chain/join_temporary_data.hpp"
 #include "../chain/signer.hpp"
 #include "../chain/types.hpp"
 #include "signer_pool.hpp"
@@ -20,20 +22,21 @@ public:
   SignerPoolManager() = default;
   // TODO: SignerPool 구조가 변경됨에 따라 나중에 수정
   //  SignerPool getSelectedSignerPool();
-  void handleMessage(MessageType &message_type, uint64_t receiver_id,
+  void handleMessage(MessageType &message_type, signer_id_type receiver_id,
                      nlohmann::json message_body_json);
 
 private:
   RandomSignerIndices generateRandomNumbers(unsigned int size);
-  bool verifySignature(nlohmann::json message_body_json);
+  bool verifySignature(signer_id_type signer_id,
+                       nlohmann::json message_body_json);
   string getCertificate();
   string signMessage(vector<uint8_t>, vector<uint8_t>, vector<uint8_t>,
                      vector<uint8_t>, vector<uint8_t>);
   bool isJoinable();
 
-  std::string m_merger_nonce;
-  std::string m_signer_cert;
-  vector<uint8_t> m_shared_secret_key;
+  // A temporary table for connection establishment.
+  unordered_map<signer_id_type, unique_ptr<JoinTemporaryData>>
+      join_temporary_table;
 };
 } // namespace gruut
 #endif


### PR DESCRIPTION
## 수정사항
- 종전의 코드에서는 다수의 Signers가 SignerPoolManager(Single intance)를 접근하면 m_merger_nonce, m_signer_cert 등 Signer가 JOIN에 필요한 정보들이 overwrite 된다.
- 그것을 막기 위해서는 signer_id 마다 따로 데이터를 관리해야 한다.
- JoinTemporaryData 구조체를 생성하고, SignerPoolManager에서 signer_id 별로 따로 관리하도록 구현.(unordered_map)