### PR TITLE
 # ADD - 신규 signer의 cert를 저장하기 위한 Transaction 생성 구현

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ add_definitions(-DBOOST_LOG_DYN_LINK)
 add_definitions(-DBOOST_ASIO_ENABLE_HANDLER_TRACKING)
 
 include(cmake/clang-cxx-dev-tools.cmake)
-find_package(Boost REQUIRED COMPONENTS system thread random filesystem)
+find_package(Boost REQUIRED COMPONENTS system thread filesystem)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 add_executable(gruut_enterprise_merger main.cpp)
 

--- a/src/chain/signer.hpp
+++ b/src/chain/signer.hpp
@@ -4,6 +4,7 @@
 #include <botan/secmem.h>
 #include <string>
 
+#include "../modules/storage/storage.hpp"
 #include "types.hpp"
 
 namespace gruut {
@@ -14,9 +15,10 @@ struct Signer {
   uint64_t last_update{0};
   SignerStatus status{SignerStatus::UNKNOWN};
 
-  // TODO: Storage에서 signer가 신규인지 아닌지 검색할 수 있는 기능 추가되면
-  // 제거할 것
-  bool isNew() { return true; }
+  bool isNew() {
+    auto cert = Storage::getInstance()->findCertificate(user_id);
+    return cert.empty();
+  }
 };
 } // namespace gruut
 #endif

--- a/src/chain/transaction.hpp
+++ b/src/chain/transaction.hpp
@@ -14,10 +14,12 @@ struct Transaction {
   TransactionType transaction_type;
   signature_type signature;
   std::vector<content_type> content_list;
+
+  virtual bool isNull() { return false; }
 };
 
 struct NullTransaction : public Transaction {
-  NullTransaction() { transaction_id = sha256(); }
+  virtual bool isNull() { return true; }
 };
 } // namespace gruut
 #endif

--- a/src/services/signer_pool.cpp
+++ b/src/services/signer_pool.cpp
@@ -1,4 +1,5 @@
 #include "signer_pool.hpp"
+#include "transaction_generator.hpp"
 
 namespace gruut {
 constexpr size_t NOT_FOUND = static_cast<const size_t>(-1);
@@ -130,4 +131,14 @@ size_t SignerPool::find(signer_id_type user_id) {
 }
 
 Signer SignerPool::getSigner(int index) { return m_signer_pool[index]; }
+
+void SignerPool::createTransactions() {
+  TransactionGenerator generator;
+
+  for (auto &signer : m_signer_pool) {
+    if (signer.isNew()) {
+      generator.generate(signer);
+    }
+  }
+}
 } // namespace gruut

--- a/src/services/signer_pool.hpp
+++ b/src/services/signer_pool.hpp
@@ -17,6 +17,8 @@ public:
                   Botan::secure_vector<uint8_t> &hmac_key,
                   SignerStatus stat = SignerStatus::UNKNOWN);
 
+  void createTransactions();
+
   bool updatePkCert(signer_id_type user_id, std::string &pk_cert);
 
   bool updateHmacKey(signer_id_type user_id, hmac_key_type &hmac_key);

