### PR TITLE
# REFACTOR - PR #106 문제를 해결하기 위한 준비

### DIFF
--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -15,8 +15,6 @@ constexpr size_t MAX_COLLECT_TRANSACTION_SIZE = 4096;
 constexpr size_t MIN_SIGNATURE_COLLECT_SIZE =
     1; // TODO: 테스트를 위해 임시로 1개로 설정
 constexpr size_t MAX_SIGNATURE_COLLECT_SIZE = 4096;
-
-constexpr size_t NOT_FOUND = static_cast<const size_t>(-1);
 } // namespace config
 } // namespace gruut
 #endif

--- a/src/services/signer_pool.cpp
+++ b/src/services/signer_pool.cpp
@@ -15,27 +15,27 @@ void SignerPool::pushSigner(signer_id_type user_id, std::string &pk_cert,
   new_signer.status = status;
   new_signer.last_update = Time::now_int();
 
-  auto signer_index = find(new_signer.user_id);
-  if (signer_index == NOT_FOUND) {
+  auto signer_iter = find(new_signer.user_id);
+  if (signer_iter == m_signer_pool.end()) {
     std::lock_guard<std::mutex> guard(m_push_mutex);
-    m_signer_pool.emplace_back(new_signer);
+    m_signer_pool.push_back(new_signer);
     m_push_mutex.unlock();
   } else {
-    std::lock_guard<std::mutex> guard(m_push_mutex);
-    m_signer_pool[signer_index] = new_signer;
-    m_push_mutex.unlock();
+    std::lock_guard<std::mutex> guard(m_update_mutex);
+    *signer_iter = new_signer;
+    m_update_mutex.unlock();
   }
 }
 
 bool SignerPool::updatePkCert(signer_id_type user_id, std::string &pk_cert) {
-  auto signer_index = find(user_id);
+  auto signer_iter = find(user_id);
 
-  if (signer_index == NOT_FOUND) {
+  if (signer_iter == m_signer_pool.end()) {
     return false;
   } else {
-    std::lock_guard<std::mutex> guard(m_push_mutex);
-    m_signer_pool[signer_index].pk_cert = pk_cert;
-    m_push_mutex.unlock();
+    std::lock_guard<std::mutex> guard(m_update_mutex);
+    (*signer_iter).pk_cert = pk_cert;
+    m_update_mutex.unlock();
 
     return true;
   }
@@ -43,14 +43,14 @@ bool SignerPool::updatePkCert(signer_id_type user_id, std::string &pk_cert) {
 
 bool SignerPool::updateHmacKey(signer_id_type user_id,
                                hmac_key_type &hmac_key) {
-  auto signer_index = find(user_id);
+  auto signer_iter = find(user_id);
 
-  if (signer_index == NOT_FOUND) {
+  if (signer_iter == m_signer_pool.end()) {
     return false;
   } else {
     std::lock_guard<std::mutex> guard(m_update_mutex);
-    m_signer_pool[signer_index].hmac_key = hmac_key;
-    m_signer_pool[signer_index].last_update = Time::now_int();
+    (*signer_iter).hmac_key = hmac_key;
+    (*signer_iter).last_update = Time::now_int();
     m_update_mutex.unlock();
 
     return true;
@@ -58,14 +58,14 @@ bool SignerPool::updateHmacKey(signer_id_type user_id,
 }
 
 bool SignerPool::updateStatus(uint64_t user_id, SignerStatus status) {
-  auto signer_index = find(user_id);
+  auto signer_iter = find(user_id);
 
-  if (signer_index == NOT_FOUND) {
+  if (signer_iter == m_signer_pool.end()) {
     return false;
   } else {
     std::lock_guard<std::mutex> guard(m_update_mutex);
-    m_signer_pool[signer_index].status = status;
-    m_signer_pool[signer_index].last_update = Time::now_int();
+    (*signer_iter).status = status;
+    (*signer_iter).last_update = Time::now_int();
     m_update_mutex.unlock();
 
     return true;
@@ -73,44 +73,41 @@ bool SignerPool::updateStatus(uint64_t user_id, SignerStatus status) {
 }
 
 bool SignerPool::removeSigner(uint64_t user_id) {
-  auto signer_index = find(user_id);
+  auto signer_iter = find(user_id);
 
-  if (signer_index == NOT_FOUND) {
+  if (signer_iter == m_signer_pool.end()) {
     return false;
   } else {
-    std::lock_guard<std::mutex> guard(m_update_mutex);
-    m_signer_pool.erase((m_signer_pool.begin() + signer_index));
-    m_update_mutex.unlock();
+    std::lock_guard<std::mutex> guard(m_push_mutex);
+    m_signer_pool.erase(signer_iter);
+    m_push_mutex.unlock();
 
     return true;
   }
 }
 
 hmac_key_type SignerPool::getHmacKey(uint64_t user_id) {
-  auto signer_index = find(user_id);
-  if (signer_index == NOT_FOUND)
+  auto signer_iter = find(user_id);
+  if (signer_iter == m_signer_pool.end())
     return hmac_key_type();
 
-  return m_signer_pool[signer_index].hmac_key;
+  return (*signer_iter).hmac_key;
 }
 
 std::string SignerPool::getPkCert(signer_id_type user_id) {
-  auto signer_index = find(user_id);
-  if (signer_index == NOT_FOUND)
+  auto signer_iter = find(user_id);
+  if (signer_iter == m_signer_pool.end())
     return "";
 
-  return m_signer_pool[signer_index].pk_cert;
+  return (*signer_iter).pk_cert;
 }
 
 size_t SignerPool::getNumSignerBy(SignerStatus status) {
-  size_t signer_num = 0;
-  for (Signer &entry : m_signer_pool) {
-    if (entry.status == status) {
-      ++signer_num;
-    }
-  }
+  auto signers_num = std::count_if(
+      m_signer_pool.begin(), m_signer_pool.end(),
+      [&status](Signer &signer) { return signer.status == status; });
 
-  return signer_num;
+  return signers_num;
 }
 
 void SignerPool::clearPool() {
@@ -121,22 +118,27 @@ void SignerPool::clearPool() {
 
 const size_t SignerPool::size() { return m_signer_pool.size(); }
 
-size_t SignerPool::find(signer_id_type user_id) {
-  for (size_t index = 0; index < m_signer_pool.size(); ++index) {
-    if (m_signer_pool[index].user_id == user_id)
-      return index;
-  }
+std::list<Signer>::iterator SignerPool::find(signer_id_type user_id) {
+  auto it = std::find_if(
+      m_signer_pool.begin(), m_signer_pool.end(),
+      [this, &user_id](Signer &signer) { return signer.user_id == user_id; });
 
-  return NOT_FOUND;
+  return it;
 }
 
-Signer SignerPool::getSigner(int index) { return m_signer_pool[index]; }
+Signer SignerPool::getSigner(int index) {
+  // TODO:
+  // https://thevaulters.atlassian.net/secure/RapidBoard.jspa?rapidView=21&projectKey=GEN&modal=detail&selectedIssue=GEN-141
+  auto it = m_signer_pool.begin();
+  std::advance(it, index);
+  return *it;
+}
 
 void SignerPool::createTransactions() {
   TransactionGenerator generator;
 
   for (auto &signer : m_signer_pool) {
-    if (signer.isNew()) {
+    if (signer.status == SignerStatus::GOOD && signer.isNew()) {
       generator.generate(signer);
     }
   }

--- a/src/services/signer_pool.hpp
+++ b/src/services/signer_pool.hpp
@@ -2,7 +2,7 @@
 #define GRUUT_ENTERPRISE_MERGER_SIGNER_POOL_HPP
 
 #include <array>
-#include <deque>
+#include <list>
 #include <mutex>
 #include <string>
 
@@ -44,9 +44,9 @@ public:
   // operations are required.
 
 private:
-  size_t find(signer_id_type user_id);
+  std::list<Signer>::iterator find(signer_id_type user_id);
 
-  std::deque<Signer> m_signer_pool;
+  std::list<Signer> m_signer_pool;
   std::mutex m_push_mutex;
   std::mutex m_update_mutex;
 };


### PR DESCRIPTION
## 수정사항
- `SignerPool`
  * m_signer_pool의 자료구조를 deque -> list로 변경
    * Signer가 추가되거나 삭제되는 일이 빈번하기 때문에 list가 적절하다.
    * 다수의 Signer가 SignerPool을 조작하는 연산을 하게 되면 iterator, pointer, reference가 무효화되기 때문이다.
  * list의 경우 노드 기반 컨테이너이기 때문에 list::begin() 부터 순차적으로 elememt를 찾아야 하기 때문에 `find` 함수가 iterator를 리턴하도록 수정
  * push_mutex, update_mutex 를 잘못 사용하고 있는 함수들 수정
  * `find`, `getNumSignerBy` stl 이 제공하는 알고리즘으로 수정

  참고자료: https://books.google.co.kr/books?id=RPnWe6QKnCcC&pg=PA11&lpg=PA11&dq=effective+stl+chapter+1&source=bl&ots=ipmCBZihSq&sig=177WGTbzrHwvI1VmVrgFvPDEfGk&hl=ko&sa=X&ved=2ahUKEwiHprGY4ZbfAhXZAYgKHTB2BeoQ6AEwDHoECAoQAQ#v=onepage&q=effective%20stl%20chapter%201&f=false