### PR TITLE
# EDIT - 블럭 생성 버그 수정 및 블럭 생성시 서명

### DIFF
--- a/src/chain/block.hpp
+++ b/src/chain/block.hpp
@@ -16,6 +16,8 @@ struct PartialBlock {
   chain_id_type chain_id;
   block_height_type height;
   transaction_root_type transaction_root;
+
+  vector<Transaction> transactions;
 };
 
 struct Block : public PartialBlock {
@@ -43,7 +45,6 @@ struct Block : public PartialBlock {
   // Body
   MerkleTree merkle_tree;
   size_t transactions_count;
-  vector<Transaction> transactions;
 };
 } // namespace gruut
 #endif

--- a/src/services/block_generator.cpp
+++ b/src/services/block_generator.cpp
@@ -1,6 +1,8 @@
 #include "block_generator.hpp"
 #include "../chain/merkle_tree.hpp"
+#include "../chain/signature.hpp"
 #include "../utils/bytes_builder.hpp"
+#include "../utils/rsa.hpp"
 #include "../utils/time.hpp"
 #include "../utils/type_converter.hpp"
 
@@ -8,7 +10,8 @@ using namespace std;
 
 namespace gruut {
 PartialBlock
-BlockGenerator::generatePartialBlock(vector<sha256> &transactions_digest) {
+BlockGenerator::generatePartialBlock(vector<sha256> &transactions_digest,
+                                     vector<Transaction> &transactions) {
   PartialBlock block;
 
   // TODO: 설정파일이 없어서 하드코딩(1)
@@ -18,24 +21,41 @@ BlockGenerator::generatePartialBlock(vector<sha256> &transactions_digest) {
   // TODO: 위와 같은 이유로 임시값 할당
   block.height = "1";
   block.transaction_root = transactions_digest.back();
+  block.transactions = transactions;
 
   return block;
 }
 
 Block BlockGenerator::generateBlock(PartialBlock &partial_block,
-                                    vector<Transaction> &transactions,
                                     vector<Signature> &signatures,
                                     MerkleTree &merkle_tree) {
   Block block(partial_block);
+  BytesBuilder signature_builder;
 
+  // Meta
   // TODO: 설정파일(config)로 설정해야 함
   block.compression_algo_type = CompressionAlgorithmType::LZ4;
+  string compression_algo_type_str;
+  if (block.compression_algo_type == CompressionAlgorithmType::LZ4)
+    compression_algo_type_str = "LZ4";
+  else
+    compression_algo_type_str = "NONE";
+  signature_builder.append(compression_algo_type_str);
+
   // TODO: 임시처리
   block.header_length = 1;
+  signature_builder.append(block.header_length);
+
+  // Header
   // TODO: 임시처리
   block.version = 1;
+  signature_builder.append(block.version);
+
+  signature_builder.append(block.chain_id);
+
   // TODO: 임시처리
   block.previous_header_hash = Sha256::hash("1");
+  signature_builder.append(block.previous_header_hash);
 
   BytesBuilder builder;
   builder.append(block.chain_id);
@@ -43,18 +63,41 @@ Block BlockGenerator::generateBlock(PartialBlock &partial_block,
   builder.append(block.merger_id);
   // TODO: 과거 블럭에 대한 해시를 계산할 수 없어서 현재 블럭해시로 입력
   block.previous_block_id = Sha256::hash(builder.getString());
-  block.block_id = Sha256::hash(builder.getString());
-  block.timestamp = Time::now_int();
+  signature_builder.append(block.previous_block_id);
 
-  transform(transactions.begin(), transactions.end(),
+  block.block_id = Sha256::hash(builder.getString());
+  signature_builder.append(block.block_id);
+
+  block.timestamp = Time::now_int();
+  signature_builder.append(block.timestamp);
+
+  signature_builder.append(block.height);
+
+  transform(block.transactions.begin(), block.transactions.end(),
             back_inserter(block.transaction_ids),
             [](Transaction &t) { return t.transaction_id; });
 
-  block.signer_signatures = move(signatures);
+  signature_builder.append(block.merger_id);
 
+  BytesBuilder signer_signatures_builder;
+  block.signer_signatures = move(signatures);
+  for_each(block.signer_signatures.begin(), block.signer_signatures.end(),
+           [&signer_signatures_builder](const Signature &signer_sig) {
+             signer_signatures_builder.append(signer_sig.signer_id);
+             auto signer_sig_bytes = signer_sig.signer_signature;
+             signer_signatures_builder.append(signer_sig_bytes);
+           });
+  auto signer_sig_bytes = signer_signatures_builder.getBytes();
+  signature_builder.append(signer_sig_bytes);
+
+  // Body
   block.merkle_tree = merkle_tree;
-  block.transactions_count = transactions.size();
-  block.transactions = transactions;
+  block.transactions_count = block.transactions.size();
+
+  auto sig_bytes = signature_builder.getBytes();
+  // TODO: Config로 부터 sk 읽어와야 함
+  string rsa_sk = "";
+  block.signature = RSA::doSign(rsa_sk, sig_bytes, true);
 
   return block;
 }

--- a/src/services/block_generator.hpp
+++ b/src/services/block_generator.hpp
@@ -13,9 +13,9 @@ using namespace std;
 namespace gruut {
 class BlockGenerator {
 public:
-  PartialBlock generatePartialBlock(vector<sha256> &transactions_digest);
+  PartialBlock generatePartialBlock(vector<sha256> &transactions_digest,
+                                    vector<Transaction> &);
   Block generateBlock(PartialBlock &partial_block,
-                      vector<Transaction> &transactions,
                       vector<Signature> &signatures, MerkleTree &merkle_tree);
 };
 } // namespace gruut

--- a/src/services/signature_pool.cpp
+++ b/src/services/signature_pool.cpp
@@ -36,7 +36,7 @@ Signatures SignaturePool::fetchN(size_t n) {
   return signatures;
 }
 
-size_t SignaturePool::size() { return 0; }
+size_t SignaturePool::size() { return m_signature_pool.size(); }
 
 bool SignaturePool::empty() { return size() == 0; }
 

--- a/src/services/signature_requester.cpp
+++ b/src/services/signature_requester.cpp
@@ -51,12 +51,12 @@ void SignatureRequester::startSignatureCollectTimer(
         auto temp_partial_block = Application::app().getTemporaryPartialBlock();
 
         auto signatures_size =
-            max(signature_pool.size(), MAX_SIGNATURE_COLLECT_SIZE);
+            min(signature_pool.size(), MAX_SIGNATURE_COLLECT_SIZE);
         auto signatures = signature_pool.fetchN(signatures_size);
 
         BlockGenerator generator;
-        Block block = generator.generateBlock(temp_partial_block, transactions,
-                                              signatures, m_merkle_tree);
+        Block block = generator.generateBlock(temp_partial_block, signatures,
+                                              m_merkle_tree);
       }
     } else {
       std::cout << "ERROR: " << ec.message() << std::endl;
@@ -91,7 +91,8 @@ PartialBlock SignatureRequester::makePartialBlock(Transactions &transactions) {
 
   m_merkle_tree.generate(transaction_ids);
   vector<sha256> merkle_tree_vector = m_merkle_tree.getMerkleTree();
-  auto &&block = block_generator.generatePartialBlock(merkle_tree_vector);
+  auto &&block =
+      block_generator.generatePartialBlock(merkle_tree_vector, transactions);
 
   return block;
 }

--- a/src/utils/bytes_builder.hpp
+++ b/src/utils/bytes_builder.hpp
@@ -57,6 +57,18 @@ public:
     append(int_val, len);
   }
 
+  void append(uint32_t int_val) {
+    std::vector<uint8_t> v;
+    v.reserve(sizeof(int_val));
+
+    for (auto i = 0; i < sizeof(int_val); ++i) {
+      v.push_back(int_val & 0xFF);
+      int_val >>= 8;
+    }
+
+    append(v);
+  }
+
   void append(uint64_t int_val, size_t len = 8) {
     if (len > sizeof(uint64_t))
       len = sizeof(uint64_t);

--- a/tests/services/test.cpp
+++ b/tests/services/test.cpp
@@ -38,7 +38,10 @@ BOOST_AUTO_TEST_SUITE(Test_BlockGenerator)
         auto tx_digest = Sha256::hash("1");
         transactions_digest.emplace_back(tx_digest);
 
-        auto block = generator.generatePartialBlock(transactions_digest);
+        vector<Transaction> transactions;
+        transactions.emplace_back(Transaction());
+
+        auto block = generator.generatePartialBlock(transactions_digest, transactions);
         BOOST_TEST(true);
     }
 


### PR DESCRIPTION
## 수정사항
- PartialBlock 생성할때 transactions를 저장하도록 수정
  * 블럭 생성할때 (signature_requester.cpp:94) transactions 가 빈 vector로 넘어감.
    * 그 이유는 async_wait를 boost io_serv job_queue에 등록 시점에는 transactions 가 있지만, timer가 만료되어서 핸들러가 실행되는 시점에는 transactions가 파괴되어 남아있지 않게 된다.
    * 그래서 블럭을 생성할때 transactions size가 0이라서 블럭을 생성하지 못하는 버그
- signature_requester.cpp (54)
  * max -> min, 논리적 오류
- signature_pool.cpp
  * size를 무조건 0으로 리턴하고 있는 버그
- BytesBuilder#append
  * uint32_t를 처리할 수 있도록 함수 추가
  * 다른 append 함수들을 하나로 합칠 수 있을 것 같지만 일단 추가

참조: https://thevaulters.atlassian.net/wiki/spaces/SGN/pages/51707911/GE4.+Block+Structure