### PR TITLE
# ADD - MSG_REQ_SSIG 메시지 보내도록 구현

### DIFF
--- a/src/chain/block.hpp
+++ b/src/chain/block.hpp
@@ -6,8 +6,6 @@
 
 namespace gruut {
 struct PartialBlock {
-  // TODO: array -> alias 'timestamp'
-  std::array<uint8_t, 8> sent_time;
   sender_id_type sender_id;
   chain_id_type chain_id;
   block_height_type height;

--- a/src/modules/communication/grpc_merger.cpp
+++ b/src/modules/communication/grpc_merger.cpp
@@ -126,9 +126,9 @@ void MergerRpcServer::sendDataToSigner(std::string &header_added_data,
     m_receiver_list[receiver_id].msg_response2 = nullptr;
   } break;
   case MessageType::MSG_REQ_SSIG: {
-    //    GrpcMsgReqSsig msg;
-    //    msg.set_message(header_added_data);
-    //    m_receiver_list[receiver_id].stream->Write(msg);
+    GrpcMsgReqSsig msg;
+    msg.set_message(header_added_data);
+    m_receiver_list[receiver_id].stream->Write(msg);
     break;
   }
   default:

--- a/src/modules/communication/grpc_util.cpp
+++ b/src/modules/communication/grpc_util.cpp
@@ -148,7 +148,7 @@ grpc::Status HeaderController::analyzeData(std::string &raw_data,
   uint64_t id;
   std::reverse(std::begin(msg_header.sender_id),
                std::end(msg_header.sender_id));
-  memcpy(&id, &msg_header.sender_id[0], sizeof(uint64_t));
+  memcpy(&id, msg_header.sender_id, sizeof(uint64_t));
   receiver_id = id;
   input_queue->emplace(
       make_tuple(msg_header.message_type, receiver_id, json_data));

--- a/src/services/block_generator.cpp
+++ b/src/services/block_generator.cpp
@@ -8,7 +8,6 @@ PartialBlock
 BlockGenerator::generatePartialBlock(vector<sha256> &transactions_digest) {
   PartialBlock block;
 
-  block.sent_time = TypeConverter::toTimestampType(Time::now());
   // TODO: Merger id 가 아직 결정 안되어서 임시값 할당
   block.sender_id = Sha256::hash("1");
   // TODO: 위와 같은 이유로 임시값 할당

--- a/src/services/signature_requester.cpp
+++ b/src/services/signature_requester.cpp
@@ -21,10 +21,8 @@ void SignatureRequester::requestSignatures() {
 
   auto transactions = std::move(fetchTransactions());
   auto partial_block = makePartialBlock(transactions);
-  //  auto message = makeMessage(partial_block);
-  //
-  //  MessageProxy proxy;
-  //  proxy.deliverOutputMessage(message);
+  requestSignature(partial_block, signers);
+
   //  startSignatureCollectTimer(transactions);
 }
 
@@ -102,13 +100,14 @@ PartialBlock SignatureRequester::makePartialBlock(Transactions &transactions) {
   return block;
 }
 
-/*
-OutputMessage SignatureRequester::makeMessage(PartialBlock &block) {
-//  auto message = MessageFactory::createSigRequestMessage(block);
-
-  return message;
+void SignatureRequester::requestSignature(PartialBlock &block,
+                                          Signers &signers) {
+  if (signers.size() > 0) {
+    auto message = MessageFactory::createSigRequestMessage(block, signers);
+    MessageProxy proxy;
+    proxy.deliverOutputMessage(message);
+  }
 }
-*/
 
 RandomSignerIndices
 SignatureRequester::generateRandomNumbers(const unsigned int size) {

--- a/src/services/signature_requester.hpp
+++ b/src/services/signature_requester.hpp
@@ -35,7 +35,7 @@ private:
 
   PartialBlock makePartialBlock(Transactions &transactions);
 
-  OutputMessage makeMessage(PartialBlock &block);
+  void requestSignature(PartialBlock &block, Signers &signers);
 
   RandomSignerIndices generateRandomNumbers(unsigned int size);
 

--- a/src/services/signer_pool_manager.cpp
+++ b/src/services/signer_pool_manager.cpp
@@ -115,16 +115,10 @@ void SignerPoolManager::handleMessage(MessageType &message_type,
 
     // TODO: 임시로 Merger ID 1로 함
     sender_id_type merger_id = Sha256::hash("1");
-    signer_id_type signer_id;
-
-    // Conversion string to uint64_t
-    auto sender_id_str = message_body_json["sender"].get<string>();
-    std::istringstream iss(sender_id_str);
-    iss >> signer_id;
 
     auto secret_key_vector = TypeConverter::toSecureVector(
         join_temporary_table[receiver_id]->shared_secret_key);
-    signer_pool.pushSigner(signer_id,
+    signer_pool.pushSigner(receiver_id,
                            join_temporary_table[receiver_id]->signer_cert,
                            secret_key_vector, SignerStatus::GOOD);
 

--- a/src/utils/type_converter.hpp
+++ b/src/utils/type_converter.hpp
@@ -1,9 +1,12 @@
 #ifndef GRUUT_ENTERPRISE_MERGER_TYPE_CONVERTER_HPP
 #define GRUUT_ENTERPRISE_MERGER_TYPE_CONVERTER_HPP
 
+#include <botan/base64.h>
 #include <botan/secmem.h>
 #include <string>
 #include <vector>
+
+#include "../chain/types.hpp"
 
 class TypeConverter {
 public:
@@ -30,6 +33,10 @@ public:
     }
 
     return timestamp;
+  }
+
+  static std::string toBase64Str(vector<uint8_t> &bytes_vector) {
+    return Botan::base64_encode(bytes_vector);
   }
 };
 


### PR DESCRIPTION
## 구현사항
- `BlockGenerator#generatePartialBlock` 에서 임시블럭을 생성
-  MessageFactory에서는 서명요청 메시지를 생성해서 OutputQueue에 넣음
  * Base64로 인코딩하는 코드가 중복으로 존재해서 TypeConverter에 `toBase64Str` 추가
- SignerPool 코드 수정
  * 이 PR과는 직접적으로는 관계없지만, sender 정보를 가져올 필요없이 `receiver_id` 를 직접 가져올 수 있어서 수정
- PartialBlock의 sent_time 필드 제거
  * 메시지 송신할때 필요한 필드이므로, 임시블럭에는 필요없는 데이터
- grpc 관련 통신 버그
  * 일관되게 엔디안 처리가 안돼서 receiver_id가 매 요청마다 다르게 들어옴(Join 할때는 id가 3203230이고, openChannel 에서는 52가 들어옴)
  * 일단 52로 들어오는게 맞으므로, reverse로 임시처리함.

  https://thevaulters.atlassian.net/secure/RapidBoard.jspa?rapidView=21&projectKey=GEN&modal=detail&selectedIssue=GEN-47