### PR TITLE
# EDIT - MSG_JOIN 수신이후 10초 이내 키교환 완료하지 못하면 중단하도록 구현

### DIFF
--- a/src/chain/join_temporary_data.hpp
+++ b/src/chain/join_temporary_data.hpp
@@ -11,6 +11,7 @@ struct JoinTemporaryData {
   string merger_nonce;
   string signer_cert;
   vector<uint8_t> shared_secret_key;
+  uint64_t expires_at;
 };
 } // namespace gruut
 #endif // GRUUT_ENTERPRISE_MERGER_JOINTEMPORARYDATA_HPP

--- a/src/modules/communication/message_handler.cpp
+++ b/src/modules/communication/message_handler.cpp
@@ -26,7 +26,7 @@ void MessageHandler::unpackMsg(std::string &packed_msg,
     std::vector<uint8_t> key;
     if (header.message_type == MessageType::MSG_SUCCESS) {
       auto &signer_pool_manager = Application::app().getSignerPoolManager();
-      // TODO: signer_pool_manager의 join_temporary_table에서 key를 임시로
+      // TODO: signer_pool_manager의 m_join_temporary_table에서 key를 임시로
       // 가져와서 테스트할 것. key = signer_pool_manager.getKey(id);
     } else if (header.message_type == MessageType::MSG_SSIG) {
       auto &signer_pool = Application::app().getSignerPool();

--- a/src/services/signer_pool_manager.hpp
+++ b/src/services/signer_pool_manager.hpp
@@ -26,11 +26,13 @@ private:
                        nlohmann::json message_body_json);
   string getCertificate();
   string signMessage(string, string, string, string, string);
+  void deliverErrorMessage(vector<uint64_t> &);
   bool isJoinable();
+  bool isTimeout(signer_id_type signer_id);
 
   // A temporary table for connection establishment.
   unordered_map<signer_id_type, unique_ptr<JoinTemporaryData>>
-      join_temporary_table;
+      m_join_temporary_table;
 };
 } // namespace gruut
 #endif

--- a/src/utils/time.hpp
+++ b/src/utils/time.hpp
@@ -13,11 +13,18 @@ public:
   }
 
   static uint64_t now_int() {
-    auto now = std::chrono::duration_cast<std::chrono::seconds>(
-                   std::chrono::system_clock::now().time_since_epoch())
-                   .count();
+    auto now = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count());
 
     return now;
+  }
+
+  static uint64_t from_now(uint64_t seconds) {
+    auto now = now_int();
+
+    return now + seconds;
   }
 };
 

--- a/tests/utils/test.cpp
+++ b/tests/utils/test.cpp
@@ -11,6 +11,7 @@
 #include "../../src/utils/hmac.hpp"
 #include "../../src/utils/hmac_key_maker.hpp"
 #include "../../src/utils/bytes_builder.hpp"
+#include "../../src/utils/time.hpp"
 
 using namespace std;
 
@@ -181,6 +182,17 @@ BOOST_AUTO_TEST_SUITE(Test_ByteBuilder)
     std::string b_str = my_builder.getString();
 
     BOOST_TEST((b_bytes.size() == 104 && b_str.size() == 104));
+  }
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(Test_Time)
+
+  BOOST_AUTO_TEST_CASE(from_now) {
+    auto now = Time::now_int();
+    auto ten_seconds_from_now = Time::from_now(10);
+    
+    BOOST_CHECK_EQUAL(now + 10, ten_seconds_from_now);
   }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## 수정이유
- 종전의 코드에서는 Signer가 네트워크에 Join할때 deadline 을 두지 않고, 키교환을 수행한다. 일반적으로 수초 내에 키교환이 완료되어야 정상이다.

## 수정사항
- `Time::from_now` 구현
  * argument 값에 따라 현재 시간으로부터 몇초 후의 값을 리턴한다
- SignerPoolManager
  * `m_join_temporary_table[receiver_id]->expires_at = Time::from_now(10);` 10초 뒤에 끝나지 않으면 expire 하도록 함
  * 만료되면 MSG_ERROR 메시지 송신 및 table entry flush 시킴