### PR TITLE
# REFACTOR - Merger Rpc, MessageHandler 수정

### DIFF
--- a/src/modules/communication/communication.cpp
+++ b/src/modules/communication/communication.cpp
@@ -1,5 +1,6 @@
 #include "communication.hpp"
 #include "grpc_merger.hpp"
+#include "merger_server.hpp"
 #include <thread>
 
 namespace gruut {

--- a/src/modules/communication/merger_client.cpp
+++ b/src/modules/communication/merger_client.cpp
@@ -1,24 +1,25 @@
 #include "merger_client.hpp"
+#include "merger_server.hpp"
 
 namespace gruut {
 void MergerClient::sendMessage(MessageType msg_type,
                                std::vector<uint64_t> &receiver_list,
-                               std::string &msg) {
+                               std::string &packed_msg) {
 
   if (checkMergerMsgType(msg_type)) {
-    sendToMerger(msg_type, receiver_list, msg);
+    sendToMerger(msg_type, receiver_list, packed_msg);
   } else if (checkSignerMsgType(msg_type)) {
-    sendToSigner(msg_type, receiver_list, msg);
+    sendToSigner(msg_type, receiver_list, packed_msg);
   }
 
   if (checkSEMsgType(msg_type)) {
-    sendToSE(msg_type, receiver_list, msg);
+    sendToSE(msg_type, receiver_list, packed_msg);
   }
 }
 
 void MergerClient::sendToSE(MessageType msg_type,
                             std::vector<uint64_t> &receiver_list,
-                            std::string &msg) {
+                            std::string &packed_msg) {
   for (uint64_t se_id : receiver_list) {
     // TODO: SE ID에 따른 ip와 port를 저장해 놓을 곳 필요.
     std::unique_ptr<GruutSeService::Stub> stub = GruutSeService::NewStub(
@@ -41,7 +42,7 @@ void MergerClient::sendToSE(MessageType msg_type,
 
 void MergerClient::sendToMerger(MessageType msg_type,
                                 std::vector<uint64_t> &receiver_list,
-                                std::string &msg) {
+                                std::string &packed_msg) {
   for (uint64_t merger_id : receiver_list) {
     // TODO: Merger ID에 따른 ip와 port를 저장해 놓을 곳 필요.
     std::unique_ptr<MergerCommunication::Stub> stub =
@@ -53,7 +54,7 @@ void MergerClient::sendToMerger(MessageType msg_type,
     MergerDataRequest request;
     MergerDataReply reply;
 
-    request.set_data(msg);
+    request.set_data(packed_msg);
     Status status = stub->pushData(&context, request, &reply);
     if (!status.ok())
       std::cout << status.error_code() << ": " << status.error_message()
@@ -63,8 +64,54 @@ void MergerClient::sendToMerger(MessageType msg_type,
 
 void MergerClient::sendToSigner(MessageType msg_type,
                                 std::vector<uint64_t> &receiver_list,
-                                std::string &msg) {
+                                std::string &packed_msg) {
+
   for (uint64_t signer_id : receiver_list) {
+    SignerRpcInfo signer_rpc_info =
+        m_rpc_receiver_list->getSignerRpcInfo(signer_id);
+    switch (msg_type) {
+    case MessageType::MSG_CHALLENGE: {
+      auto tag = static_cast<Join *>(signer_rpc_info.tag_join);
+      *signer_rpc_info.join_status = RpcCallStatus::FINISH;
+
+      GrpcMsgChallenge reply;
+      reply.set_message(packed_msg);
+
+      signer_rpc_info.send_challenge->Finish(reply, Status::OK, tag);
+    } break;
+
+    case MessageType::MSG_RESPONSE_2: {
+      auto tag = static_cast<DHKeyEx *>(signer_rpc_info.tag_dhkeyex);
+      *signer_rpc_info.dhkeyex_status = RpcCallStatus::FINISH;
+
+      GrpcMsgResponse2 reply;
+      reply.set_message(packed_msg);
+
+      signer_rpc_info.send_response2->Finish(reply, Status::OK, tag);
+    } break;
+
+    case MessageType::MSG_ACCEPT: {
+      auto tag =
+          static_cast<KeyExFinished *>(signer_rpc_info.tag_keyexfinished);
+      *signer_rpc_info.keyexfinished_status = RpcCallStatus::FINISH;
+
+      GrpcMsgAccept reply;
+      reply.set_message(packed_msg);
+
+      signer_rpc_info.send_accept->Finish(reply, Status::OK, tag);
+    } break;
+
+    case MessageType::MSG_REQ_SSIG: {
+      auto tag = static_cast<Identity *>(signer_rpc_info.tag_identity);
+
+      GrpcMsgReqSsig reply;
+      reply.set_message(packed_msg);
+      signer_rpc_info.send_req_ssig->Write(reply, tag);
+    } break;
+
+    default:
+      break;
+    }
   }
 }
 

--- a/src/modules/communication/merger_client.cpp
+++ b/src/modules/communication/merger_client.cpp
@@ -1,0 +1,91 @@
+#include "merger_client.hpp"
+
+namespace gruut {
+void MergerClient::sendMessage(MessageType msg_type,
+                               std::vector<uint64_t> &receiver_list,
+                               std::string &msg) {
+
+  if (checkMergerMsgType(msg_type)) {
+    sendToMerger(msg_type, receiver_list, msg);
+  } else if (checkSignerMsgType(msg_type)) {
+    sendToSigner(msg_type, receiver_list, msg);
+  }
+
+  if (checkSEMsgType(msg_type)) {
+    sendToSE(msg_type, receiver_list, msg);
+  }
+}
+
+void MergerClient::sendToSE(MessageType msg_type,
+                            std::vector<uint64_t> &receiver_list,
+                            std::string &msg) {
+  for (uint64_t se_id : receiver_list) {
+    // TODO: SE ID에 따른 ip와 port를 저장해 놓을 곳 필요.
+    std::unique_ptr<GruutSeService::Stub> stub = GruutSeService::NewStub(
+        CreateChannel("SE ip and port", InsecureChannelCredentials()));
+
+    ClientContext context;
+    // TODO: SE protobuf 수정작업 후 주석 해제.
+
+    /*  DataRequest request;
+      DataReply reply;
+
+      request.set_data(msg);
+      Status status = stub->sendData(&context, request, &reply);
+      if(!status.ok())
+        std::cout<<status.error_code() << ":
+    "<<status.error_message()<<std::endl;
+    }*/
+  }
+}
+
+void MergerClient::sendToMerger(MessageType msg_type,
+                                std::vector<uint64_t> &receiver_list,
+                                std::string &msg) {
+  for (uint64_t merger_id : receiver_list) {
+    // TODO: Merger ID에 따른 ip와 port를 저장해 놓을 곳 필요.
+    std::unique_ptr<MergerCommunication::Stub> stub =
+        MergerCommunication::NewStub(
+            CreateChannel("Merger ip and port", InsecureChannelCredentials()));
+
+    ClientContext context;
+
+    MergerDataRequest request;
+    MergerDataReply reply;
+
+    request.set_data(msg);
+    Status status = stub->pushData(&context, request, &reply);
+    if (!status.ok())
+      std::cout << status.error_code() << ": " << status.error_message()
+                << std::endl;
+  }
+}
+
+void MergerClient::sendToSigner(MessageType msg_type,
+                                std::vector<uint64_t> &receiver_list,
+                                std::string &msg) {
+  for (uint64_t signer_id : receiver_list) {
+  }
+}
+
+bool MergerClient::checkMergerMsgType(MessageType msg_type) {
+  return (msg_type == MessageType::MSG_UP ||
+          msg_type == MessageType::MSG_PING ||
+          msg_type == MessageType::MSG_REQ_BLOCK ||
+          msg_type == MessageType::MSG_BLOCK);
+}
+
+bool MergerClient::checkSignerMsgType(MessageType msg_type) {
+  return (msg_type == MessageType::MSG_CHALLENGE ||
+          msg_type == MessageType::MSG_RESPONSE_2 ||
+          msg_type == MessageType::MSG_ACCEPT ||
+          msg_type == MessageType::MSG_ECHO ||
+          msg_type == MessageType::MSG_REQ_SSIG ||
+          msg_type == MessageType::MSG_ERROR);
+}
+
+bool MergerClient::checkSEMsgType(MessageType msg_type) {
+  return (msg_type == MessageType::MSG_UP || msg_type == MessageType::MSG_PING);
+  // TODO: 다른 MSG TYPE은 차 후 추가
+}
+}; // namespace gruut

--- a/src/modules/communication/merger_client.hpp
+++ b/src/modules/communication/merger_client.hpp
@@ -20,17 +20,17 @@ class MergerClient {
 public:
   MergerClient() { m_rpc_receiver_list = RpcReceiverList::getInstance(); }
   void sendMessage(MessageType msg_type, std::vector<uint64_t> &receiver_list,
-                   std::string &msg);
+                   std::string &packed_msg);
 
 private:
   RpcReceiverList *m_rpc_receiver_list;
 
   void sendToSE(MessageType msg_type, std::vector<uint64_t> &receiver_list,
-                std::string &msg);
+                std::string &packed_msg);
   void sendToMerger(MessageType msg_type, std::vector<uint64_t> &receiver_list,
-                    std::string &msg);
+                    std::string &packed_msg);
   void sendToSigner(MessageType msg_type, std::vector<uint64_t> &receiver_list,
-                    std::string &msg);
+                    std::string &packed_msg);
 
   bool checkMergerMsgType(MessageType msg_tpye);
   bool checkSignerMsgType(MessageType msg_tpye);

--- a/src/modules/communication/merger_client.hpp
+++ b/src/modules/communication/merger_client.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "../../application.hpp"
+#include "grpc_merger.hpp"
+#include "protos/protobuf_merger.grpc.pb.h"
+#include "protos/protobuf_se.grpc.pb.h"
+#include "protos/protobuf_signer.grpc.pb.h"
+#include "rpc_receiver_list.hpp"
+#include <grpc/support/log.h>
+#include <grpcpp/grpcpp.h>
+#include <iostream>
+#include <memory>
+using namespace grpc;
+using namespace grpc_merger;
+using namespace grpc_se;
+using namespace grpc_signer;
+
+namespace gruut {
+class MergerClient {
+public:
+  MergerClient() { m_rpc_receiver_list = RpcReceiverList::getInstance(); }
+  void sendMessage(MessageType msg_type, std::vector<uint64_t> &receiver_list,
+                   std::string &msg);
+
+private:
+  RpcReceiverList *m_rpc_receiver_list;
+
+  void sendToSE(MessageType msg_type, std::vector<uint64_t> &receiver_list,
+                std::string &msg);
+  void sendToMerger(MessageType msg_type, std::vector<uint64_t> &receiver_list,
+                    std::string &msg);
+  void sendToSigner(MessageType msg_type, std::vector<uint64_t> &receiver_list,
+                    std::string &msg);
+
+  bool checkMergerMsgType(MessageType msg_tpye);
+  bool checkSignerMsgType(MessageType msg_tpye);
+  bool checkSEMsgType(MessageType msg_type);
+};
+} // namespace gruut

--- a/src/modules/communication/merger_server.cpp
+++ b/src/modules/communication/merger_server.cpp
@@ -1,0 +1,269 @@
+#include "merger_server.hpp"
+#include "message_handler.hpp"
+#include <chrono>
+#include <cstring>
+#include <future>
+#include <thread>
+namespace gruut {
+
+void MergerServer::runServer(char const *port) {
+  std::string port_num(port);
+  std::string server_address("0.0.0.0:");
+  server_address += port_num;
+
+  ServerBuilder builder;
+  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+  builder.RegisterService(&m_merger_service);
+  builder.RegisterService(&m_se_service);
+  builder.RegisterService(&m_signer_service);
+  m_completion_queue = builder.AddCompletionQueue();
+  m_server = builder.BuildAndStart();
+  std::cout << "Server listening on " << server_address << std::endl;
+
+  recvData();
+}
+
+void MergerServer::recvData() {
+  new RecvFromMerger(&m_merger_service, m_completion_queue.get());
+  new RecvFromSE(&m_se_service, m_completion_queue.get());
+  new OpenChannel(&m_signer_service, m_completion_queue.get());
+  new Join(&m_signer_service, m_completion_queue.get());
+  new DHKeyEx(&m_signer_service, m_completion_queue.get());
+  new KeyExFinished(&m_signer_service, m_completion_queue.get());
+  new SigSend(&m_signer_service, m_completion_queue.get());
+
+  void *tag;
+  bool ok;
+  while (true) {
+    std::this_thread::sleep_for(chrono::milliseconds(200));
+    GPR_ASSERT(m_completion_queue->Next(&tag, &ok));
+    GPR_ASSERT(ok);
+    static_cast<CallData *>(tag)->proceed();
+  }
+}
+
+void MergerServer::RecvFromMerger::proceed() {
+  switch (m_receive_status) {
+  case CallStatus::CREATE: {
+    m_receive_status = CallStatus::PROCESS;
+    m_service->RequestpushData(&m_context, &m_request, &m_responder,
+                               m_completion_queue, m_completion_queue, this);
+  } break;
+
+  case CallStatus::PROCESS: {
+    new RecvFromMerger(m_service, m_completion_queue);
+
+    std::string packed_msg = m_request.data();
+    std::promise<Status> rpc_status;
+    std::future<Status> future_rpc_status = rpc_status.get_future();
+    Status final_rpc_status = future_rpc_status.get();
+    MessageHandler message_handler;
+    std::thread handler(&MessageHandler::unpackMsg, &message_handler,
+                        std::ref(packed_msg), std::ref(rpc_status));
+    handler.join();
+    MergerDataReply m_reply;
+    m_receive_status = CallStatus::FINISH;
+    m_responder.Finish(m_reply, final_rpc_status, this);
+  } break;
+
+  default: {
+    GPR_ASSERT(m_receive_status == CallStatus::FINISH);
+    delete this;
+  } break;
+  }
+}
+
+void MergerServer::RecvFromSE::proceed() {
+  switch (m_receive_status) {
+  case CallStatus::CREATE: {
+    m_receive_status = CallStatus::PROCESS;
+    m_service->Requesttransaction(&m_context, &m_request, &m_responder,
+                                  m_completion_queue, m_completion_queue, this);
+  } break;
+
+  case CallStatus::PROCESS: {
+    new RecvFromSE(m_service, m_completion_queue);
+
+    std::string packed_msg = m_request.message();
+    std::promise<Status> rpc_status;
+    std::future<Status> future_rpc_status = rpc_status.get_future();
+    Status final_rpc_status = future_rpc_status.get();
+    MessageHandler message_handler;
+    std::thread handler(&MessageHandler::unpackMsg, &message_handler,
+                        std::ref(packed_msg), std::ref(rpc_status));
+    handler.join();
+    Nothing m_reply;
+    m_receive_status = CallStatus::FINISH;
+    m_responder.Finish(m_reply, final_rpc_status, this);
+  } break;
+
+  default: {
+    GPR_ASSERT(m_receive_status == CallStatus::FINISH);
+    delete this;
+  } break;
+  }
+}
+
+void MergerServer::OpenChannel::proceed() {
+  switch (m_receive_status) {
+  case CallStatus::CREATE: {
+    m_receive_status = CallStatus::PROCESS;
+    m_service->RequestopenChannel(&m_context, m_stream.get(),
+                                  m_completion_queue, m_completion_queue, this);
+  } break;
+
+  case CallStatus::PROCESS: {
+    new OpenChannel(m_service, m_completion_queue);
+
+    m_stream->Read(&m_request, this);
+    uint64_t receiver_id;
+    std::memcpy(&receiver_id, &m_request.sender()[0], sizeof(uint64_t));
+    // TODO: receiver_id_list 에 map[receiver_id].stream = m_stream 저장
+
+    m_receive_status = CallStatus::FINISH;
+  } break;
+
+  default: {
+    GPR_ASSERT(m_receive_status == CallStatus::FINISH);
+    delete this;
+  } break;
+  }
+}
+
+void MergerServer::Join::proceed() {
+  switch (m_receive_status) {
+  case CallStatus::CREATE: {
+    m_receive_status = CallStatus::PROCESS;
+    m_service->Requestjoin(&m_context, &m_request, m_responder.get(),
+                           m_completion_queue, m_completion_queue, this);
+  } break;
+
+  case CallStatus::PROCESS: {
+    new Join(m_service, m_completion_queue);
+
+    std::string packed_msg = m_request.message();
+    std::promise<Status> rpc_status;
+    std::future<Status> future_rpc_status = rpc_status.get_future();
+    Status final_rpc_status = future_rpc_status.get();
+
+    MessageHandler message_handler;
+    std::thread handler(&MessageHandler::unpackMsg, &message_handler,
+                        std::ref(packed_msg), std::ref(rpc_status));
+    handler.join();
+    if (!final_rpc_status.ok()) {
+      GrpcMsgChallenge m_reply;
+      m_responder->Finish(m_reply, final_rpc_status, this);
+    }
+    m_receive_status = CallStatus::FINISH;
+  } break;
+
+  default: {
+    GPR_ASSERT(m_receive_status == CallStatus::FINISH);
+    delete this;
+  } break;
+  }
+}
+
+void MergerServer::DHKeyEx::proceed() {
+  switch (m_receive_status) {
+  case CallStatus::CREATE: {
+    m_receive_status = CallStatus::PROCESS;
+    m_service->RequestdhKeyEx(&m_context, &m_request, m_responder.get(),
+                              m_completion_queue, m_completion_queue, this);
+  } break;
+
+  case CallStatus::PROCESS: {
+    new DHKeyEx(m_service, m_completion_queue);
+
+    std::string packed_msg = m_request.message();
+    std::promise<Status> rpc_status;
+    std::future<Status> future_rpc_status = rpc_status.get_future();
+    Status final_rpc_status = future_rpc_status.get();
+
+    MessageHandler message_handler;
+    std::thread handler(&MessageHandler::unpackMsg, &message_handler,
+                        std::ref(packed_msg), std::ref(rpc_status));
+    handler.join();
+
+    if (!final_rpc_status.ok()) {
+      GrpcMsgResponse2 m_reply;
+      m_responder->Finish(m_reply, final_rpc_status, this);
+    }
+    m_receive_status = CallStatus::FINISH;
+  } break;
+
+  default: {
+    GPR_ASSERT(m_receive_status == CallStatus::FINISH);
+    delete this;
+  } break;
+  }
+}
+
+void MergerServer::KeyExFinished::proceed() {
+  switch (m_receive_status) {
+  case CallStatus::CREATE: {
+    m_receive_status = CallStatus::PROCESS;
+    m_service->RequestkeyExFinished(&m_context, &m_request, m_responder.get(),
+                                    m_completion_queue, m_completion_queue,
+                                    this);
+  } break;
+
+  case CallStatus::PROCESS: {
+    new KeyExFinished(m_service, m_completion_queue);
+
+    std::string packed_msg = m_request.message();
+    std::promise<Status> rpc_status;
+    std::future<Status> future_rpc_status = rpc_status.get_future();
+    Status final_rpc_status = future_rpc_status.get();
+
+    MessageHandler message_handler;
+    std::thread handler(&MessageHandler::unpackMsg, &message_handler,
+                        std::ref(packed_msg), std::ref(rpc_status));
+    handler.join();
+    if (!final_rpc_status.ok()) {
+      GrpcMsgAccept m_reply;
+      m_responder->Finish(m_reply, final_rpc_status, this);
+    }
+    m_receive_status = CallStatus::FINISH;
+  } break;
+
+  default: {
+    GPR_ASSERT(m_receive_status == CallStatus::FINISH);
+    delete this;
+  } break;
+  }
+}
+
+void MergerServer::SigSend::proceed() {
+  switch (m_receive_status) {
+  case CallStatus::CREATE: {
+    m_receive_status = CallStatus::PROCESS;
+    m_service->RequestsigSend(&m_context, &m_request, &m_responder,
+                              m_completion_queue, m_completion_queue, this);
+  } break;
+
+  case CallStatus::PROCESS: {
+    new SigSend(m_service, m_completion_queue);
+
+    std::string packed_msg = m_request.message();
+    std::promise<Status> rpc_status;
+    std::future<Status> future_rpc_status = rpc_status.get_future();
+    Status final_rpc_status = future_rpc_status.get();
+
+    MessageHandler message_handler;
+    std::thread handler(&MessageHandler::unpackMsg, &message_handler,
+                        std::ref(packed_msg), std::ref(rpc_status));
+    handler.join();
+    NoReply m_reply;
+    m_responder.Finish(m_reply, final_rpc_status, this);
+    m_receive_status = CallStatus::FINISH;
+  } break;
+
+  default: {
+    GPR_ASSERT(m_receive_status == CallStatus::FINISH);
+    delete this;
+  } break;
+  }
+}
+
+} // namespace gruut

--- a/src/modules/communication/merger_server.hpp
+++ b/src/modules/communication/merger_server.hpp
@@ -5,6 +5,7 @@
 #include "protos/protobuf_merger.grpc.pb.h"
 #include "protos/protobuf_se.grpc.pb.h"
 #include "protos/protobuf_signer.grpc.pb.h"
+#include "rpc_receiver_list.hpp"
 #include <grpc/support/log.h>
 #include <grpcpp/grpcpp.h>
 #include <iostream>
@@ -15,8 +16,6 @@ using namespace grpc_se;
 using namespace grpc_signer;
 
 namespace gruut {
-
-// enum class CallStatus { CREATE, PROCESS, FINISH };
 
 class MergerServer {
 public:
@@ -35,140 +34,146 @@ private:
   GruutNetworkService::AsyncService m_signer_service;
 
   void recvData();
+};
 
-  class CallData {
-  public:
-    virtual void proceed() = 0;
+class CallData {
+public:
+  virtual void proceed() = 0;
 
-  protected:
-    ServerCompletionQueue *m_completion_queue;
-    ServerContext m_context;
-    CallStatus m_receive_status;
-  };
+protected:
+  ServerCompletionQueue *m_completion_queue;
+  ServerContext m_context;
+  RpcStatus m_receive_status;
+};
 
-  class RecvFromMerger final : public CallData {
-  public:
-    RecvFromMerger(MergerCommunication::AsyncService *service,
-                   ServerCompletionQueue *cq)
-        : m_responder(&m_context) {
-      m_service = service;
-      m_completion_queue = cq;
-      m_receive_status = CallStatus::CREATE;
-      proceed();
-    }
-    void proceed();
+class RecvFromMerger final : public CallData {
+public:
+  RecvFromMerger(MergerCommunication::AsyncService *service,
+                 ServerCompletionQueue *cq)
+      : m_responder(&m_context) {
+    m_service = service;
+    m_completion_queue = cq;
+    m_receive_status = RpcStatus::CREATE;
+    proceed();
+  }
+  void proceed();
 
-  private:
-    MergerCommunication::AsyncService *m_service;
-    MergerDataRequest m_request;
-    ServerAsyncResponseWriter<MergerDataReply> m_responder;
-  };
+private:
+  MergerCommunication::AsyncService *m_service;
+  MergerDataRequest m_request;
+  ServerAsyncResponseWriter<MergerDataReply> m_responder;
+};
 
-  class RecvFromSE final : public CallData {
-  public:
-    RecvFromSE(GruutSeService::AsyncService *service, ServerCompletionQueue *cq)
-        : m_responder(&m_context) {
-      m_service = service;
-      m_completion_queue = cq;
-      m_receive_status = CallStatus::CREATE;
-      proceed();
-    }
-    void proceed();
+class RecvFromSE final : public CallData {
+public:
+  RecvFromSE(GruutSeService::AsyncService *service, ServerCompletionQueue *cq)
+      : m_responder(&m_context) {
+    m_service = service;
+    m_completion_queue = cq;
+    m_receive_status = RpcStatus::CREATE;
+    proceed();
+  }
+  void proceed();
 
-  private:
-    GruutSeService::AsyncService *m_service;
-    GrpcMsgTX m_request;
-    ServerAsyncResponseWriter<Nothing> m_responder;
-  };
+private:
+  GruutSeService::AsyncService *m_service;
+  GrpcMsgTX m_request;
+  ServerAsyncResponseWriter<Nothing> m_responder;
+};
 
-  class OpenChannel final : public CallData {
-  public:
-    OpenChannel(GruutNetworkService::AsyncService *service,
-                ServerCompletionQueue *cq) {
-      m_service = service;
-      m_completion_queue = cq;
-      m_receive_status = CallStatus::CREATE;
-      m_stream = make_shared<ServerAsyncReaderWriter<GrpcMsgReqSsig, Identity>>(
-          &m_context);
-    }
-    void proceed();
+class OpenChannel final : public CallData {
+public:
+  OpenChannel(GruutNetworkService::AsyncService *service,
+              ServerCompletionQueue *cq)
+      : m_stream(&m_context) {
+    m_service = service;
+    m_completion_queue = cq;
+    m_receive_status = RpcStatus::CREATE;
+    m_rpc_receiver_list = RpcReceiverList::getInstance();
+    proceed();
+  }
+  void proceed();
 
-  private:
-    GruutNetworkService::AsyncService *m_service;
-    Identity m_request;
-    std::shared_ptr<ServerAsyncReaderWriter<GrpcMsgReqSsig, Identity>> m_stream;
-  };
+private:
+  RpcReceiverList *m_rpc_receiver_list;
+  GruutNetworkService::AsyncService *m_service;
+  Identity m_request;
+  ServerAsyncReaderWriter<GrpcMsgReqSsig, Identity> m_stream;
+};
 
-  class Join final : public CallData {
-  public:
-    Join(GruutNetworkService::AsyncService *service,
-         ServerCompletionQueue *cq) {
-      m_service = service;
-      m_completion_queue = cq;
-      m_receive_status = CallStatus::CREATE;
-      m_responder =
-          make_shared<ServerAsyncResponseWriter<GrpcMsgChallenge>>(&m_context);
-    }
-    void proceed();
+class Join final : public CallData {
+public:
+  Join(GruutNetworkService::AsyncService *service, ServerCompletionQueue *cq)
+      : m_responder(&m_context) {
+    m_service = service;
+    m_completion_queue = cq;
+    m_receive_status = RpcStatus::CREATE;
+    m_rpc_receiver_list = RpcReceiverList::getInstance();
+    proceed();
+  }
+  void proceed();
 
-  private:
-    GruutNetworkService::AsyncService *m_service;
-    GrpcMsgJoin m_request;
-    std::shared_ptr<ServerAsyncResponseWriter<GrpcMsgChallenge>> m_responder;
-  };
+private:
+  RpcReceiverList *m_rpc_receiver_list;
+  GruutNetworkService::AsyncService *m_service;
+  GrpcMsgJoin m_request;
+  ServerAsyncResponseWriter<GrpcMsgChallenge> m_responder;
+};
 
-  class DHKeyEx final : public CallData {
-  public:
-    DHKeyEx(GruutNetworkService::AsyncService *service,
-            ServerCompletionQueue *cq) {
-      m_service = service;
-      m_completion_queue = cq;
-      m_receive_status = CallStatus::CREATE;
-      m_responder =
-          make_shared<ServerAsyncResponseWriter<GrpcMsgResponse2>>(&m_context);
-    }
-    void proceed();
+class DHKeyEx final : public CallData {
+public:
+  DHKeyEx(GruutNetworkService::AsyncService *service, ServerCompletionQueue *cq)
+      : m_responder(&m_context) {
+    m_service = service;
+    m_completion_queue = cq;
+    m_receive_status = RpcStatus::CREATE;
+    m_rpc_receiver_list = RpcReceiverList::getInstance();
+    proceed();
+  }
+  void proceed();
 
-  private:
-    GruutNetworkService::AsyncService *m_service;
-    GrpcMsgResponse1 m_request;
-    std::shared_ptr<ServerAsyncResponseWriter<GrpcMsgResponse2>> m_responder;
-  };
+private:
+  RpcReceiverList *m_rpc_receiver_list;
+  GruutNetworkService::AsyncService *m_service;
+  GrpcMsgResponse1 m_request;
+  ServerAsyncResponseWriter<GrpcMsgResponse2> m_responder;
+};
 
-  class KeyExFinished final : public CallData {
-  public:
-    KeyExFinished(GruutNetworkService::AsyncService *service,
-                  ServerCompletionQueue *cq) {
-      m_service = service;
-      m_completion_queue = cq;
-      m_receive_status = CallStatus::CREATE;
-      m_responder =
-          make_shared<ServerAsyncResponseWriter<GrpcMsgAccept>>(&m_context);
-    }
-    void proceed();
+class KeyExFinished final : public CallData {
+public:
+  KeyExFinished(GruutNetworkService::AsyncService *service,
+                ServerCompletionQueue *cq)
+      : m_responder(&m_context) {
+    m_service = service;
+    m_completion_queue = cq;
+    m_receive_status = RpcStatus::CREATE;
+    m_rpc_receiver_list = RpcReceiverList::getInstance();
+    proceed();
+  }
+  void proceed();
 
-  private:
-    GruutNetworkService::AsyncService *m_service;
-    GrpcMsgSuccess m_request;
-    std::shared_ptr<ServerAsyncResponseWriter<GrpcMsgAccept>> m_responder;
-  };
+private:
+  RpcReceiverList *m_rpc_receiver_list;
+  GruutNetworkService::AsyncService *m_service;
+  GrpcMsgSuccess m_request;
+  ServerAsyncResponseWriter<GrpcMsgAccept> m_responder;
+};
 
-  class SigSend final : public CallData {
-  public:
-    SigSend(GruutNetworkService::AsyncService *service,
-            ServerCompletionQueue *cq)
-        : m_responder(&m_context) {
-      m_service = service;
-      m_completion_queue = cq;
-      m_receive_status = CallStatus::CREATE;
-    }
-    void proceed();
+class SigSend final : public CallData {
+public:
+  SigSend(GruutNetworkService::AsyncService *service, ServerCompletionQueue *cq)
+      : m_responder(&m_context) {
+    m_service = service;
+    m_completion_queue = cq;
+    m_receive_status = RpcStatus::CREATE;
+    proceed();
+  }
+  void proceed();
 
-  private:
-    GruutNetworkService::AsyncService *m_service;
-    GrpcMsgSsig m_request;
-    ServerAsyncResponseWriter<NoReply> m_responder;
-  };
+private:
+  GruutNetworkService::AsyncService *m_service;
+  GrpcMsgSsig m_request;
+  ServerAsyncResponseWriter<NoReply> m_responder;
 };
 
 } // namespace gruut

--- a/src/modules/communication/merger_server.hpp
+++ b/src/modules/communication/merger_server.hpp
@@ -1,0 +1,174 @@
+#pragma once
+
+#include "../../application.hpp"
+#include "grpc_merger.hpp"
+#include "protos/protobuf_merger.grpc.pb.h"
+#include "protos/protobuf_se.grpc.pb.h"
+#include "protos/protobuf_signer.grpc.pb.h"
+#include <grpc/support/log.h>
+#include <grpcpp/grpcpp.h>
+#include <iostream>
+#include <memory>
+using namespace grpc;
+using namespace grpc_merger;
+using namespace grpc_se;
+using namespace grpc_signer;
+
+namespace gruut {
+
+// enum class CallStatus { CREATE, PROCESS, FINISH };
+
+class MergerServer {
+public:
+  ~MergerServer() {
+    m_server->Shutdown();
+    m_completion_queue->Shutdown();
+  }
+  void runServer(char const *port);
+
+private:
+  std::unique_ptr<Server> m_server;
+  std::unique_ptr<ServerCompletionQueue> m_completion_queue;
+  // TODO: protobuf의 변수 명 정리후 namespace ,변수명 들은 바뀔수 있습니다.
+  MergerCommunication::AsyncService m_merger_service;
+  GruutSeService::AsyncService m_se_service;
+  GruutNetworkService::AsyncService m_signer_service;
+
+  void recvData();
+
+  class CallData {
+  public:
+    virtual void proceed() = 0;
+
+  protected:
+    ServerCompletionQueue *m_completion_queue;
+    ServerContext m_context;
+    CallStatus m_receive_status;
+  };
+
+  class RecvFromMerger final : public CallData {
+  public:
+    RecvFromMerger(MergerCommunication::AsyncService *service,
+                   ServerCompletionQueue *cq)
+        : m_responder(&m_context) {
+      m_service = service;
+      m_completion_queue = cq;
+      m_receive_status = CallStatus::CREATE;
+      proceed();
+    }
+    void proceed();
+
+  private:
+    MergerCommunication::AsyncService *m_service;
+    MergerDataRequest m_request;
+    ServerAsyncResponseWriter<MergerDataReply> m_responder;
+  };
+
+  class RecvFromSE final : public CallData {
+  public:
+    RecvFromSE(GruutSeService::AsyncService *service, ServerCompletionQueue *cq)
+        : m_responder(&m_context) {
+      m_service = service;
+      m_completion_queue = cq;
+      m_receive_status = CallStatus::CREATE;
+      proceed();
+    }
+    void proceed();
+
+  private:
+    GruutSeService::AsyncService *m_service;
+    GrpcMsgTX m_request;
+    ServerAsyncResponseWriter<Nothing> m_responder;
+  };
+
+  class OpenChannel final : public CallData {
+  public:
+    OpenChannel(GruutNetworkService::AsyncService *service,
+                ServerCompletionQueue *cq) {
+      m_service = service;
+      m_completion_queue = cq;
+      m_receive_status = CallStatus::CREATE;
+      m_stream = make_shared<ServerAsyncReaderWriter<GrpcMsgReqSsig, Identity>>(
+          &m_context);
+    }
+    void proceed();
+
+  private:
+    GruutNetworkService::AsyncService *m_service;
+    Identity m_request;
+    std::shared_ptr<ServerAsyncReaderWriter<GrpcMsgReqSsig, Identity>> m_stream;
+  };
+
+  class Join final : public CallData {
+  public:
+    Join(GruutNetworkService::AsyncService *service,
+         ServerCompletionQueue *cq) {
+      m_service = service;
+      m_completion_queue = cq;
+      m_receive_status = CallStatus::CREATE;
+      m_responder =
+          make_shared<ServerAsyncResponseWriter<GrpcMsgChallenge>>(&m_context);
+    }
+    void proceed();
+
+  private:
+    GruutNetworkService::AsyncService *m_service;
+    GrpcMsgJoin m_request;
+    std::shared_ptr<ServerAsyncResponseWriter<GrpcMsgChallenge>> m_responder;
+  };
+
+  class DHKeyEx final : public CallData {
+  public:
+    DHKeyEx(GruutNetworkService::AsyncService *service,
+            ServerCompletionQueue *cq) {
+      m_service = service;
+      m_completion_queue = cq;
+      m_receive_status = CallStatus::CREATE;
+      m_responder =
+          make_shared<ServerAsyncResponseWriter<GrpcMsgResponse2>>(&m_context);
+    }
+    void proceed();
+
+  private:
+    GruutNetworkService::AsyncService *m_service;
+    GrpcMsgResponse1 m_request;
+    std::shared_ptr<ServerAsyncResponseWriter<GrpcMsgResponse2>> m_responder;
+  };
+
+  class KeyExFinished final : public CallData {
+  public:
+    KeyExFinished(GruutNetworkService::AsyncService *service,
+                  ServerCompletionQueue *cq) {
+      m_service = service;
+      m_completion_queue = cq;
+      m_receive_status = CallStatus::CREATE;
+      m_responder =
+          make_shared<ServerAsyncResponseWriter<GrpcMsgAccept>>(&m_context);
+    }
+    void proceed();
+
+  private:
+    GruutNetworkService::AsyncService *m_service;
+    GrpcMsgSuccess m_request;
+    std::shared_ptr<ServerAsyncResponseWriter<GrpcMsgAccept>> m_responder;
+  };
+
+  class SigSend final : public CallData {
+  public:
+    SigSend(GruutNetworkService::AsyncService *service,
+            ServerCompletionQueue *cq)
+        : m_responder(&m_context) {
+      m_service = service;
+      m_completion_queue = cq;
+      m_receive_status = CallStatus::CREATE;
+    }
+    void proceed();
+
+  private:
+    GruutNetworkService::AsyncService *m_service;
+    GrpcMsgSsig m_request;
+    ServerAsyncResponseWriter<NoReply> m_responder;
+  };
+};
+
+} // namespace gruut

--- a/src/modules/communication/merger_server.hpp
+++ b/src/modules/communication/merger_server.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../../application.hpp"
-#include "grpc_merger.hpp"
 #include "protos/protobuf_merger.grpc.pb.h"
 #include "protos/protobuf_se.grpc.pb.h"
 #include "protos/protobuf_signer.grpc.pb.h"
@@ -33,7 +32,7 @@ private:
   GruutSeService::AsyncService m_se_service;
   GruutNetworkService::AsyncService m_signer_service;
 
-  void recvData();
+  void recvMessage();
 };
 
 class CallData {
@@ -43,7 +42,7 @@ public:
 protected:
   ServerCompletionQueue *m_completion_queue;
   ServerContext m_context;
-  RpcStatus m_receive_status;
+  RpcCallStatus m_receive_status;
 };
 
 class RecvFromMerger final : public CallData {
@@ -53,7 +52,7 @@ public:
       : m_responder(&m_context) {
     m_service = service;
     m_completion_queue = cq;
-    m_receive_status = RpcStatus::CREATE;
+    m_receive_status = RpcCallStatus::CREATE;
     proceed();
   }
   void proceed();
@@ -70,7 +69,7 @@ public:
       : m_responder(&m_context) {
     m_service = service;
     m_completion_queue = cq;
-    m_receive_status = RpcStatus::CREATE;
+    m_receive_status = RpcCallStatus::CREATE;
     proceed();
   }
   void proceed();
@@ -88,7 +87,7 @@ public:
       : m_stream(&m_context) {
     m_service = service;
     m_completion_queue = cq;
-    m_receive_status = RpcStatus::CREATE;
+    m_receive_status = RpcCallStatus::CREATE;
     m_rpc_receiver_list = RpcReceiverList::getInstance();
     proceed();
   }
@@ -107,7 +106,7 @@ public:
       : m_responder(&m_context) {
     m_service = service;
     m_completion_queue = cq;
-    m_receive_status = RpcStatus::CREATE;
+    m_receive_status = RpcCallStatus::CREATE;
     m_rpc_receiver_list = RpcReceiverList::getInstance();
     proceed();
   }
@@ -126,7 +125,7 @@ public:
       : m_responder(&m_context) {
     m_service = service;
     m_completion_queue = cq;
-    m_receive_status = RpcStatus::CREATE;
+    m_receive_status = RpcCallStatus::CREATE;
     m_rpc_receiver_list = RpcReceiverList::getInstance();
     proceed();
   }
@@ -146,7 +145,7 @@ public:
       : m_responder(&m_context) {
     m_service = service;
     m_completion_queue = cq;
-    m_receive_status = RpcStatus::CREATE;
+    m_receive_status = RpcCallStatus::CREATE;
     m_rpc_receiver_list = RpcReceiverList::getInstance();
     proceed();
   }
@@ -165,7 +164,7 @@ public:
       : m_responder(&m_context) {
     m_service = service;
     m_completion_queue = cq;
-    m_receive_status = RpcStatus::CREATE;
+    m_receive_status = RpcCallStatus::CREATE;
     proceed();
   }
   void proceed();

--- a/src/modules/communication/message_handler.cpp
+++ b/src/modules/communication/message_handler.cpp
@@ -1,0 +1,115 @@
+#include "message_handler.hpp"
+#include "../../utils/compressor.hpp"
+
+namespace gruut {
+void MessageHandler::unpackMsg(std::string &packed_msg,
+                               std::promise<grpc::Status> &rpc_status) {
+  using namespace grpc;
+  auto &input_queue = Application::app().getInputQueue();
+
+  MessageHeader header = HeaderController::parseHeader(packed_msg);
+  if (!validateMessage(header)) {
+    rpc_status.set_value(Status(StatusCode::INVALID_ARGUMENT, "Wrong Message"));
+    return;
+  }
+  int body_size = getMsgBodySize(header);
+  // TODO:  HMAC 검증을 위해 key를 가져올 수 있게 되면. 가져오면 주석 해제
+  /*if(header.mac_algo_type ==  MACAlgorithmType::HMAC){
+      std::string msg = packed_msg.substr(0, HEADER_LENGTH +
+    body_size); std::vector<uint8_t> hmac(packed_msg.begin() + HEADER_LENGTH +
+    json_size , packed_msg.end()); std::vector<uint8_t> key;
+      if(!Hmac::verifyHMAC(msg, hmac, key)){
+        rpc_status.set_value(Status(StatusCode::UNAUTHENTICATED, "Wrong HMAC"));
+                return
+      }
+    }*/
+  std::string msg_body = getMsgBody(packed_msg, body_size);
+  nlohmann::json json_data = getJson(header.compression_algo_type, msg_body);
+
+  if (!JsonValidator::validateSchema(json_data, header.message_type)) {
+    rpc_status.set_value(
+        Status(grpc::StatusCode::INVALID_ARGUMENT, "json schema check fail"));
+    return;
+  }
+
+  uint64_t receiver_id;
+  memcpy(&receiver_id, &header.sender_id[0], sizeof(uint64_t));
+  input_queue->emplace(make_tuple(header.message_type, receiver_id, json_data));
+  rpc_status.set_value(Status::OK);
+}
+void MessageHandler::packMsg(OutputMessage &output_msg) {
+  auto &output_queue = Application::app().getOutputQueue();
+  OutputMessage msg = output_queue->front();
+  MessageType msg_type = get<0>(msg);
+
+  output_queue->pop();
+  nlohmann::json body = get<2>(msg);
+  MessageHeader header;
+  header.message_type = msg_type;
+  // TODO : Compression type에 따라 수정 될 수 있습니다.
+  header.compression_algo_type = CompressionAlgorithmType::NONE;
+  std::string packed_msg = genPackedMsg(header, body);
+
+  // TODO : Merger send datas to receivers
+}
+
+bool MessageHandler::validateMessage(MessageHeader &header) {
+  bool check = (header.identifier == G /*&& msg_header.version == VERSION*/);
+  if (header.mac_algo_type == MACAlgorithmType::HMAC) {
+    check &= (header.message_type == MessageType::MSG_SUCCESS ||
+              header.message_type == MessageType::MSG_SSIG);
+  }
+  return check;
+}
+
+int MessageHandler::getMsgBodySize(MessageHeader &header) {
+  int total_size = HeaderController::convertU8ToU32BE(header.total_length);
+  int body_size = total_size - static_cast<int>(HEADER_LENGTH);
+  return body_size;
+}
+
+std::string MessageHandler::getMsgBody(std::string &packed_msg, int body_size) {
+  std::string packed_body = packed_msg.substr(HEADER_LENGTH, body_size);
+  return packed_body;
+}
+
+nlohmann::json
+MessageHandler::getJson(CompressionAlgorithmType compression_type,
+                        std::string &body) {
+  nlohmann::json unpacked_body;
+  switch (compression_type) {
+  case CompressionAlgorithmType::LZ4: {
+    std::string origin_data;
+    Compressor::decompressData(body, origin_data, body.size());
+    unpacked_body = nlohmann::json::parse(origin_data);
+  } break;
+  case CompressionAlgorithmType::NONE: {
+    unpacked_body = nlohmann::json::parse(body);
+  } break;
+  default:
+    break;
+  }
+  return unpacked_body;
+}
+
+std::string MessageHandler::genPackedMsg(MessageHeader &header,
+                                         nlohmann::json &body) {
+  std::string body_dump = body.dump();
+
+  switch (header.compression_algo_type) {
+  case CompressionAlgorithmType::LZ4: {
+    std::string compressed_body;
+    Compressor::compressData(body_dump, compressed_body);
+    body_dump = compressed_body;
+  } break;
+  case CompressionAlgorithmType ::NONE:
+  default:
+    break;
+  }
+
+  std::string packed_msg = HeaderController::attachHeader(
+      body_dump, header.message_type, header.compression_algo_type);
+  return packed_msg;
+}
+
+}; // namespace gruut

--- a/src/modules/communication/message_handler.hpp
+++ b/src/modules/communication/message_handler.hpp
@@ -14,7 +14,8 @@ namespace gruut {
 class MessageHandler {
 public:
   void unpackMsg(std::string &packed_msg,
-                 std::promise<grpc::Status> &rpc_status);
+                 std::promise<grpc::Status> &rpc_status,
+                 std::promise<uint64_t> receiver_id);
   void packMsg(OutputMessage &output_msg);
 
 private:
@@ -24,6 +25,7 @@ private:
   nlohmann::json getJson(CompressionAlgorithmType compression_type,
                          std::string &body);
   std::string genPackedMsg(MessageHeader &header, nlohmann::json &body);
+  bool checkSignerMsgType(MessageType msg_tpye);
 };
 
 } // namespace gruut

--- a/src/modules/communication/message_handler.hpp
+++ b/src/modules/communication/message_handler.hpp
@@ -13,9 +13,8 @@ namespace gruut {
 
 class MessageHandler {
 public:
-  void unpackMsg(std::string &packed_msg,
-                 std::promise<grpc::Status> &rpc_status,
-                 std::promise<uint64_t> receiver_id);
+  void unpackMsg(std::string &packed_msg, grpc::Status &rpc_status,
+                 uint64_t &receiver_id);
   void packMsg(OutputMessage &output_msg);
 
 private:
@@ -25,7 +24,6 @@ private:
   nlohmann::json getJson(CompressionAlgorithmType compression_type,
                          std::string &body);
   std::string genPackedMsg(MessageHeader &header, nlohmann::json &body);
-  bool checkSignerMsgType(MessageType msg_tpye);
 };
 
 } // namespace gruut

--- a/src/modules/communication/message_handler.hpp
+++ b/src/modules/communication/message_handler.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "../../../include/nlohmann/json.hpp"
+#include "../../application.hpp"
+#include "grpc_util.hpp"
+#include <cstring>
+#include <future>
+#include <grpcpp/impl/codegen/status.h>
+#include <iostream>
+#include <string>
+
+namespace gruut {
+
+class MessageHandler {
+public:
+  void unpackMsg(std::string &packed_msg,
+                 std::promise<grpc::Status> &rpc_status);
+  void packMsg(OutputMessage &output_msg);
+
+private:
+  bool validateMessage(MessageHeader &header);
+  int getMsgBodySize(MessageHeader &header);
+  std::string getMsgBody(std::string &packed_msg, int body_size);
+  nlohmann::json getJson(CompressionAlgorithmType compression_type,
+                         std::string &body);
+  std::string genPackedMsg(MessageHeader &header, nlohmann::json &body);
+};
+
+} // namespace gruut

--- a/src/modules/communication/rpc_receiver_list.hpp
+++ b/src/modules/communication/rpc_receiver_list.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "../../utils/template_singleton.hpp"
+#include "grpc_merger.hpp"
+#include "protos/protobuf_signer.grpc.pb.h"
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <tuple>
+#include <unordered_map>
+
+using namespace grpc;
+using namespace grpc_signer;
+namespace gruut {
+
+enum class RpcStatus { CREATE, PROCESS, WAIT, FINISH };
+
+struct SignerRpcInfo {
+  void *tag_identity;
+  void *tag_join;
+  void *tag_dhkeyex;
+  void *tag_keyexfinished;
+  ServerAsyncReaderWriter<GrpcMsgReqSsig, Identity> *send_req_ssig;
+  ServerAsyncResponseWriter<GrpcMsgChallenge> *send_challenge;
+  ServerAsyncResponseWriter<GrpcMsgResponse2> *send_response2;
+  ServerAsyncResponseWriter<GrpcMsgAccept> *send_accept;
+};
+
+class RpcReceiverList : public TemplateSingleton<RpcReceiverList> {
+private:
+  std::unordered_map<uint64_t, SignerRpcInfo> m_receiver_list;
+  std::mutex m_mutex;
+
+public:
+  void
+  setReqSsig(uint64_t receiver_id,
+             ServerAsyncReaderWriter<GrpcMsgReqSsig, Identity> *req_sig_rpc) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_receiver_list[receiver_id].send_req_ssig = req_sig_rpc;
+    m_mutex.unlock();
+  }
+
+  void setChanllenge(uint64_t receiver_id,
+                     ServerAsyncResponseWriter<GrpcMsgChallenge> *challenge) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_receiver_list[receiver_id].send_challenge = challenge;
+    m_mutex.unlock();
+  }
+
+  void setResponse2(uint64_t receiver_id,
+                    ServerAsyncResponseWriter<GrpcMsgResponse2> *response2) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_receiver_list[receiver_id].send_response2 = response2;
+  }
+
+  void setAccept(uint64_t receiver_id,
+                 ServerAsyncResponseWriter<GrpcMsgAccept> *accept) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_receiver_list[receiver_id].send_accept = accept;
+  }
+
+  SignerRpcInfo getSignerRpcInfo(uint64_t receiver_id) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    SignerRpcInfo rpc_info = m_receiver_list[receiver_id];
+    m_mutex.unlock();
+    return rpc_info;
+  }
+
+  void clearRpcReceiverList() { m_receiver_list.clear(); }
+};
+} // namespace gruut

--- a/src/modules/message_fetcher/out_message_fetcher.cpp
+++ b/src/modules/message_fetcher/out_message_fetcher.cpp
@@ -1,0 +1,45 @@
+#include "out_message_fetcher.hpp"
+#include "../../application.hpp"
+#include "../../chain/types.hpp"
+#include "../communication/message_handler.hpp"
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+namespace gruut {
+
+OutMessageFetcher::OutMessageFetcher() {
+  m_timer.reset(
+      new boost::asio::deadline_timer(Application::app().getIoService()));
+}
+
+void OutMessageFetcher::start() { fetch(); }
+
+void OutMessageFetcher::fetch() {
+  auto &io_service = Application::app().getIoService();
+  io_service.post([this]() {
+    auto &output_queue = Application::app().getOutputQueue();
+    while (!output_queue->empty()) {
+      OutputMessage output_msg = output_queue->front();
+      output_queue->pop();
+
+      MessageHandler msg_handler;
+      msg_handler.packMsg(output_msg);
+    }
+  });
+
+  m_timer->expires_from_now(boost::posix_time::milliseconds(1000));
+  m_timer->async_wait([this](const boost::system::error_code &ec) {
+    if (ec == boost::asio::error::operation_aborted) {
+      std::cout << "Out MessageFetcher: Timer was cancelled or retriggered."
+                << std::endl;
+    } else if (ec.value() == 0) {
+      fetch();
+    } else {
+      std::cout << "ERROR: " << ec.message() << std::endl;
+      throw;
+    }
+  });
+}
+
+} // namespace gruut

--- a/src/modules/message_fetcher/out_message_fetcher.hpp
+++ b/src/modules/message_fetcher/out_message_fetcher.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "../module.hpp"
+#include <boost/asio.hpp>
+
+namespace gruut {
+class OutMessageFetcher : public Module {
+public:
+  OutMessageFetcher();
+
+  void start() override;
+
+private:
+  void fetch();
+
+  std::unique_ptr<boost::asio::deadline_timer> m_timer;
+};
+
+} // namespace gruut

--- a/src/utils/compressor.hpp
+++ b/src/utils/compressor.hpp
@@ -3,6 +3,7 @@
 
 #include <lz4.h>
 #include <string>
+#include <vector>
 
 using namespace std;
 class Compressor {


### PR DESCRIPTION
- MergerServer, MergerClient, MessageHandler, OutMessageFetcher class로 분할
- signer와  rpc 통신하던 부분을 비동기 부분으로 처리
- 1개의 port에서 통신이 가능하도록 수정 (이전에는 Merger , Signer 를 각 다른 port에서 하려고 했음)