### PR TITLE
# ADD - MSG_SSIG 서명 검증하는 코드 구현

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -61,4 +61,8 @@ Application::Application() {
 
   m_thread_group = make_shared<std::vector<std::thread>>();
 }
+
+PartialBlock &Application::getTemporaryPartialBlock() {
+  return temporary_partial_block;
+}
 } // namespace gruut

--- a/src/application.hpp
+++ b/src/application.hpp
@@ -51,6 +51,8 @@ public:
 
   SignaturePool &getSignaturePool();
 
+  PartialBlock &getTemporaryPartialBlock();
+
   void start(const vector<shared_ptr<Module>> &modules);
 
   void exec();
@@ -61,6 +63,7 @@ private:
   shared_ptr<boost::asio::io_service> m_io_serv;
   InputQueue m_input_queue;
   OutputQueue m_output_queue;
+  PartialBlock temporary_partial_block;
   shared_ptr<SignerPool> m_signer_pool;
   shared_ptr<SignerPoolManager> m_signer_pool_manager;
   shared_ptr<TransactionPool> m_transaction_pool;

--- a/src/chain/signer.hpp
+++ b/src/chain/signer.hpp
@@ -9,7 +9,7 @@
 
 namespace gruut {
 struct Signer {
-  signer_id_type user_id{0};
+  signer_id_type user_id;
   std::string pk_cert;
   hmac_key_type hmac_key;
   uint64_t last_update{0};

--- a/src/services/signature_pool.cpp
+++ b/src/services/signature_pool.cpp
@@ -8,6 +8,8 @@ using namespace nlohmann;
 using namespace std;
 
 namespace gruut {
+using BytesArray = array<uint8_t, 8>;
+
 void SignaturePool::handleMessage(signer_id_type receiver_id,
                                   json message_body_json) {
   if (verifySignature(receiver_id, message_body_json)) {
@@ -16,10 +18,9 @@ void SignaturePool::handleMessage(signer_id_type receiver_id,
     s.signer_id = receiver_id;
 
     string signer_sig = message_body_json["sig"].get<string>();
-    auto decoded_signer_sig = Botan::base64_decode(signer_sig);
-    auto decoded_signer_sig_bytes =
-        bytes(decoded_signer_sig.begin(), decoded_signer_sig.end());
-    s.signer_signature = decoded_signer_sig_bytes;
+    auto decoded_signer_sig =
+        TypeConverter::toBytes(Botan::base64_decode(signer_sig));
+    s.signer_signature = decoded_signer_sig;
 
     push(s);
   }
@@ -38,17 +39,45 @@ bool SignaturePool::verifySignature(signer_id_type receiver_id,
                                     json message_body_json) {
   auto pk_cert = Application::app().getSignerPool().getPkCert(receiver_id);
   if (pk_cert != "") {
-    auto signer_id = message_body_json["sID"].get<string>();
+    bytes signature_message_bytes;
+
+    auto not_decoded_id = message_body_json["sID"].get<string>();
+    auto signer_id_str =
+        TypeConverter::toString(Botan::base64_decode(not_decoded_id));
+
+    BytesArray signer_id_array = TypeConverter::to8BytesArray(signer_id_str);
+    signature_message_bytes.insert(signature_message_bytes.cend(),
+                                   signer_id_array.cbegin(),
+                                   signer_id_array.cend());
+
     auto timestamp = message_body_json["time"].get<string>();
+    auto timestamp_bytes = TypeConverter::to8BytesArray(timestamp);
+    signature_message_bytes.insert(signature_message_bytes.cend(),
+                                   timestamp_bytes.cbegin(),
+                                   timestamp_bytes.cend());
+
+    PartialBlock &partial_block = Application::app().getTemporaryPartialBlock();
+    auto merger_id = partial_block.sender_id;
+    signature_message_bytes.insert(signature_message_bytes.cend(),
+                                   merger_id.cbegin(), merger_id.cend());
+
+    auto height = partial_block.height;
+    BytesArray height_array = TypeConverter::to8BytesArray(height);
+    signature_message_bytes.insert(signature_message_bytes.cend(),
+                                   height_array.cbegin(), height_array.cend());
+
+    auto tx_root = partial_block.transaction_root;
+    signature_message_bytes.insert(signature_message_bytes.cend(),
+                                   tx_root.cbegin(), tx_root.cend());
 
     auto signer_signature_str = message_body_json["sig"].get<string>();
-    auto sec_vector = Botan::base64_decode(signer_signature_str);
-    auto signer_signature_bytes = bytes(sec_vector.begin(), sec_vector.end());
-    // TODO: Signer쪽 코드 미완성
-    //    bool verify_result = RSA::doVerify(pk_cert, signer_signature_str,
-    //    signer_signature_bytes, true);
+    auto signer_signature_bytes =
+        TypeConverter::toBytes(Botan::base64_decode(signer_signature_str));
 
-    return true;
+    bool verify_result = RSA::doVerify(pk_cert, signature_message_bytes,
+                                       signer_signature_bytes, true);
+
+    return verify_result;
   }
 
   return false;

--- a/src/services/signature_requester.cpp
+++ b/src/services/signature_requester.cpp
@@ -20,9 +20,11 @@ void SignatureRequester::requestSignatures() {
   auto signers = selectSigners();
 
   auto transactions = std::move(fetchTransactions());
-  auto partial_block = makePartialBlock(transactions);
-  requestSignature(partial_block, signers);
 
+  auto partial_block = makePartialBlock(transactions);
+  Application::app().getTemporaryPartialBlock() = partial_block;
+
+  requestSignature(partial_block, signers);
   startSignatureCollectTimer(transactions);
 }
 

--- a/src/services/transaction_collector.cpp
+++ b/src/services/transaction_collector.cpp
@@ -33,7 +33,7 @@ void TransactionCollector::handleMessage(json message_body_json) {
                              txid_vector.cend());
 
     transaction.sent_time =
-        TypeConverter::toTimestampType(message_body_json["time"].get<string>());
+        TypeConverter::to8BytesArray(message_body_json["time"].get<string>());
     signature_message.insert(signature_message.cend(),
                              transaction.sent_time.cbegin(),
                              transaction.sent_time.cend());

--- a/src/services/transaction_generator.cpp
+++ b/src/services/transaction_generator.cpp
@@ -20,7 +20,7 @@ void TransactionGenerator::generate(Signer &signer) {
                              new_transaction.transaction_id.cend());
 
     string timestamp = Time::now();
-    new_transaction.sent_time = TypeConverter::toTimestampType(timestamp);
+    new_transaction.sent_time = TypeConverter::to8BytesArray(timestamp);
     signature_message.insert(signature_message.cend(),
                              new_transaction.sent_time.cbegin(),
                              new_transaction.sent_time.cend());

--- a/src/utils/rsa.hpp
+++ b/src/utils/rsa.hpp
@@ -81,6 +81,22 @@ public:
     return verifier.verify_message(data, sig);
   }
 
+  static bool doVerify(std::string &rsa_pk, const std::vector<uint8_t> &data,
+                       const std::vector<uint8_t> &sig, bool pkcs1v15 = false) {
+    try {
+      Botan::DataSource_Memory cert_datasource(rsa_pk);
+      Botan::X509_Certificate cert(cert_datasource);
+      Botan::RSA_PublicKey public_key(cert.subject_public_key_algo(),
+                                      cert.subject_public_key_bitstring());
+
+      return doVerify(public_key, data, sig, pkcs1v15);
+    } catch (Botan::Exception &exception) {
+      // TODO: Logging
+      std::cout << "error on PEM to RSA PK: " << exception.what() << std::endl;
+      return false;
+    }
+  }
+
 private:
   static std::string getEmsa(bool is_pkcs1v15) {
     return is_pkcs1v15 ? "EMSA3(SHA-256)" : "EMSA4(SHA-256)";

--- a/src/utils/type_converter.hpp
+++ b/src/utils/type_converter.hpp
@@ -10,8 +10,8 @@
 
 class TypeConverter {
 public:
-  static std::vector<uint8_t> toBytes(std::string str) {
-    return std::vector<uint8_t>(str.begin(), str.end());
+  template <class T> inline static std::vector<uint8_t> toBytes(T t) {
+    return std::vector<uint8_t>(t.cbegin(), t.cend());
   }
 
   static Botan::secure_vector<uint8_t>
@@ -19,24 +19,29 @@ public:
     return Botan::secure_vector<uint8_t>(vec.begin(), vec.end());
   }
 
-  static std::array<uint8_t, 8> toTimestampType(std::string str) {
-    uint64_t time_int = static_cast<uint64_t>(stoll(str));
-    std::array<uint8_t, 8> timestamp = {0, 0, 0, 0, 0, 0, 0, 0};
+  static std::array<uint8_t, 8> to8BytesArray(std::string str) {
+    uint64_t target_integer = static_cast<uint64_t>(stoll(str));
+    std::array<uint8_t, 8> bytes_arr = {0, 0, 0, 0, 0, 0, 0, 0};
 
-    auto unassigned_index = timestamp.size() - 1;
-    while (time_int != 0) {
-      uint8_t byte = static_cast<uint8_t>(time_int & 0xFF);
-      timestamp[unassigned_index] = byte;
+    auto unassigned_index = bytes_arr.size() - 1;
+    while (target_integer != 0) {
+      uint8_t byte = static_cast<uint8_t>(target_integer & 0xFF);
+      bytes_arr[unassigned_index] = byte;
 
-      time_int >>= 8;
+      target_integer >>= 8;
       --unassigned_index;
     }
 
-    return timestamp;
+    return bytes_arr;
   }
 
   static std::string toBase64Str(vector<uint8_t> &bytes_vector) {
     return Botan::base64_encode(bytes_vector);
+  }
+
+  template <class Container>
+  static inline std::string toString(const Container &bytes) {
+    return std::string(bytes.cbegin(), bytes.cend());
   }
 };
 


### PR DESCRIPTION
## 구현사항
- `signature_pool.cpp`
  * Signer로부터 온 서명을 검증하는 코드를 구현
  * json 형태로 넘어온 `signer_id` 를 파싱하기 위해 기존의 `TypeConverter::toTimeStampType`을 `TypeConverter::to8BytesArray`로 함수명 변경하고 그것을 사용함
- Appliction 클래스에 임시블럭을 블럭 생성 전에 저장하도록 구현
  * Signer에게 서명요청하기 위해 임시블럭을 전송하고, Merger는 MSG_SSIG(서명 메세지)를 받게 된다. SignaturePool에서 Signer가 보내온 Signature를 서명 검증하는 과정에서 merger_id 및 height 그리고 tx_root가 필요하기 때문에 임시블럭에 대한 정보가 필요하다.
  * SignatureRequester#requestSignatures 에서 임시블럭을 Signer에게 보내기 전에 저장.
- ETC
  * 중복되는 함수 템플릿으로 리팩토링함