--- a/src/services/transaction_collector.cpp
+++ b/src/services/transaction_collector.cpp
@@ -18,6 +18,7 @@ void TransactionCollector::handleMessage(json message_body_json) {
     if (!m_timer_running) {
       m_timer_running = true;
       startTimer();
+      Application::app().getSignerPool().createTransactions();
       m_signature_requester.requestSignatures();
     }
 

--- a/src/services/transaction_collector.hpp
+++ b/src/services/transaction_collector.hpp
@@ -23,8 +23,6 @@ private:
 
   void startTimer();
 
-  void startSignatureRequest();
-
   std::unique_ptr<boost::asio::deadline_timer> m_timer;
   SignatureRequester m_signature_requester;
 

--- a/src/services/transaction_fetcher.cpp
+++ b/src/services/transaction_fetcher.cpp
@@ -1,6 +1,4 @@
 #include <algorithm>
-#include <boost/random/random_device.hpp>
-#include <boost/random/uniform_int_distribution.hpp>
 
 #include "../../include/nlohmann/json.hpp"
 #include "../application.hpp"
@@ -12,18 +10,18 @@ using json = nlohmann::json;
 
 TransactionFetcher::TransactionFetcher(Signers &&signers) {
   m_signers = signers;
-  auto &transaction_pool = Application::app().getTransactionPool();
-
-  const int transaciton_size = transaction_pool.size();
-  auto t_size = std::min(transaciton_size, MAX_COLLECT_TRANSACTION_SIZE);
-
-  m_selected_transaction_list = Transactions(
-      transaction_pool.cbegin(), transaction_pool.cbegin() + t_size);
 }
 
 Transactions TransactionFetcher::fetchAll() {
-  Transactions transactions;
+  auto &transaction_pool = Application::app().getTransactionPool();
 
+  const int transacitons_size = static_cast<const int>(transaction_pool.size());
+  auto t_size = std::min(transacitons_size, MAX_COLLECT_TRANSACTION_SIZE);
+
+  Transactions transactions;
+  for (unsigned int i = 0; i < t_size; i++) {
+    transactions.emplace_back();
+  }
   //  for_each(m_signers.begin(), m_signers.end(),
   //           [this, &transactions](Signer &signer) {
   //             auto transaction = fetch(signer);
@@ -35,63 +33,5 @@ Transactions TransactionFetcher::fetchAll() {
   return transactions;
 }
 
-Transaction TransactionFetcher::fetch(Signer &signer) {
-  auto sent_time = to_string(time(0));
-
-  if (signer.isNew()) {
-    Transaction new_transaction;
-
-    new_transaction.transaction_id = generateTransactionId();
-    new_transaction.transaction_type = TransactionType::CERTIFICATE;
-
-    // TODO: requestor_id <- Merger Id, 임시로 sent_time
-    //    new_transaction.requestor_id = sent_time;
-
-    // TODO: Merger의 signature, 임시로 sent_time
-    //    new_transaction.signature = Sha256::hash(sent_time);
-
-    //    new_transaction.sent_time = sent_time;
-
-    json j;
-    // TOOD: 공증요청한 client의 id를 넣어야 함, 임시로 트랜잭션 requestor_id
-    j["requestor_id"] = new_transaction.requestor_id;
-    j["sent_time"] = new_transaction.sent_time;
-    // TOOD: 임시로 sent_time
-    j["data_id"] = sent_time;
-    // TODO: 공증서에 대한 내용이 들어가야 하지만, 임시로 sent_time 해싱
-    j["digest"] = Sha256::toString(Sha256::hash(sent_time));
-    //    new_transaction.content = j.dump();
-
-    return new_transaction;
-  } else {
-    if (!m_selected_transaction_list.empty()) {
-      auto last_transaction = *(m_selected_transaction_list.end());
-      m_selected_transaction_list.pop_back();
-
-      return last_transaction;
-    } else {
-      NullTransaction null_transaction;
-
-      return null_transaction;
-    }
-  }
-}
-
-transaction_id_type TransactionFetcher::generateTransactionId() {
-  std::string chars("abcdefghijklmnopqrstuvwxyz"
-                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                    "1234567890"
-                    "!@#$%^&*()"
-                    "`~-_=+[{]}\\|;:'\",<.>/? ");
-  boost::random::random_device rng;
-  boost::random::uniform_int_distribution<> index_dist(0, chars.size() - 1);
-
-  stringstream s;
-  for (int i = 0; i < 32; ++i) {
-    s << chars[index_dist(rng)];
-  }
-
-  // TODO: 임시로 sha256 객체 리턴하도록 함
-  return sha256();
-}
+Transaction TransactionFetcher::fetch(Signer &signer) { return Transaction(); }
 } // namespace gruut

--- a/src/services/transaction_fetcher.hpp
+++ b/src/services/transaction_fetcher.hpp
@@ -23,7 +23,6 @@ private:
   Transaction fetch(Signer &signer);
   transaction_id_type generateTransactionId();
 
-  Transactions m_selected_transaction_list;
   Signers m_signers;
 };
 } // namespace gruut

