### PR TITLE
# ADD - Transaction을 TransactionPool에 넣는 코드 구현

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -1,7 +1,6 @@
 #include "application.hpp"
 #include "chain/transaction.hpp"
 #include "modules/module.hpp"
-#include "services/signer_pool_manager.hpp"
 
 namespace gruut {
 boost::asio::io_service &Application::getIoService() { return *m_io_serv; }
@@ -18,6 +17,10 @@ SignerPoolManager &Application::getSignerPoolManager() {
 
 TransactionPool &Application::getTransactionPool() {
   return *m_transaction_pool;
+}
+
+TransactionCollector &Application::getTransactionCollector() {
+  return *m_transaction_collector;
 }
 
 SignaturePool &Application::getSignaturePool() { return *m_signature_pool; }
@@ -53,6 +56,7 @@ Application::Application() {
   m_signer_pool = make_shared<SignerPool>();
   m_signer_pool_manager = make_shared<SignerPoolManager>();
   m_transaction_pool = make_shared<TransactionPool>();
+  m_transaction_collector = make_shared<TransactionCollector>();
   m_signature_pool = make_shared<SignaturePool>();
 
   m_thread_group = make_shared<std::vector<std::thread>>();

--- a/src/application.hpp
+++ b/src/application.hpp
@@ -3,6 +3,7 @@
 
 #include "modules/module.hpp"
 #include "services/signer_pool_manager.hpp"
+#include "services/transaction_collector.hpp"
 #include <boost/asio.hpp>
 #include <queue>
 #include <thread>
@@ -44,6 +45,8 @@ public:
 
   TransactionPool &getTransactionPool();
 
+  TransactionCollector &getTransactionCollector();
+
   SignaturePool &getSignaturePool();
 
   void start(const vector<shared_ptr<Module>> &modules);
@@ -59,6 +62,7 @@ private:
   shared_ptr<SignerPool> m_signer_pool;
   shared_ptr<SignerPoolManager> m_signer_pool_manager;
   shared_ptr<TransactionPool> m_transaction_pool;
+  shared_ptr<TransactionCollector> m_transaction_collector;
   shared_ptr<SignaturePool> m_signature_pool;
 
   shared_ptr<std::vector<std::thread>> m_thread_group;

--- a/src/chain/transaction.hpp
+++ b/src/chain/transaction.hpp
@@ -2,15 +2,18 @@
 #define GRUUT_ENTERPRISE_MERGER_TRANSACTION_HPP
 
 #include "types.hpp"
+#include <array>
+#include <string>
+#include <vector>
 
 namespace gruut {
 struct Transaction {
   transaction_id_type transaction_id;
-  timestamp sent_time;
+  std::array<uint8_t, 8> sent_time;
   requestor_id_type requestor_id;
   TransactionType transaction_type;
   signature_type signature;
-  content_type content;
+  std::vector<content_type> content_list;
 };
 
 struct NullTransaction : public Transaction {

--- a/src/chain/types.hpp
+++ b/src/chain/types.hpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 namespace gruut {
-enum class TransactionType { CHECKSUM, CERTIFICATE };
+enum class TransactionType { DIGESTS, CERTIFICATE };
 
 enum class BlockType { PARTIAL, NORMAL };
 
@@ -46,16 +46,17 @@ enum class CompressionAlgorithmType : uint8_t { LZ4 = 0x04, NONE = 0xFF };
 enum class SignerStatus { UNKNOWN, ERROR, GOOD };
 
 using sha256 = std::vector<uint8_t>;
+using bytes = std::vector<uint8_t>;
 using timestamp = std::string;
 using block_height_type = std::string;
 
-using transaction_id_type = sha256;
+using transaction_id_type = bytes;
 using requestor_id_type = sha256;
 using sender_id_type = sha256;
 using signer_id_type = uint64_t;
 using transaction_root_type = sha256;
 using chain_id_type = sha256;
-using signature_type = sha256;
+using signature_type = bytes;
 
 using content_type = std::string;
 

--- a/src/services/block_generator.cpp
+++ b/src/services/block_generator.cpp
@@ -5,8 +5,8 @@ namespace gruut {
 PartialBlock BlockGenerator::generatePartialBlock(sha256 transaction_root_id) {
   PartialBlock block;
 
-  auto sent_time = to_string(std::time(0));
-  block.sent_time = sent_time;
+  //  auto sent_time = to_string(std::time(0));
+  //  block.sent_time = sent_time;
   // TODO: sender_id, Merger ID 임시로 sent_time으로
   //  block.sender_id = sent_time;
   // TODO: 위와 같은 이유로 sent_time

--- a/src/services/message_proxy.cpp
+++ b/src/services/message_proxy.cpp
@@ -19,6 +19,10 @@ void MessageProxy::deliverInputMessage(InputMessage &input_message) {
     Application::app().getSignerPoolManager().handleMessage(
         message_type, receiver_id, message_body_json);
   } break;
+  case MessageType::MSG_TX: {
+    Application::app().getTransactionCollector().handleMessage(
+        message_body_json);
+  } break;
   default:
     break;
   }

--- a/src/services/signature_requester.cpp
+++ b/src/services/signature_requester.cpp
@@ -11,11 +11,6 @@
 #include "transaction_fetcher.hpp"
 
 namespace gruut {
-SignatureRequester::SignatureRequester() {
-  m_timer.reset(
-      new boost::asio::deadline_timer(Application::app().getIoService()));
-}
-
 bool SignatureRequester::requestSignatures() {
   // TODO: SignerPool 구조가 변경됨에 따라 블럭 생성 구현할때 주석 해제
   //  auto transactions = std::move(fetchTransactions());
@@ -29,6 +24,8 @@ bool SignatureRequester::requestSignatures() {
 
 void SignatureRequester::startSignatureCollectTimer(
     Transactions &transactions) {
+  m_timer.reset(
+      new boost::asio::deadline_timer(Application::app().getIoService()));
   m_timer->expires_from_now(
       boost::posix_time::milliseconds(SIGNATURE_COLLECTION_INTERVAL));
   m_timer->async_wait([this](const boost::system::error_code &ec) {

--- a/src/services/signature_requester.hpp
+++ b/src/services/signature_requester.hpp
@@ -6,7 +6,6 @@
 #include <thread>
 #include <vector>
 
-#include "../application.hpp"
 #include "../chain/block.hpp"
 #include "../chain/merkle_tree.hpp"
 #include "../chain/message.hpp"
@@ -21,7 +20,7 @@ using Transactions = std::vector<Transaction>;
 
 class SignatureRequester {
 public:
-  SignatureRequester();
+  SignatureRequester() = default;
 
   bool requestSignatures();
 

--- a/src/services/transaction_collector.hpp
+++ b/src/services/transaction_collector.hpp
@@ -5,7 +5,6 @@
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <queue>
-#include <thread>
 
 #include "../chain/types.hpp"
 #include "../modules/module.hpp"
@@ -17,8 +16,7 @@ const int TRANSACTION_COLLECTION_INTERVAL = 5000;
 class TransactionCollector {
 public:
   TransactionCollector();
-  void handleMessage(MessageType &message_type, signer_id_type receiver_id,
-                     nlohmann::json message_body_json);
+  void handleMessage(nlohmann::json message_body_json);
 
 private:
   bool isRunnable();
@@ -30,8 +28,7 @@ private:
   std::unique_ptr<boost::asio::deadline_timer> m_timer;
   std::shared_ptr<SignatureRequester> m_signature_requester;
 
-  bool m_runnable = false;
-  std::thread *m_worker_thread;
+  bool m_timer_running = false;
 };
 } // namespace gruut
 #endif

--- a/src/services/transaction_fetcher.cpp
+++ b/src/services/transaction_fetcher.cpp
@@ -24,13 +24,13 @@ TransactionFetcher::TransactionFetcher(Signers &&signers) {
 Transactions TransactionFetcher::fetchAll() {
   Transactions transactions;
 
-  for_each(m_signers.begin(), m_signers.end(),
-           [this, &transactions](Signer &signer) {
-             auto transaction = fetch(signer);
-             if (!(transaction.sent_time == "")) {
-               transactions.push_back(transaction);
-             }
-           });
+  //  for_each(m_signers.begin(), m_signers.end(),
+  //           [this, &transactions](Signer &signer) {
+  //             auto transaction = fetch(signer);
+  //             if (!(transaction.sent_time == "")) {
+  //               transactions.push_back(transaction);
+  //             }
+  //           });
 
   return transactions;
 }
@@ -50,7 +50,7 @@ Transaction TransactionFetcher::fetch(Signer &signer) {
     // TODO: Merger의 signature, 임시로 sent_time
     //    new_transaction.signature = Sha256::hash(sent_time);
 
-    new_transaction.sent_time = sent_time;
+    //    new_transaction.sent_time = sent_time;
 
     json j;
     // TOOD: 공증요청한 client의 id를 넣어야 함, 임시로 트랜잭션 requestor_id
@@ -60,7 +60,7 @@ Transaction TransactionFetcher::fetch(Signer &signer) {
     j["data_id"] = sent_time;
     // TODO: 공증서에 대한 내용이 들어가야 하지만, 임시로 sent_time 해싱
     j["digest"] = Sha256::toString(Sha256::hash(sent_time));
-    new_transaction.content = j.dump();
+    //    new_transaction.content = j.dump();
 
     return new_transaction;
   } else {

--- a/src/utils/rsa.hpp
+++ b/src/utils/rsa.hpp
@@ -74,12 +74,11 @@ public:
     }
   }
 
-  static bool doVerify(Botan::RSA_PublicKey &rsa_pk,
+  static bool doVerify(Botan::Public_Key &rsa_pk,
                        const std::vector<uint8_t> &data,
                        const std::vector<uint8_t> &sig, bool pkcs1v15 = false) {
     Botan::PK_Verifier verifier(rsa_pk, getEmsa(pkcs1v15));
     return verifier.verify_message(data, sig);
-    ;
   }
 
 private:

--- a/src/utils/type_converter.hpp
+++ b/src/utils/type_converter.hpp
@@ -15,6 +15,22 @@ public:
   toSecureVector(std::vector<uint8_t> vec) {
     return Botan::secure_vector<uint8_t>(vec.begin(), vec.end());
   }
+
+  static std::array<uint8_t, 8> toTimestampType(std::string str) {
+    uint64_t time_int = static_cast<uint64_t>(stoll(str));
+    std::array<uint8_t, 8> timestamp = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    auto unassigned_index = timestamp.size() - 1;
+    while (time_int != 0) {
+      uint8_t byte = static_cast<uint8_t>(time_int & 0xFF);
+      timestamp[unassigned_index] = byte;
+
+      time_int >>= 8;
+      --unassigned_index;
+    }
+
+    return timestamp;
+  }
 };
 
 #endif // GRUUT_ENTERPRISE_MERGER_TYPE_CONVERTER_HPP

--- a/tests/modules/CMakeLists.txt
+++ b/tests/modules/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 set(CMAKE_CXX_STANDARD 11)
 
-find_package(Boost REQUIRED COMPONENTS system thread unit_test_framework filesystem)
+find_package(Boost REQUIRED COMPONENTS system thread unit_test_framework filesystem random)
 
 file(GLOB UNIT_TEST_SOURCE_FILES
         "test.cpp"
@@ -15,9 +15,7 @@ file(GLOB HEADER_FILES
         "../../src/modules/message_fetcher/message_fetcher.hpp"
         "../../include/*.hpp"
         "../../utils/*.hpp"
-        "../../src/services/message_proxy.hpp"
-        "../../src/services/signer_pool_manager.hpp"
-        "../../src/services/signer_pool.hpp"
+        "../../src/services/*.hpp"
         "../../src/modules/communication/msg_schema.hpp"
         "../../src/modules/communication/grpc_util.hpp"
         )
@@ -27,9 +25,7 @@ file(GLOB SOURCE_FILES
         "../../src/modules/storage/storage.cpp"
         "../../src/modules/message_fetcher/message_fetcher.cpp"
         "../../src/modules/*.cpp"
-        "../../src/services/message_proxy.cpp"
-        "../../src/services/signer_pool_manager.cpp"
-        "../../src/services/signer_pool.cpp"
+        "../../src/services/*.cpp"
         "../../src/modules/communication/grpc_util.cpp"
         )
 

--- a/tests/services/test.cpp
+++ b/tests/services/test.cpp
@@ -28,15 +28,15 @@ using namespace std;
 BOOST_AUTO_TEST_SUITE(Test_BlockGenerator)
 
     BOOST_AUTO_TEST_CASE(generatePartialBlock) {
-        vector<Transaction> transactions;
-        transactions.push_back(Transaction());
-
-        BlockGenerator generator;
-
-        auto block = generator.generatePartialBlock(sha256());
-
-        bool result = stoi(block.sent_time) > 0;
-        BOOST_TEST(result);
+//        vector<Transaction> transactions;
+//        transactions.push_back(Transaction());
+//
+//        BlockGenerator generator;
+//
+//        auto block = generator.generatePartialBlock(sha256());
+//
+//        bool result = stoi(block.sent_time) > 0;
+//        BOOST_TEST(result);
     }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Overview
- MSG_TX을 수신했을때 Transaction을 Pool에 저장할 수 있어야 한다.

## 구현사항
- MSG_TX가 들어왔을때 TransactionCollector#handle_message 에서 파싱하고, 서명검증한다. 그리고 서명이 valid하면 TransactionPool에 추가한다.
- TransactionPool을 global하게 접근할 수 있도록 수정(Application 클래스의 멤버변수로 추가 및 관련 getter 함수 추가)
- Timestamp를 uint64_t 형식으로 저장하기 위해서 유틸 함수 추가함(`toTimestampType`)
  * 비트 플래그 및 비트 쉬프트 이용해서 구현
  * Timestamp 관련 코드 추후 이 함수를 이용해서 변경할 예정
- RSA utils
  * `static bool doVerify(Botan::RSA_PublicKey &rsa_pk)` -> `static bool doVerify(Botan::Public_Key &rsa_pk)` 매개변수 타입 변경
    *  Botan::Public_Key 가 Botan::RSA_PublicKey 의 base 클래스이므로 범용성에서 Botan::Public_Key 를 받는게 더 적절함

## ETC
- 관련 없는 코드 일단 주석처리함. 다음 PR에서 주석해제하면서 서명요청 기능 구현할 것

https://thevaulters.atlassian.net/secure/RapidBoard.jspa?rapidView=21&projectKey=GEN&modal=detail&selectedIssue=GEN-45