### PR TITLE
# EDIT - Signature 검증 및 sign 로직 변경

### DIFF
--- a/src/services/signer_pool_manager.hpp
+++ b/src/services/signer_pool_manager.hpp
@@ -24,7 +24,7 @@ private:
   bool verifySignature(signer_id_type signer_id,
                        nlohmann::json message_body_json);
   string getCertificate();
-  string signMessage(string, string, string, string, string);
+  string signMessage(string, string, string, string, uint64_t);
   void deliverErrorMessage(vector<uint64_t> &);
   bool isJoinable();
   bool isTimeout(signer_id_type signer_id);

--- a/src/utils/rsa.hpp
+++ b/src/utils/rsa.hpp
@@ -81,7 +81,8 @@ public:
     return verifier.verify_message(data, sig);
   }
 
-  static bool doVerify(std::string &rsa_pk, const std::vector<uint8_t> &data,
+  static bool doVerify(const std::string &rsa_pk,
+                       const std::vector<uint8_t> &data,
                        const std::vector<uint8_t> &sig, bool pkcs1v15 = false) {
     try {
       Botan::DataSource_Memory cert_datasource(rsa_pk);


### PR DESCRIPTION
 ## 수정사항
- 종전의 코드에서는 서명 검증하는 로직이 string concatenate 후에 검증했다. Signer 쪽에서도 그렇게 구현이 되어있었음.
- Bytes 형식으로 처리가 되어야 하므로, Bytes 형식으로 처리하도록 수정
- 서명하는 로직도 마찬가지