### PR TITLE
 # FIX - sender-id parsing 문제 해결

### DIFF
--- a/src/modules/communication/grpc_merger.cpp
+++ b/src/modules/communication/grpc_merger.cpp
@@ -141,10 +141,11 @@ Status MergerRpcServer::SignerService::openChannel(
     ServerReaderWriter<GrpcMsgReqSsig, Identity> *stream) {
   ReceiverRpcData receiver_rpc = ReceiverRpcData();
   receiver_rpc.stream = stream;
-  uint64_t receiver_id;
+  uint64_t receiver_id = 0;
   Identity receiver_data;
   stream->Read(&receiver_data);
-  memcpy(&receiver_id, &receiver_data.sender()[0], sizeof(uint64_t));
+  memcpy(&receiver_id, &receiver_data.sender()[0],
+         receiver_data.sender().length());
   m_server.m_receiver_list[receiver_id] = receiver_rpc;
   // TODO: 보낼 데이터를 받을 때 까지 rpc 는 종료 되면 안됩니다. nullptr 이
   // 됬다는건 데이터를 전송했다는 뜻이 됩니다.

--- a/src/modules/communication/grpc_util.cpp
+++ b/src/modules/communication/grpc_util.cpp
@@ -146,6 +146,8 @@ grpc::Status HeaderController::analyzeData(std::string &raw_data,
                         "json schema check fail");
   }
   uint64_t id;
+  std::reverse(std::begin(msg_header.sender_id),
+               std::end(msg_header.sender_id));
   memcpy(&id, &msg_header.sender_id[0], sizeof(uint64_t));
   receiver_id = id;
   input_queue->emplace(


### PR DESCRIPTION
- signer와 rpc에서 openChannel시 파싱할때 길이를 잘 못 지정하여 더미값이
들어갔었음
- header를 파싱할 때 endian 문제로 수정