### PR TITLE
 # ADD - Signer가 보낸 Signature를 Pool에 넣는 코드 구현

### DIFF
--- a/src/application.hpp
+++ b/src/application.hpp
@@ -14,15 +14,15 @@
 #include <vector>
 
 #include "chain/message.hpp"
-#include "chain/signature.cpp"
+#include "chain/signature.hpp"
 #include "chain/transaction.hpp"
+#include "services/signature_pool.hpp"
 
 using namespace std;
 
 namespace gruut {
 using InputQueue = shared_ptr<queue<InputMessage>>;
 using OutputQueue = shared_ptr<queue<OutputMessage>>;
-using SignaturePool = vector<Signature>;
 
 class Application {
 public:

--- a/src/chain/signature.hpp
+++ b/src/chain/signature.hpp
@@ -6,7 +6,6 @@
 namespace gruut {
 struct Signature {
   signer_id_type signer_id;
-  timestamp sent_time;
   signature_type signer_signature;
 };
 } // namespace gruut

--- a/src/modules/message_fetcher/message_fetcher.cpp
+++ b/src/modules/message_fetcher/message_fetcher.cpp
@@ -28,8 +28,8 @@ void MessageFetcher::fetch() {
     }
   });
 
-  // TODO: 임시로 3000(3초)
-  m_timer->expires_from_now(boost::posix_time::milliseconds(3000));
+  // TODO: 임시로 1000(1초)
+  m_timer->expires_from_now(boost::posix_time::milliseconds(1000));
   m_timer->async_wait([this](const boost::system::error_code &ec) {
     if (ec == boost::asio::error::operation_aborted) {
       std::cout << "MessageFetcher: Timer was cancelled or retriggered."

--- a/src/services/message_proxy.cpp
+++ b/src/services/message_proxy.cpp
@@ -23,6 +23,10 @@ void MessageProxy::deliverInputMessage(InputMessage &input_message) {
     Application::app().getTransactionCollector().handleMessage(
         message_body_json);
   } break;
+  case MessageType::MSG_SSIG: {
+    Application::app().getSignaturePool().handleMessage(receiver_id,
+                                                        message_body_json);
+  } break;
   default:
     break;
   }

--- a/src/services/signature_pool.cpp
+++ b/src/services/signature_pool.cpp
@@ -1,0 +1,56 @@
+#include "../application.hpp"
+#include "../utils/rsa.hpp"
+#include "../utils/type_converter.hpp"
+
+#include <string>
+
+using namespace nlohmann;
+using namespace std;
+
+namespace gruut {
+void SignaturePool::handleMessage(signer_id_type receiver_id,
+                                  json message_body_json) {
+  if (verifySignature(receiver_id, message_body_json)) {
+    Signature s;
+
+    s.signer_id = receiver_id;
+
+    string signer_sig = message_body_json["sig"].get<string>();
+    auto decoded_signer_sig = Botan::base64_decode(signer_sig);
+    auto decoded_signer_sig_bytes =
+        bytes(decoded_signer_sig.begin(), decoded_signer_sig.end());
+    s.signer_signature = decoded_signer_sig_bytes;
+
+    push(s);
+  }
+}
+
+void SignaturePool::push(Signature &signature) {
+  std::lock_guard<std::mutex> guard(m_mutex);
+  m_signature_pool.emplace_back(signature);
+}
+
+size_t SignaturePool::size() { return 0; }
+
+bool SignaturePool::empty() { return size() == 0; }
+
+bool SignaturePool::verifySignature(signer_id_type receiver_id,
+                                    json message_body_json) {
+  auto pk_cert = Application::app().getSignerPool().getPkCert(receiver_id);
+  if (pk_cert != "") {
+    auto signer_id = message_body_json["sID"].get<string>();
+    auto timestamp = message_body_json["time"].get<string>();
+
+    auto signer_signature_str = message_body_json["sig"].get<string>();
+    auto sec_vector = Botan::base64_decode(signer_signature_str);
+    auto signer_signature_bytes = bytes(sec_vector.begin(), sec_vector.end());
+    // TODO: Signer쪽 코드 미완성
+    //    bool verify_result = RSA::doVerify(pk_cert, signer_signature_str,
+    //    signer_signature_bytes, true);
+
+    return true;
+  }
+
+  return false;
+}
+} // namespace gruut

--- a/src/services/signature_pool.hpp
+++ b/src/services/signature_pool.hpp
@@ -1,0 +1,31 @@
+#ifndef GRUUT_ENTERPRISE_MERGER_SIGNATURE_POOL_HPP
+#define GRUUT_ENTERPRISE_MERGER_SIGNATURE_POOL_HPP
+
+#include <list>
+#include <mutex>
+#include <nlohmann/json.hpp>
+
+#include "../chain/signature.hpp"
+
+using namespace nlohmann;
+
+namespace gruut {
+class SignaturePool {
+public:
+  void handleMessage(signer_id_type receiver_id, nlohmann::json);
+
+  bool empty();
+
+  size_t size();
+
+private:
+  void push(Signature &signature);
+
+  bool verifySignature(signer_id_type, json);
+
+  std::list<Signature> m_signature_pool;
+
+  std::mutex m_mutex;
+};
+}; // namespace gruut
+#endif

--- a/src/services/signature_requester.hpp
+++ b/src/services/signature_requester.hpp
@@ -16,7 +16,7 @@ namespace gruut {
 class Transaction;
 
 const int SIGNATURE_COLLECTION_INTERVAL = 10000;
-const int SIGNATURE_COLLECT_SIZE = 10;
+const int MAX_SIGNATURE_COLLECT_SIZE = 1;
 
 using RandomSignerIndices = std::set<int>;
 using Transactions = std::vector<Transaction>;
@@ -41,8 +41,6 @@ private:
 
   Signers selectSigners();
   std::unique_ptr<boost::asio::deadline_timer> m_timer;
-  std::thread *m_signature_check_thread;
-  bool m_runnable = false;
   MerkleTree m_merkle_tree;
 };
 } // namespace gruut

--- a/src/services/signer_pool_manager.cpp
+++ b/src/services/signer_pool_manager.cpp
@@ -65,8 +65,10 @@ void SignerPoolManager::handleMessage(MessageType &message_type,
       // TODO: 임시로 Merger ID 1로 함
       sender_id_type sender_id = Sha256::hash("1");
 
-      join_temporary_table[receiver_id]->signer_cert =
-          message_body_json["cert"].get<string>();
+      auto signer_pk_cert = message_body_json["cert"].get<string>();
+      auto cert_vector = Botan::base64_decode(signer_pk_cert);
+      string decoded_cert_str(cert_vector.begin(), cert_vector.end());
+      join_temporary_table[receiver_id]->signer_cert = decoded_cert_str;
 
       json message_body;
       message_body["sender"] = Sha256::toString(sender_id);

--- a/src/services/transaction_collector.cpp
+++ b/src/services/transaction_collector.cpp
@@ -106,7 +106,7 @@ void TransactionCollector::startTimer() {
   m_timer.reset(
       new boost::asio::deadline_timer(Application::app().getIoService()));
   m_timer->expires_from_now(
-      boost::posix_time::milliseconds(TRANSACTION_COLLECTION_INTERVAL));
+      boost::posix_time::seconds(TRANSACTION_COLLECTION_INTERVAL_SEC));
   m_timer->async_wait([this](const boost::system::error_code &ec) {
     if (ec == boost::asio::error::operation_aborted) {
       cout << "startTimer: Timer was cancelled or retriggered." << endl;
@@ -114,8 +114,8 @@ void TransactionCollector::startTimer() {
     } else if (ec.value() == 0) {
       this->m_timer_running = false;
       // TODO: Logger
-      cout << "POOL SIZE: " << Application::app().getTransactionPool().size()
-           << endl;
+      cout << "Transaction POOL SIZE: "
+           << Application::app().getTransactionPool().size() << endl;
     } else {
       this->m_timer_running = false;
       throw;

--- a/src/services/transaction_collector.hpp
+++ b/src/services/transaction_collector.hpp
@@ -11,7 +11,7 @@
 #include "signature_requester.hpp"
 
 namespace gruut {
-const int TRANSACTION_COLLECTION_INTERVAL = 5000;
+const int TRANSACTION_COLLECTION_INTERVAL_SEC = 50;
 
 class TransactionCollector {
 public:


### PR DESCRIPTION
## 구현사항
- Application 클래스에 SignaturePool가 stl 컨테이너 형태로 선언되어있었음. MSG_SSIG(Signer가 보내주는 서명 메시지)를 처리하고 서명을 저장해야 하므로 signature_pool 클래스를 생성
  * 서명을 pool에 넣기 전에 Signer의 서명을 검증하는데, 검증하는 작업은 다음 PR에서 진행
- signature.cpp -> signature.hpp 로 수정
- SignatureRequester
  * `startSignatureCollectTimer`를 주석해제. timer는 일정시간 서명을 취합하고 expire되면 블럭을 생성하도록 함(블럭 생성하는 것은 다음 PR에서 진행)
- ETC
  * signer_pool_manager
    * join 시 signer_cert를 base64 디코딩없이 바로 저장하고 있어서 디코딩 후 저장하도록 수정
    * MessageFetcher 가 종전의 코드에서는 input_queue에서 3초마다 하나씩 꺼내왔는데, 1초마다 가져오도록 수정(테스트 용이를 위해서)
    * TRANSACTION_COLLECTION_INTERVAL_SEC 를 seconds로 변경