### PR TITLE
# REFACTOR - sender_id 변수명 변경 및 타입 관련 리팩토링

### DIFF
--- a/src/chain/block.hpp
+++ b/src/chain/block.hpp
@@ -6,7 +6,7 @@
 
 namespace gruut {
 struct PartialBlock {
-  sender_id_type sender_id;
+  merger_id_type merger_id;
   chain_id_type chain_id;
   block_height_type height;
   transaction_root_type transaction_root;

--- a/src/chain/transaction.hpp
+++ b/src/chain/transaction.hpp
@@ -9,7 +9,7 @@
 namespace gruut {
 struct Transaction {
   transaction_id_type transaction_id;
-  std::array<uint8_t, 8> sent_time;
+  std::vector<uint8_t> sent_time;
   requestor_id_type requestor_id;
   TransactionType transaction_type;
   signature_type signature;

--- a/src/chain/types.hpp
+++ b/src/chain/types.hpp
@@ -52,7 +52,7 @@ using block_height_type = std::string;
 
 using transaction_id_type = bytes;
 using requestor_id_type = sha256;
-using sender_id_type = sha256;
+using merger_id_type = uint64_t;
 using signer_id_type = uint64_t;
 using transaction_root_type = sha256;
 using chain_id_type = sha256;

--- a/src/services/block_generator.cpp
+++ b/src/services/block_generator.cpp
@@ -8,8 +8,8 @@ PartialBlock
 BlockGenerator::generatePartialBlock(vector<sha256> &transactions_digest) {
   PartialBlock block;
 
-  // TODO: Merger id 가 아직 결정 안되어서 임시값 할당
-  block.sender_id = Sha256::hash("1");
+  // TODO: 설정파일이 없어서 하드코딩(1)
+  block.merger_id = 1;
   // TODO: 위와 같은 이유로 임시값 할당
   block.chain_id = Sha256::hash("1");
   // TODO: 위와 같은 이유로 임시값 할당

--- a/src/services/message_factory.hpp
+++ b/src/services/message_factory.hpp
@@ -21,7 +21,10 @@ public:
     json j_partial_block;
 
     j_partial_block["time"] = Time::now();
-    j_partial_block["mID"] = TypeConverter::toBase64Str(block.sender_id);
+
+    auto merger_id_str = to_string(block.merger_id);
+    j_partial_block["mID"] = TypeConverter::toBase64Str(merger_id_str);
+
     j_partial_block["cID"] = TypeConverter::toBase64Str(block.chain_id);
     j_partial_block["txrt"] =
         TypeConverter::toBase64Str(block.transaction_root);

--- a/src/services/signer_pool_manager.hpp
+++ b/src/services/signer_pool_manager.hpp
@@ -24,8 +24,7 @@ private:
   bool verifySignature(signer_id_type signer_id,
                        nlohmann::json message_body_json);
   string getCertificate();
-  string signMessage(vector<uint8_t>, vector<uint8_t>, vector<uint8_t>,
-                     vector<uint8_t>, vector<uint8_t>);
+  string signMessage(string, string, string, string, string);
   bool isJoinable();
 
   // A temporary table for connection establishment.

--- a/src/services/transaction_generator.cpp
+++ b/src/services/transaction_generator.cpp
@@ -20,7 +20,7 @@ void TransactionGenerator::generate(Signer &signer) {
                              new_transaction.transaction_id.cend());
 
     string timestamp = Time::now();
-    new_transaction.sent_time = TypeConverter::to8BytesArray(timestamp);
+    new_transaction.sent_time = TypeConverter::digitStringToBytes(timestamp);
     signature_message.insert(signature_message.cend(),
                              new_transaction.sent_time.cbegin(),
                              new_transaction.sent_time.cend());

--- a/src/utils/type_converter.hpp
+++ b/src/utils/type_converter.hpp
@@ -10,35 +10,52 @@
 
 class TypeConverter {
 public:
-  template <class T> inline static std::vector<uint8_t> toBytes(T t) {
-    return std::vector<uint8_t>(t.cbegin(), t.cend());
+  template <class T> inline static std::vector<uint8_t> toBytes(T input) {
+    std::vector<uint8_t> v;
+    v.reserve(sizeof(input));
+
+    for (auto i = 0; i < sizeof(input); ++i) {
+      v.push_back(input & 0xFF);
+      input >>= 8;
+    }
+    return v;
   }
 
-  static Botan::secure_vector<uint8_t>
-  toSecureVector(std::vector<uint8_t> vec) {
+  inline static std::vector<uint8_t> stringToBytes(std::string &input) {
+    return std::vector<uint8_t>(input.cbegin(), input.cend());
+  }
+
+  inline static Botan::secure_vector<uint8_t>
+  toSecureVector(std::vector<uint8_t> &vec) {
     return Botan::secure_vector<uint8_t>(vec.begin(), vec.end());
   }
 
-  static std::array<uint8_t, 8> to8BytesArray(std::string str) {
+  static std::vector<uint8_t> digitStringToBytes(std::string &str) {
     uint64_t target_integer = static_cast<uint64_t>(stoll(str));
-    std::array<uint8_t, 8> bytes_arr = {0, 0, 0, 0, 0, 0, 0, 0};
+    std::vector<uint8_t> bytes = {0, 0, 0, 0, 0, 0, 0, 0};
 
-    auto unassigned_index = bytes_arr.size() - 1;
+    auto unassigned_index = bytes.size() - 1;
     while (target_integer != 0) {
       uint8_t byte = static_cast<uint8_t>(target_integer & 0xFF);
-      bytes_arr[unassigned_index] = byte;
+      bytes[unassigned_index] = byte;
 
       target_integer >>= 8;
       --unassigned_index;
     }
 
-    return bytes_arr;
+    return bytes;
   }
 
-  static std::string toBase64Str(vector<uint8_t> &bytes_vector) {
-    return Botan::base64_encode(bytes_vector);
+  template <typename T> inline static std::string toBase64Str(T &t) {
+    return Botan::base64_encode(vector<uint8_t>(t.begin(), t.end()));
   }
 
+  template <typename T>
+  inline static std::vector<uint8_t> decodeBase64(T &input) {
+    auto s_vector = Botan::base64_decode(input);
+
+    return std::vector<uint8_t>(s_vector.begin(), s_vector.end());
+  }
   template <class Container>
   static inline std::string toString(const Container &bytes) {
     return std::string(bytes.cbegin(), bytes.cend());


### PR DESCRIPTION
## 수정사항
- sender_id_type -> merger_id_type
  * 변수명 변경
  * 설계서에 따르면 merger_id_type은 64비트가 되어야 함.
  * block.merger_id = 1로 하드코딩, config 관련 파일 생성되면 변경할 것.
- `Transaction`의 sent_time 타입 변경
  * 현재 대부분의 비트를 vector 컨테이너로 핸들링하고 있어서, array를 vector로 converting하는게 번거로움.
- stl container::insert -> BytesBuilder
  * 바이트 array를 생성하기 위해 종전의 코드에서는 vector를 하나 선언하고, `insert`를 통해 데이터를 붙였다.
  * Bytes를 쉽게 생성할 수 있는 유틸 클래스가 생겨서, 그것을 통해 바이트를 쉽게 생성할 수 있도록 리팩토링
- `TypeConverter`
  * 함수명이 애매한 것들을 변경함
  * 일부 inline 이 가능한 함수들에 inline 키워드 추가
  * `decodeBase64` 함수 추가
    * 일부 코드에서 Botan::base64_decode 에 대한 의존성을 줄이기 위함