### PR TITLE
# EDIT - HMAC 검증을 위해 통신모듈에서 shared_secret_key를 접근할 수 있도록 지원

### DIFF
--- a/src/services/signer_pool_manager.cpp
+++ b/src/services/signer_pool_manager.cpp
@@ -130,6 +130,15 @@ void SignerPoolManager::handleMessage(MessageType &message_type,
   }
 }
 
+const vector<uint8_t>
+SignerPoolManager::getSecretKey(signer_id_type receiver_id) {
+  if (join_temporary_table[receiver_id]) {
+    return join_temporary_table[receiver_id]->shared_secret_key;
+  }
+
+  return vector<uint8_t>();
+}
+
 bool SignerPoolManager::verifySignature(signer_id_type signer_id,
                                         json message_body_json) {
   const auto decoded_signer_signature =

--- a/src/services/signer_pool_manager.hpp
+++ b/src/services/signer_pool_manager.hpp
@@ -19,6 +19,7 @@ public:
   SignerPoolManager() = default;
   void handleMessage(MessageType &message_type, signer_id_type receiver_id,
                      nlohmann::json message_body_json);
+  const vector<uint8_t> getSecretKey(signer_id_type receiver_id);
 
 private:
   bool verifySignature(signer_id_type signer_id,

--- a/tests/services/test.cpp
+++ b/tests/services/test.cpp
@@ -160,6 +160,16 @@ BOOST_AUTO_TEST_SUITE(Test_SignaturePool)
   }
 BOOST_AUTO_TEST_SUITE_END()
 
+BOOST_AUTO_TEST_SUITE(Test_SignerPoolManger)
+  BOOST_AUTO_TEST_CASE(getSecretKey) {
+    SignerPoolManager manager;
+
+    auto sk = manager.getSecretKey(0);
+
+    BOOST_CHECK_EQUAL(sk.size(), 0);
+  }
+BOOST_AUTO_TEST_SUITE_END()
+
 BOOST_AUTO_TEST_SUITE(Test_Storage_Service)
 
   BOOST_AUTO_TEST_CASE(save_block) {


### PR DESCRIPTION
## 수정이유
- MSG_SUCCESS 메시지 검증을 위해서는 `shared_secret_key`를 접근할 수 있어야 한다.
- 하지만 종전의 코드에서는 `join_temporary_table` 가 private member 였기 때문에 접근할 수 없었다.
- `SingerPool#pushSigner` 이후에나 key를 접근할 수 있었기 때문에 `MSG_SUCCESS`를 받는 통신 모듈 입장에선 아직 shared_key가 signer_pool에 들어가지 않았으므로 접근할 방법이 없었다.

## 수정사항
- `getSecretKey` getter method 구현
- SignerPool에 SignerStatus::TEMP 상태로 shared_key를 임시로 저장하는 방법이 제안되었으나 다음과 같은 제한사항으로 SignerPoolManager에서 관리하도록 함
  * 다수의 Signer가 SignerPool을 매번 가져오는게 부담됨(SignerPool은 현재 global variable임)
  * 통신모듈이 shared_key를 가져오기 위해서는 SignerPool을 접근해서 find해야 하는데, signer_pool 자료구조가 deque이기 때문에 find 연산이 **O(n)** 임
- 하지만 SignerPoolManager에서 관리하면 좋은 점은,
  * `join_temporary_table`가 unordered_map 이기 때문에 쉽게 접근가능하다.
  * 다수의 Signer가 table에 접근해도 각자 receiver_id가 다르기 때문에 어느정도 race condition 문제에서 자유롭다.