--- a/src/services/transaction_generator.cpp
+++ b/src/services/transaction_generator.cpp
@@ -1,0 +1,66 @@
+#include "transaction_generator.hpp"
+#include "../application.hpp"
+#include "../chain/transaction.hpp"
+#include "../utils/rsa.hpp"
+#include "../utils/sha256.hpp"
+#include "../utils/time.hpp"
+#include "../utils/type_converter.hpp"
+#include <climits>
+#include <random>
+
+namespace gruut {
+void TransactionGenerator::generate(Signer &signer) {
+  if (signer.isNew()) {
+    Transaction new_transaction;
+    bytes signature_message;
+
+    new_transaction.transaction_id = generateTransactionId();
+    signature_message.insert(signature_message.cend(),
+                             new_transaction.transaction_id.cbegin(),
+                             new_transaction.transaction_id.cend());
+
+    string timestamp = Time::now();
+    new_transaction.sent_time = TypeConverter::toTimestampType(timestamp);
+    signature_message.insert(signature_message.cend(),
+                             new_transaction.sent_time.cbegin(),
+                             new_transaction.sent_time.cend());
+
+    // TODO: requestor_id <- Merger Id, 임시로 txID
+    new_transaction.requestor_id = new_transaction.transaction_id;
+    signature_message.insert(signature_message.cend(),
+                             new_transaction.requestor_id.cbegin(),
+                             new_transaction.requestor_id.cend());
+
+    new_transaction.transaction_type = TransactionType::CERTIFICATE;
+    string transaction_type_str = "certificate";
+    signature_message.insert(signature_message.cend(),
+                             transaction_type_str.cbegin(),
+                             transaction_type_str.cend());
+
+    auto user_id_str = to_string(signer.user_id);
+    new_transaction.content_list.emplace_back(user_id_str);
+    signature_message.insert(signature_message.cend(), user_id_str.cbegin(),
+                             user_id_str.cend());
+
+    new_transaction.content_list.emplace_back(signer.pk_cert);
+    signature_message.insert(signature_message.cend(), signer.pk_cert.cbegin(),
+                             signer.pk_cert.cend());
+
+    // TODO: private_key 하드코딩 되어있음. 설정파일 생성되면 제거할 것
+    string private_key = "";
+    new_transaction.signature =
+        RSA::doSign(private_key, signature_message, true);
+
+    Application::app().getTransactionPool().emplace_back(new_transaction);
+  }
+}
+
+transaction_id_type TransactionGenerator::generateTransactionId() {
+  mt19937 mt;
+  mt.seed(random_device()());
+
+  std::uniform_int_distribution<std::mt19937::result_type> dist;
+  auto random_number = dist(mt);
+  return Sha256::hash(to_string(random_number));
+}
+} // namespace gruut

--- a/src/services/transaction_generator.hpp
+++ b/src/services/transaction_generator.hpp
@@ -1,0 +1,15 @@
+#ifndef GRUUT_ENTERPRISE_MERGER_TRANSACTION_GENERATOR_HPP
+#define GRUUT_ENTERPRISE_MERGER_TRANSACTION_GENERATOR_HPP
+
+#include "../chain/signer.hpp"
+
+namespace gruut {
+class TransactionGenerator {
+public:
+  void generate(Signer &signer);
+
+private:
+  transaction_id_type generateTransactionId();
+};
+} // namespace gruut
+#endif

--- a/src/utils/time.hpp
+++ b/src/utils/time.hpp
@@ -1,0 +1,18 @@
+#ifndef GRUUT_ENTERPRISE_MERGER_TIME_HPP
+#define GRUUT_ENTERPRISE_MERGER_TIME_HPP
+
+#include <chrono>
+#include <string>
+
+class Time {
+public:
+  static std::string now() {
+    auto now = std::chrono::duration_cast<std::chrono::seconds>(
+                   std::chrono::system_clock::now().time_since_epoch())
+                   .count();
+
+    return std::to_string(now);
+  }
+};
+
+#endif

--- a/tests/services/CMakeLists.txt
+++ b/tests/services/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 set(CMAKE_CXX_STANDARD 11)
-find_package(Boost REQUIRED COMPONENTS system thread random unit_test_framework)
+find_package(Boost REQUIRED COMPONENTS system thread random filesystem unit_test_framework)
 
 file(GLOB UNIT_TEST_SOURCE_FILES
         "test.cpp"
@@ -11,13 +11,16 @@ file(GLOB HEADER_FILES
         "../../src/services/*.hpp"
         "../../src/chain/*.hpp"
         "../../src/utils/*.hpp"
+        "../../src/modules/storage/storage.hpp"
         "../../src/application.hpp"
+        "../../src/utils/template_singleton.hpp"
         )
 
 file(GLOB SOURCE_FILES
         "../../src/chain/*.cpp"
         "../../src/services/*.cpp"
         "../../src/application.cpp"
+        "../../src/modules/storage/storage.cpp"
         )
 
 set(LIB_PREFIX "/usr/local/lib")
@@ -33,10 +36,11 @@ target_sources(services_test
         ${HEADER_FILES}
         )
 
-target_include_directories(services_test PRIVATE ${Boost_INCLUDE_DIR} ../../include /usr/local/include)
+target_include_directories(services_test PRIVATE ${Boost_INCLUDE_DIR} ../../include ../../lib/leveldb /usr/local/include)
 target_link_libraries(services_test
         PRIVATE
         ${Boost_LIBRARIES}
+        leveldb
         ${LZ4_LIBS}
         /usr/local/lib/libbotan-2.a
         )

--- a/tests/services/test.cpp
+++ b/tests/services/test.cpp
@@ -77,6 +77,7 @@ BOOST_AUTO_TEST_SUITE(Test_SignerPool)
 
       BOOST_CHECK_EQUAL(signer_pool.size(), 1);
     }
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(Test_MessageIOQueues)
@@ -101,4 +102,29 @@ BOOST_AUTO_TEST_SUITE(Test_MessageIOQueues)
     BOOST_TEST(test_result);
   }
 
