### PR TITLE
# ADD - HMAC 검증을 위해 통신모듈에서 shared_secret_key를 접근할 수 있도록 지원

### DIFF
--- a/src/chain/types.hpp
+++ b/src/chain/types.hpp
@@ -43,7 +43,7 @@ enum class MACAlgorithmType : uint8_t {
 
 enum class CompressionAlgorithmType : uint8_t { LZ4 = 0x04, NONE = 0xFF };
 
-enum class SignerStatus { UNKNOWN, ERROR, GOOD };
+enum class SignerStatus { UNKNOWN, TEMPORARY, ERROR, GOOD };
 
 using sha256 = std::vector<uint8_t>;
 using bytes = std::vector<uint8_t>;

--- a/src/services/signer_pool_manager.cpp
+++ b/src/services/signer_pool_manager.cpp
@@ -92,6 +92,13 @@ void SignerPoolManager::handleMessage(MessageType &message_type,
           join_temporary_table[receiver_id]->merger_nonce,
           message_body_json["sN"].get<string>(), dhx, dhy, timestamp);
 
+      auto &signer_pool = Application::app().getSignerPool();
+      auto secret_key_vector = TypeConverter::toSecureVector(
+          join_temporary_table[receiver_id]->shared_secret_key);
+      signer_pool.pushSigner(receiver_id,
+                             join_temporary_table[receiver_id]->signer_cert,
+                             secret_key_vector, SignerStatus::TEMPORARY);
+
       output_message =
           make_tuple(MessageType::MSG_RESPONSE_2, receiver_list, message_body);
     } else {
@@ -103,12 +110,7 @@ void SignerPoolManager::handleMessage(MessageType &message_type,
   } break;
   case MessageType::MSG_SUCCESS: {
     auto &signer_pool = Application::app().getSignerPool();
-
-    auto secret_key_vector = TypeConverter::toSecureVector(
-        join_temporary_table[receiver_id]->shared_secret_key);
-    signer_pool.pushSigner(receiver_id,
-                           join_temporary_table[receiver_id]->signer_cert,
-                           secret_key_vector, SignerStatus::GOOD);
+    signer_pool.updateStatus(receiver_id, SignerStatus::GOOD);
 
     json message_body;
     message_body["sender"] = merger_id;

--- a/tests/services/fixture.hpp
+++ b/tests/services/fixture.hpp
@@ -1,0 +1,22 @@
+#ifndef GRUUT_ENTERPRISE_MERGER_FIXTURE_HPP
+#define GRUUT_ENTERPRISE_MERGER_FIXTURE_HPP
+
+#include "../../src/chain/types.hpp"
+#include "../../src/services/signer_pool.hpp"
+
+using namespace gruut;
+
+struct SignerPoolFixture {
+  SignerPoolFixture() {
+    id = 1;
+    string test_cert = "MIIC7zCCAdegAwIBAgIBADANBgkqhkiG9w0BAQsFADBhMRQwEgYDVQQDEwt0aGVWYXVsdGVyczELMAkGA1UEBhMCS1IxCTAHBgNVBAgTADEQMA4GA1UEBxMHSW5jaGVvbjEUMBIGA1UEChMLdGhlVmF1bHRlcnMxCTAHBgNVBAsTADAeFw0xODExMjgwNTM1NDFaFw0xOTExMjgwNTM1NDFaMBUxEzARBgNVBAMMCkdSVVVUX0FVVEgwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDV2RKC+oo6sBeAoSJn55ZZJ+U9bRh4z/TOsc4V/92NsV5qXpiWhUMTqPfNGHTjR7ScI57ZH9lqltcBJ2mcqhBWY1A/lQfdWAJf+3/eh+H/ZvDcZW8s9PFeuJcftmEDtUMlh9xMUoL5a74dS5lhrdbH0tXRMfhB3w02fmkuvqW+MCsUubhL7mu0PDbJeWjqqu8P+c+6PWO0CRgkMmry1f1VksXTzp54wARW2O3Zut6Z56VknrMOP2f4IYGiLy8zC/oO/JRCPCFvW1cM5UDdjVaq8UkIZ7B/z4zqFjwT3gXHHdMp+RLS8t+tA15rhZ2iRtKPcSwlpV95BTBG3Jpbm7xTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAEAzwa2yTQMR6nRUgafc/v0z7PylG4ohkXljBzMxfFipYju1/AKse1PCBq2H9DSnSbeL/BI4lQjsXXJLCDSnWXNnJSt1oatOHv4JeJ2Ob88EBVkx7G0aK2S2yijfMx5Bpptp8FIYxZX0QuOJ2oNK73j1Dx9Xax+5ZkBE8wxYYXpsZ0R/BGw8Es1bNFyFcbNYWd3iQOwoXOenWWa6YOyzRhZ2EAw+l7C7LB6I68xIIAP0BBSMTOfq4Smdizdd3qWYJyouUcv83AZn8KWBJjRKNJgHQvnYzCCGnhOwekbh9WlrGVEUvr/b6yV/aXX6kMqsCAfLhloqQ7Ai24QvOfdOAEQ=";
+    vector<uint8_t> secret_key(32, 0);
+    auto secret_key_vector = TypeConverter::toSecureVector(secret_key);
+
+    signer_pool.pushSigner(id, test_cert, secret_key_vector, SignerStatus::GOOD);
+  }
+
+  SignerPool signer_pool;
+  signer_id_type id;
+};
+#endif

--- a/tests/services/test.cpp
+++ b/tests/services/test.cpp
@@ -25,6 +25,8 @@
 #include "../../src/services/storage.hpp"
 #include "../../src/services/block_json.hpp"
 
+#include "fixture.hpp"
+
 using namespace gruut;
 using namespace nlohmann;
 using namespace std;
@@ -71,18 +73,20 @@ BOOST_AUTO_TEST_SUITE(Test_MessageFactory)
 
 BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_AUTO_TEST_SUITE(Test_SignerPool)
+BOOST_FIXTURE_TEST_SUITE(Test_SignerPool, SignerPoolFixture)
 
     BOOST_AUTO_TEST_CASE(pushSigner) {
-      SignerPool signer_pool;
+      SignerPoolFixture signer_pool_fixture;
+      BOOST_CHECK_EQUAL(signer_pool_fixture.signer_pool.size(), 1);
+    }
 
-      signer_id_type id = 1;
-      string test_cert = "MIIC7zCCAdegAwIBAgIBADANBgkqhkiG9w0BAQsFADBhMRQwEgYDVQQDEwt0aGVWYXVsdGVyczELMAkGA1UEBhMCS1IxCTAHBgNVBAgTADEQMA4GA1UEBxMHSW5jaGVvbjEUMBIGA1UEChMLdGhlVmF1bHRlcnMxCTAHBgNVBAsTADAeFw0xODExMjgwNTM1NDFaFw0xOTExMjgwNTM1NDFaMBUxEzARBgNVBAMMCkdSVVVUX0FVVEgwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDV2RKC+oo6sBeAoSJn55ZZJ+U9bRh4z/TOsc4V/92NsV5qXpiWhUMTqPfNGHTjR7ScI57ZH9lqltcBJ2mcqhBWY1A/lQfdWAJf+3/eh+H/ZvDcZW8s9PFeuJcftmEDtUMlh9xMUoL5a74dS5lhrdbH0tXRMfhB3w02fmkuvqW+MCsUubhL7mu0PDbJeWjqqu8P+c+6PWO0CRgkMmry1f1VksXTzp54wARW2O3Zut6Z56VknrMOP2f4IYGiLy8zC/oO/JRCPCFvW1cM5UDdjVaq8UkIZ7B/z4zqFjwT3gXHHdMp+RLS8t+tA15rhZ2iRtKPcSwlpV95BTBG3Jpbm7xTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAEAzwa2yTQMR6nRUgafc/v0z7PylG4ohkXljBzMxfFipYju1/AKse1PCBq2H9DSnSbeL/BI4lQjsXXJLCDSnWXNnJSt1oatOHv4JeJ2Ob88EBVkx7G0aK2S2yijfMx5Bpptp8FIYxZX0QuOJ2oNK73j1Dx9Xax+5ZkBE8wxYYXpsZ0R/BGw8Es1bNFyFcbNYWd3iQOwoXOenWWa6YOyzRhZ2EAw+l7C7LB6I68xIIAP0BBSMTOfq4Smdizdd3qWYJyouUcv83AZn8KWBJjRKNJgHQvnYzCCGnhOwekbh9WlrGVEUvr/b6yV/aXX6kMqsCAfLhloqQ7Ai24QvOfdOAEQ=";
-      vector<uint8_t> secret_key(32, 0);
-      auto secret_key_vector = TypeConverter::toSecureVector(secret_key);
-      signer_pool.pushSigner(4, test_cert, secret_key_vector, SignerStatus::GOOD);
+    BOOST_AUTO_TEST_CASE(updateStatus) {
+      SignerPoolFixture signer_pool_fixture;
+      signer_pool_fixture.signer_pool.updateStatus(signer_pool_fixture.id, SignerStatus::TEMPORARY);
 
-      BOOST_CHECK_EQUAL(signer_pool.size(), 1);
+      auto signer = signer_pool_fixture.signer_pool.getSigner(0);
+      bool result = signer.status == SignerStatus::TEMPORARY;
+      BOOST_TEST(result);
     }
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
## 수정이유
- MSG_SUCCESS 메시지 검증을 위해서는 `shared_secret_key`를 접근할 수 있어야 한다.
- 하지만 종전의 코드에서는 `join_temporary_table` 가 private member 였기 때문에 접근할 수 없었다.
- `SingerPool#pushSigner` 이후에나 key를 접근할 수 있었기 때문에 `MSG_SUCCESS`를 받는 통신 모듈 입장에선 아직 shared_key가 signer_pool에 들어가지 않았으므로 접근할 방법이 없었다.

## 수정사항
- `MSG_RESPONSE_1` 단계에서 SignerPool에 Signer를 넣는다. (SignerStatus::TEMPORARY 상태의 Signer)
- `MSG_SUCCESS` 단계에서 `updateStatus`를 통해 Signer의 상태를 업데이트한다.
- SignerPool#updateStatus test 케이스 추가