### PR TITLE
 #FIXED - 빈 큐 처리 및 테스트 코드 추가

### DIFF
--- a/src/chain/types.hpp
+++ b/src/chain/types.hpp
@@ -11,6 +11,7 @@ enum class TransactionType { CHECKSUM, CERTIFICATE };
 enum class BlockType { PARTIAL, NORMAL };
 
 enum class MessageType : uint8_t {
+  MSG_NULL = 0x00,
   MSG_UP = 0x30,
   MSG_PING = 0x31,
   MSG_REQ_BLOCK = 0x32,
@@ -34,6 +35,7 @@ enum class MACAlgorithmType : uint8_t {
   ECDSA = 0x01,
   EdDSA = 0x02,
   Schnorr = 0x03,
+  RSA_PKCS115 = 0x10,
 
   HMAC = 0xF1,
   NONE = 0xFF

--- a/src/services/input_queue.hpp
+++ b/src/services/input_queue.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../utils/template_singleton.hpp"
+#include "../chain/types.hpp"
 #include <deque>
 #include <iostream>
 #include <mutex>
@@ -10,25 +11,27 @@
 namespace gruut {
 
 struct InputMsgEntry {
-  uint8_t type;
+  MessageType type;
   nlohmann::json body;
-  InputMsgEntry(uint8_t msg_type_, nlohmann::json &msg_body_)
+  InputMsgEntry()
+      : type(MessageType::MSG_NULL), body(nullptr) {}
+  InputMsgEntry(MessageType msg_type_, nlohmann::json &msg_body_)
       : type(msg_type_), body(msg_body_) {}
 };
 
-class InputQueue : public TemplateSingleton<InputQueue> {
+class InputQueueAlt : public TemplateSingleton<InputQueueAlt> {
 private:
   std::deque<InputMsgEntry> m_input_msg_pool;
   std::mutex m_queue_mutex;
 
 public:
-  void push(std::tuple<uint8_t, nlohmann::json> &msg_entry_tuple) {
+  void push(std::tuple<MessageType, nlohmann::json> &msg_entry_tuple) {
     InputMsgEntry tmp_msg_entry(std::get<0>(msg_entry_tuple),
                                 std::get<1>(msg_entry_tuple));
     push(tmp_msg_entry);
   }
 
-  void push(uint8_t msg_type, nlohmann::json &msg_body) {
+  void push(MessageType msg_type, nlohmann::json &msg_body) {
     InputMsgEntry tmp_msg_entry(msg_type, msg_body);
     push(tmp_msg_entry);
   }
@@ -40,13 +43,22 @@ public:
   }
 
   InputMsgEntry fetch() {
+    InputMsgEntry ret_msg;
     std::lock_guard<std::mutex> lock(m_queue_mutex);
-    InputMsgEntry ret_msg = m_input_msg_pool.front();
-    m_input_msg_pool.pop_front();
+    if(!m_input_msg_pool.empty()) {
+      ret_msg = m_input_msg_pool.front();
+      m_input_msg_pool.pop_front();
+    }
     m_queue_mutex.unlock();
     return ret_msg;
   }
 
-  void clearInputQueue() { m_input_msg_pool.clear(); }
+  inline bool empty(){
+    return m_input_msg_pool.empty();
+  }
+
+  inline void clearInputQueue() {
+    m_input_msg_pool.clear();
+  }
 };
 } // namespace gruut

--- a/src/services/output_queue.hpp
+++ b/src/services/output_queue.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../utils/template_singleton.hpp"
+#include "../chain/types.hpp"
 #include <deque>
 #include <iostream>
 #include <mutex>
@@ -10,35 +11,38 @@
 namespace gruut {
 
 struct OutputMsgEntry {
-  uint8_t type;
+  MessageType type;
   nlohmann::json body;
   std::vector<std::string> receivers;
-  OutputMsgEntry(uint8_t msg_type_, nlohmann::json &msg_body_,
+  OutputMsgEntry()
+      : type(MessageType::MSG_NULL), body(nullptr), receivers({}) {}
+  OutputMsgEntry(MessageType msg_type_, nlohmann::json &msg_body_,
                  std::vector<std::string> &msg_receivers_)
       : type(msg_type_), body(msg_body_), receivers(msg_receivers_) {}
 };
 
-class OutputQueue : public TemplateSingleton<OutputQueue> {
+class OutputQueueAlt : public TemplateSingleton<OutputQueueAlt> {
 private:
   std::deque<OutputMsgEntry> m_output_msg_pool;
   std::mutex m_queue_mutex;
 
 public:
-  void push(std::tuple<uint8_t, nlohmann::json, std::vector<std::string>>
+  void push(std::tuple<MessageType, nlohmann::json, std::vector<std::string>>
                 &msg_entry_tuple) {
     OutputMsgEntry tmp_msg_entry(std::get<0>(msg_entry_tuple),
                                  std::get<1>(msg_entry_tuple),
                                  std::get<2>(msg_entry_tuple));
+
     push(tmp_msg_entry);
   }
 
-  void push(uint8_t msg_type, nlohmann::json &msg_body) {
+  void push(MessageType msg_type, nlohmann::json &msg_body) {
     std::vector<std::string> msg_receivers;
     OutputMsgEntry tmp_msg_entry(msg_type, msg_body, msg_receivers);
     push(tmp_msg_entry);
   }
 
-  void push(uint8_t msg_type, nlohmann::json &msg_body,
+  void push(MessageType msg_type, nlohmann::json &msg_body,
             std::vector<std::string> &msg_receivers) {
     OutputMsgEntry tmp_msg_entry(msg_type, msg_body, msg_receivers);
     push(tmp_msg_entry);
@@ -50,14 +54,23 @@ public:
     m_queue_mutex.unlock();
   }
 
-  OutputMsgEntry fetch() {
+  OutputMsgEntry fetch(OutputMsgEntry &msg) {
+    OutputMsgEntry ret_msg;
     std::lock_guard<std::mutex> lock(m_queue_mutex);
-    OutputMsgEntry ret_msg = m_output_msg_pool.front();
-    m_output_msg_pool.pop_front();
+    if(!m_output_msg_pool.empty()) {
+      ret_msg = m_output_msg_pool.front();
+      m_output_msg_pool.pop_front();
+    }
     m_queue_mutex.unlock();
     return ret_msg;
   }
 
-  void clearOutputQueue() { m_output_msg_pool.clear(); }
+  inline bool empty(){
+    return m_output_msg_pool.empty();
+  }
+
+  inline void clearOutputQueue() {
+    m_output_msg_pool.clear();
+  }
 };
 } // namespace gruut

--- a/tests/services/test.cpp
+++ b/tests/services/test.cpp
@@ -9,6 +9,8 @@
 #include "../../src/services/signer_pool_manager.hpp"
 #include "../../src/services/block_generator.hpp"
 #include "../../src/services/message_factory.hpp"
+#include "../../src/services/input_queue.hpp"
+#include "../../src/services/output_queue.hpp"
 
 #include "../../src/chain/transaction.hpp"
 #include "../../src/chain/message.hpp"
@@ -75,5 +77,30 @@ BOOST_AUTO_TEST_SUITE(Test_SignerPool)
 
       BOOST_CHECK_EQUAL(signer_pool.size(), 1);
     }
+
+BOOST_AUTO_TEST_SUITE_END()
+
+
+BOOST_AUTO_TEST_SUITE(Test_MessageIOQueues)
+
+  BOOST_AUTO_TEST_CASE(pushMessages) {
+    nlohmann::json msg_body = "{}"_json;
+    std::vector<std::string> msg_receiver = {};
+
+    InputQueueAlt * input_queue = InputQueueAlt::getInstance();
+    InputMsgEntry test_input_msg(MessageType::MSG_ACCEPT, msg_body);
+    input_queue->push(test_input_msg);
+
+    OutputQueueAlt * output_queue = OutputQueueAlt::getInstance();
+    OutputMsgEntry test_output_msg(MessageType::MSG_ACCEPT, msg_body, msg_receiver);
+    output_queue->push(test_output_msg);
+
+    bool test_result = (!input_queue->empty() && !output_queue->empty());
+
+    InputQueueAlt::destroyInstance();
+    OutputQueueAlt::destroyInstance();
+
+    BOOST_TEST(test_result);
+  }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### 한 일
- 타입에 MSG_NULL 추가
- 큐가 비어 있을 때 fetch하면 MSG_NULL 메시지가 리턴되도록 수정
- empty() 멤버함수 추가 (fetch하기 전에 큐가 비어 있는지 확인하는 걸 권고)
- 약간의 테스트 코드 추가
- 클래스 이름 InputQueueAlt / OutputQueueAlt로 재명명