+
+    BOOST_AUTO_TEST_CASE(create_transactions) {
+      SignerPool signer_pool;
+
+      string test_cert = "MIIC7zCCAdegAwIBAgIBADANBgkqhkiG9w0BAQsFADBhMRQwEgYDVQQDEwt0aGVWYXVsdGVyczELMAkGA1UEBhMCS1IxCTAHBgNVBAgTADEQMA4GA1UEBxMHSW5jaGVvbjEUMBIGA1UEChMLdGhlVmF1bHRlcnMxCTAHBgNVBAsTADAeFw0xODExMjgwNTM1NDFaFw0xOTExMjgwNTM1NDFaMBUxEzARBgNVBAMMCkdSVVVUX0FVVEgwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDV2RKC+oo6sBeAoSJn55ZZJ+U9bRh4z/TOsc4V/92NsV5qXpiWhUMTqPfNGHTjR7ScI57ZH9lqltcBJ2mcqhBWY1A/lQfdWAJf+3/eh+H/ZvDcZW8s9PFeuJcftmEDtUMlh9xMUoL5a74dS5lhrdbH0tXRMfhB3w02fmkuvqW+MCsUubhL7mu0PDbJeWjqqu8P+c+6PWO0CRgkMmry1f1VksXTzp54wARW2O3Zut6Z56VknrMOP2f4IYGiLy8zC/oO/JRCPCFvW1cM5UDdjVaq8UkIZ7B/z4zqFjwT3gXHHdMp+RLS8t+tA15rhZ2iRtKPcSwlpV95BTBG3Jpbm7xTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAEAzwa2yTQMR6nRUgafc/v0z7PylG4ohkXljBzMxfFipYju1/AKse1PCBq2H9DSnSbeL/BI4lQjsXXJLCDSnWXNnJSt1oatOHv4JeJ2Ob88EBVkx7G0aK2S2yijfMx5Bpptp8FIYxZX0QuOJ2oNK73j1Dx9Xax+5ZkBE8wxYYXpsZ0R/BGw8Es1bNFyFcbNYWd3iQOwoXOenWWa6YOyzRhZ2EAw+l7C7LB6I68xIIAP0BBSMTOfq4Smdizdd3qWYJyouUcv83AZn8KWBJjRKNJgHQvnYzCCGnhOwekbh9WlrGVEUvr/b6yV/aXX6kMqsCAfLhloqQ7Ai24QvOfdOAEQ=";
+      vector<uint8_t> secret_key(32, 0);
+      auto secret_key_vector = TypeConverter::toSecureVector(secret_key);
+      signer_pool.pushSigner(1, test_cert, secret_key_vector, SignerStatus::GOOD);
+
+      signer_pool.createTransactions();
+      auto transaction_pool_size = Application::app().getTransactionPool().size();
+      BOOST_CHECK_EQUAL(transaction_pool_size, 1);
+    }
+
+    BOOST_AUTO_TEST_CASE(delete_all_directory_for_test) {
+      Storage *storage = Storage::getInstance();
+      storage->deleteAllDirectory("./block_header");
+      storage->deleteAllDirectory("./block_binary");
+      storage->deleteAllDirectory("./certificate");
+      storage->deleteAllDirectory("./latest_block_header");
+      storage->deleteAllDirectory("./transaction");
+      Storage::destroyInstance();
+
+      BOOST_TEST(true);
+    }
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Overview
- TransactionCollector의 타이머가 trigger 되는 순간, 신규 Signers에 대해서 Transaction을 생성해야 한다.

## 구현사항
- SignerPool#create_transactions 구현
  * SignerPool은 signers를 parameter로 `TransactionGenerator#generate`를 호출한다.
  * `TransactionGenerator#generate`에서는 새로운 Transaction을 생성해서 TransactionPool에 넣는다.
- Signer#isNew
  * 새로운 Signer인지 검사하는 로직
- Time Util 생성
  * Transaction의 생성시간을 저장해야 한다.
  * 다른 곳에서 자주 사용하고 있으므로 유틸 클래스로 생성함. 추후 리팩토링 필요
- storage 를 이용하게 되면서 service 테스트 cmakelist 수정
- 테스트코드 추가

## ETC
- 빌드 성공을 위해서 TransactionFetcher 관련 코드 수정함
  * 이 PR과 관계는 없지만 우선 빌드가 안돼서 필요없는 코드 제거

참조: https://thevaulters.atlassian.net/wiki/spaces/SGN/pages/47022295/GE2.+Protocol+Diagram