### PR TITLE
# EDIT - MSG_JOIN 수신이후 10초 이내 키교환 완료하지 못하면 중단하도록 구현

### DIFF
--- a/src/chain/join_temporary_data.hpp
+++ b/src/chain/join_temporary_data.hpp
@@ -11,6 +11,7 @@ struct JoinTemporaryData {
   string merger_nonce;
   string signer_cert;
   vector<uint8_t> shared_secret_key;
+  uint64_t expires_at;
 };
 } // namespace gruut
 #endif // GRUUT_ENTERPRISE_MERGER_JOINTEMPORARYDATA_HPP

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -15,6 +15,8 @@ constexpr size_t MAX_COLLECT_TRANSACTION_SIZE = 4096;
 constexpr size_t MIN_SIGNATURE_COLLECT_SIZE =
     1; // TODO: 테스트를 위해 임시로 1개로 설정
 constexpr size_t MAX_SIGNATURE_COLLECT_SIZE = 4096;
+
+constexpr uint64_t JOIN_TIMEOUT_SEC = 10;
 } // namespace config
 } // namespace gruut
 #endif

--- a/src/modules/communication/message_handler.cpp
+++ b/src/modules/communication/message_handler.cpp
@@ -26,7 +26,7 @@ void MessageHandler::unpackMsg(std::string &packed_msg,
     std::vector<uint8_t> key;
     if (header.message_type == MessageType::MSG_SUCCESS) {
       auto &signer_pool_manager = Application::app().getSignerPoolManager();
-      // TODO: signer_pool_manager의 join_temporary_table에서 key를 임시로
+      // TODO: signer_pool_manager의 m_join_temporary_table에서 key를 임시로
       // 가져와서 테스트할 것. key = signer_pool_manager.getKey(id);
     } else if (header.message_type == MessageType::MSG_SSIG) {
       auto &signer_pool = Application::app().getSignerPool();

--- a/src/services/signer_pool_manager.cpp
+++ b/src/services/signer_pool_manager.cpp
@@ -11,10 +11,12 @@
 
 #include "../application.hpp"
 #include "../chain/types.hpp"
+#include "../config/config.hpp"
 #include "../utils/bytes_builder.hpp"
 #include "../utils/hmac_key_maker.hpp"
 #include "../utils/random_number_generator.hpp"
 #include "../utils/sha256.hpp"
+#include "../utils/time.hpp"
 #include "../utils/type_converter.hpp"
 #include "message_proxy.hpp"
 #include "signer_pool_manager.hpp"
@@ -37,19 +39,19 @@ void SignerPoolManager::handleMessage(MessageType &message_type,
   switch (message_type) {
   case MessageType::MSG_JOIN: {
     if (!isJoinable()) {
-      OutputMessage output_message =
-          make_tuple(MessageType::MSG_ERROR, receiver_list, json({}));
-      proxy.deliverOutputMessage(output_message);
+      deliverErrorMessage(receiver_list);
     } else {
-      join_temporary_table[receiver_id].reset(new JoinTemporaryData());
+      m_join_temporary_table[receiver_id].reset(new JoinTemporaryData());
+      m_join_temporary_table[receiver_id]->expires_at =
+          Time::from_now(config::JOIN_TIMEOUT_SEC);
 
       json message_body;
       message_body["sender"] = merger_id;
       message_body["time"] = timestamp;
 
-      join_temporary_table[receiver_id]->merger_nonce =
+      m_join_temporary_table[receiver_id]->merger_nonce =
           RandomNumGenerator::toString(RandomNumGenerator::randomize(32));
-      message_body["mN"] = join_temporary_table[receiver_id]->merger_nonce;
+      message_body["mN"] = m_join_temporary_table[receiver_id]->merger_nonce;
 
       OutputMessage output_message =
           make_tuple(MessageType::MSG_CHALLENGE, receiver_list, message_body);
@@ -57,6 +59,12 @@ void SignerPoolManager::handleMessage(MessageType &message_type,
     }
   } break;
   case MessageType::MSG_RESPONSE_1: {
+    if (isTimeout(receiver_id)) {
+      m_join_temporary_table[receiver_id].release();
+      deliverErrorMessage(receiver_list);
+      return;
+    }
+
     OutputMessage output_message;
     if (verifySignature(receiver_id, message_body_json)) {
       std::cout << "Validation success!" << std::endl;
@@ -64,7 +72,7 @@ void SignerPoolManager::handleMessage(MessageType &message_type,
       auto signer_pk_cert = message_body_json["cert"].get<string>();
       auto cert_vector = TypeConverter::decodeBase64(signer_pk_cert);
       string decoded_cert_str(cert_vector.begin(), cert_vector.end());
-      join_temporary_table[receiver_id]->signer_cert = decoded_cert_str;
+      m_join_temporary_table[receiver_id]->signer_cert = decoded_cert_str;
 
       json message_body;
       message_body["sender"] = merger_id;
@@ -85,18 +93,18 @@ void SignerPoolManager::handleMessage(MessageType &message_type,
 
       auto shared_secret_key_vector =
           key_maker.getSharedSecretKey(signer_dhx, signer_dhy, 32);
-      join_temporary_table[receiver_id]->shared_secret_key = vector<uint8_t>(
+      m_join_temporary_table[receiver_id]->shared_secret_key = vector<uint8_t>(
           shared_secret_key_vector.begin(), shared_secret_key_vector.end());
 
       message_body["sig"] = signMessage(
-          join_temporary_table[receiver_id]->merger_nonce,
+          m_join_temporary_table[receiver_id]->merger_nonce,
           message_body_json["sN"].get<string>(), dhx, dhy, timestamp);
 
       auto &signer_pool = Application::app().getSignerPool();
       auto secret_key_vector = TypeConverter::toSecureVector(
-          join_temporary_table[receiver_id]->shared_secret_key);
+          m_join_temporary_table[receiver_id]->shared_secret_key);
       signer_pool.pushSigner(receiver_id,
-                             join_temporary_table[receiver_id]->signer_cert,
+                             m_join_temporary_table[receiver_id]->signer_cert,
                              secret_key_vector, SignerStatus::TEMPORARY);
 
       output_message =
@@ -110,6 +118,14 @@ void SignerPoolManager::handleMessage(MessageType &message_type,
   } break;
   case MessageType::MSG_SUCCESS: {
     auto &signer_pool = Application::app().getSignerPool();
+
+    if (isTimeout(receiver_id)) {
+      m_join_temporary_table[receiver_id].release();
+      signer_pool.removeSigner(receiver_id);
+      deliverErrorMessage(receiver_list);
+      return;
+    }
+
     signer_pool.updateStatus(receiver_id, SignerStatus::GOOD);
 
     json message_body;
@@ -143,7 +159,7 @@ bool SignerPoolManager::verifySignature(signer_id_type signer_id,
   const vector<uint8_t> signer_signature(decoded_signer_signature.begin(),
                                          decoded_signer_signature.end());
 
-  const string message = join_temporary_table[signer_id]->merger_nonce +
+  const string message = m_join_temporary_table[signer_id]->merger_nonce +
                          message_body_json["sN"].get<string>() +
                          message_body_json["dhx"].get<string>() +
                          message_body_json["dhy"].get<string>() +
@@ -199,5 +215,24 @@ string SignerPoolManager::signMessage(string merger_nonce, string signer_nonce,
 bool SignerPoolManager::isJoinable() {
   // TODO: 현재 100명 정도 가입할 수 있다. Config 관련 코드 구현하면 제거할 것
   return true;
+}
+
+bool SignerPoolManager::isTimeout(signer_id_type signer_id) {
+  if (m_join_temporary_table[signer_id]) {
+    auto expires_at = m_join_temporary_table[signer_id]->expires_at;
+    auto timeout = expires_at < Time::now_int();
+    // TODO: Logger
+    if (timeout)
+      std::cout << "Signer " << signer_id << " is expired" << std::endl;
+    return timeout;
+  }
+  return false;
+}
+
+void SignerPoolManager::deliverErrorMessage(vector<uint64_t> &receiver_list) {
+  MessageProxy proxy;
+  OutputMessage output_message =
+      make_tuple(MessageType::MSG_ERROR, receiver_list, json({}));
+  proxy.deliverOutputMessage(output_message);
 }
 } // namespace gruut

--- a/src/services/signer_pool_manager.hpp
+++ b/src/services/signer_pool_manager.hpp
@@ -25,11 +25,13 @@ private:
                        nlohmann::json message_body_json);
   string getCertificate();
   string signMessage(string, string, string, string, string);
+  void deliverErrorMessage(vector<uint64_t> &);
   bool isJoinable();
+  bool isTimeout(signer_id_type signer_id);
 
   // A temporary table for connection establishment.
   unordered_map<signer_id_type, unique_ptr<JoinTemporaryData>>
-      join_temporary_table;
+      m_join_temporary_table;
 };
 } // namespace gruut
 #endif

--- a/src/utils/time.hpp
+++ b/src/utils/time.hpp
@@ -13,11 +13,17 @@ public:
   }
 
   static uint64_t now_int() {
-    auto now = std::chrono::duration_cast<std::chrono::seconds>(
-                   std::chrono::system_clock::now().time_since_epoch())
-                   .count();
+    auto now = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count());
 
     return now;
+  }
+
+  static uint64_t from_now(uint64_t seconds) {
+    auto now = now_int();
+    return now + seconds;
   }
 };
 

--- a/tests/utils/test.cpp
+++ b/tests/utils/test.cpp
@@ -11,6 +11,7 @@
 #include "../../src/utils/hmac.hpp"
 #include "../../src/utils/hmac_key_maker.hpp"
 #include "../../src/utils/bytes_builder.hpp"
+#include "../../src/utils/time.hpp"
 
 using namespace std;
 
@@ -164,7 +165,6 @@ BOOST_AUTO_TEST_SUITE(Test_ECDH)
 
 BOOST_AUTO_TEST_SUITE_END()
 
-
 BOOST_AUTO_TEST_SUITE(Test_ByteBuilder)
 
   BOOST_AUTO_TEST_CASE(appendAndGet) {
@@ -181,6 +181,17 @@ BOOST_AUTO_TEST_SUITE(Test_ByteBuilder)
     std::string b_str = my_builder.getString();
 
     BOOST_TEST((b_bytes.size() == 104 && b_str.size() == 104));
+  }
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(Test_Time)
+
+  BOOST_AUTO_TEST_CASE(from_now) {
+    auto now = Time::now_int();
+    auto ten_seconds_from_now = Time::from_now(10);
+
+    BOOST_CHECK_EQUAL(now + 10, ten_seconds_from_now);
   }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## 수정이유
- 종전의 코드에서는 Signer가 네트워크에 Join할때 deadline 을 두지 않고, 키교환을 수행한다. 일반적으로 수초 내에 키교환이 완료되어야 정상이다.

## 수정사항
- `Time::from_now` 구현
  * argument 값에 따라 현재 시간으로부터 몇초 후의 값을 리턴한다
- SignerPoolManager
  * `m_join_temporary_table[receiver_id]->expires_at = Time::from_now(10);` 10초 뒤에 끝나지 않으면 expire 하도록 함
  * 만료되면 MSG_ERROR 메시지 송신 및 temporary table entry, SignerPool의 receiver_id에 해당하는 entry를 flush 시킴.