### PR TITLE
#FIXED: bug in fetching entry from InputQueue and OutputQueue

### DIFF
--- a/src/services/input_queue.hpp
+++ b/src/services/input_queue.hpp
@@ -40,8 +40,8 @@ public:
   }
 
   InputMsgEntry fetch() {
-    InputMsgEntry ret_msg = m_input_msg_pool.front();
     std::lock_guard<std::mutex> lock(m_queue_mutex);
+    InputMsgEntry ret_msg = m_input_msg_pool.front();
     m_input_msg_pool.pop_front();
     m_queue_mutex.unlock();
     return ret_msg;

--- a/src/services/output_queue.hpp
+++ b/src/services/output_queue.hpp
@@ -51,8 +51,8 @@ public:
   }
 
   OutputMsgEntry fetch() {
-    OutputMsgEntry ret_msg = m_output_msg_pool.front();
     std::lock_guard<std::mutex> lock(m_queue_mutex);
+    OutputMsgEntry ret_msg = m_output_msg_pool.front();
     m_output_msg_pool.pop_front();
     m_queue_mutex.unlock();
     return ret_msg;


### PR DESCRIPTION
### 설명
- InputQueue와 OutpuQueue에서 메시지 엔트리를 패치해올 때, pop_front에 mutex 를 걸었습니다.
- 그런데 잘 생각해 보면 read하는 것은 두 쓰레드가 동시에 할 수 있고, 동일한 엔트리를 가져왔는데, 그 사이에 한 쓰레드가 pop_front 해버리고, 다른 쓰레드가 pop_front를 연속해서 해버리면 두 쓰레드가 가져간 메시지 엔트리는 같은데, 메시지 엔트리가 2개 사라지는 일이 벌어집니다. 
- 따라서 mutex를 read 액션에도 같이 걸어주어야 합니다.