### PR TITLE
# EDIT - Transaction id type 변경

### DIFF
--- a/src/chain/types.hpp
+++ b/src/chain/types.hpp
@@ -50,7 +50,9 @@ using bytes = std::vector<uint8_t>;
 using timestamp_type = uint64_t;
 using block_height_type = uint64_t;
 
-using transaction_id_type = bytes;
+constexpr auto TRANSACTION_ID_TYPE_SIZE = 32;
+using transaction_id_type = std::array<uint8_t, TRANSACTION_ID_TYPE_SIZE>;
+
 using requestor_id_type = sha256;
 using merger_id_type = uint64_t;
 using signer_id_type = uint64_t;

--- a/src/services/signature_requester.cpp
+++ b/src/services/signature_requester.cpp
@@ -1,4 +1,3 @@
-#include <algorithm>
 #include <boost/system/error_code.hpp>
 #include <iostream>
 #include <random>
@@ -80,13 +79,8 @@ Transactions SignatureRequester::fetchTransactions() {
 
 PartialBlock SignatureRequester::makePartialBlock(Transactions &transactions) {
   BlockGenerator block_generator;
-  vector<sha256> transaction_ids;
 
-  transaction_ids.reserve(transactions.size());
-  for (auto &transaction : transactions)
-    transaction_ids.emplace_back(transaction.transaction_id);
-
-  m_merkle_tree.generate(transaction_ids);
+  m_merkle_tree.generate(transactions);
   vector<sha256> merkle_tree_vector = m_merkle_tree.getMerkleTree();
   auto &&block =
       block_generator.generatePartialBlock(merkle_tree_vector, transactions);

--- a/src/services/transaction_collector.cpp
+++ b/src/services/transaction_collector.cpp
@@ -1,13 +1,13 @@
-#include <iostream>
-
+#include "transaction_collector.hpp"
 #include "../application.hpp"
 #include "../chain/transaction.hpp"
 #include "../utils/bytes_builder.hpp"
 #include "../utils/rsa.hpp"
 #include "../utils/type_converter.hpp"
-#include "transaction_collector.hpp"
+#include <boost/assert.hpp>
 #include <botan/data_src.h>
 #include <botan/x509_key.h>
+#include <iostream>
 
 using namespace std;
 using namespace nlohmann;
@@ -25,8 +25,11 @@ void TransactionCollector::handleMessage(json message_body_json) {
 
     string txid_str = message_body_json["txid"].get<string>();
     auto txid_bytes = TypeConverter::decodeBase64(txid_str);
-    transaction.transaction_id = txid_bytes;
-    bytes_builder.append(transaction.transaction_id);
+    BOOST_ASSERT_MSG(txid_bytes.size() == 32,
+                     "The size of the transaction is not 32 bytes");
+    transaction.transaction_id =
+        TypeConverter::bytesToArray<TRANSACTION_ID_TYPE_SIZE>(txid_bytes);
+    bytes_builder.append(txid_bytes);
 
     string t_str = message_body_json["time"].get<string>();
     auto sent_time = TypeConverter::digitStringToBytes(t_str);

--- a/src/services/transaction_generator.cpp
+++ b/src/services/transaction_generator.cpp
@@ -26,7 +26,7 @@ void TransactionGenerator::generate(Signer &signer) {
                              new_transaction.sent_time.cend());
 
     // TODO: requestor_id <- Merger Id, 임시로 txID
-    new_transaction.requestor_id = new_transaction.transaction_id;
+    new_transaction.requestor_id = requestor_id_type();
     signature_message.insert(signature_message.cend(),
                              new_transaction.requestor_id.cbegin(),
                              new_transaction.requestor_id.cend());
@@ -61,6 +61,11 @@ transaction_id_type TransactionGenerator::generateTransactionId() {
 
   std::uniform_int_distribution<std::mt19937::result_type> dist;
   auto random_number = dist(mt);
-  return Sha256::hash(to_string(random_number));
+
+  auto bytes = TypeConverter::toBytes(random_number);
+  transaction_id_type tx_id =
+      TypeConverter::bytesToArray<TRANSACTION_ID_TYPE_SIZE>(bytes);
+
+  return tx_id;
 }
 } // namespace gruut

--- a/src/utils/bytes_builder.hpp
+++ b/src/utils/bytes_builder.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <cstring>
 #include <iterator>
@@ -9,6 +10,7 @@
 #include <iostream>
 
 #include "../../include/base64.hpp"
+#include "../../src/utils/type_converter.hpp"
 
 class BytesBuilder {
 private:
@@ -46,6 +48,12 @@ public:
 
       m_filled_len += len;
     }
+  }
+
+  template <size_t S>
+  void append(std::array<uint8_t, S> &bytes_val, int len = -1) {
+    auto vec = TypeConverter::arrayToVector<S>(bytes_val);
+    append(vec);
   }
 
   void append(time_t time_val, size_t len = 8) {

--- a/src/utils/sha256.hpp
+++ b/src/utils/sha256.hpp
@@ -36,6 +36,16 @@ public:
     hash_function->update(data);
     return hash_function->final_stdvec();
   }
+
+  template <size_t S> static sha256 hash(std::array<uint8_t, S> &data) {
+    std::unique_ptr<Botan::HashFunction> hash_function(
+        Botan::HashFunction::create("SHA-256"));
+
+    std::vector<uint8_t> data_vec(data.begin(), data.end());
+
+    hash_function->update(data_vec);
+    return hash_function->final_stdvec();
+  }
 };
 
 #endif

--- a/src/utils/type_converter.hpp
+++ b/src/utils/type_converter.hpp
@@ -1,12 +1,16 @@
 #ifndef GRUUT_ENTERPRISE_MERGER_TYPE_CONVERTER_HPP
 #define GRUUT_ENTERPRISE_MERGER_TYPE_CONVERTER_HPP
 
+#include <algorithm>
+#include <array>
 #include <botan/base64.h>
 #include <botan/secmem.h>
 #include <string>
 #include <vector>
 
 #include "../chain/types.hpp"
+
+using namespace std;
 
 class TypeConverter {
 public:
@@ -19,6 +23,23 @@ public:
       input >>= 8;
     }
     return v;
+  }
+
+  template <size_t S>
+  inline static std::array<uint8_t, S> bytesToArray(std::vector<uint8_t> b) {
+    using Array = std::array<uint8_t, S>;
+
+    Array arr;
+    std::copy(b.begin(), b.end(), arr.begin());
+
+    return arr;
+  }
+
+  template <size_t S>
+  inline static std::vector<uint8_t> arrayToVector(std::array<uint8_t, S> arr) {
+    vector<uint8_t> vec(arr.begin(), arr.end());
+
+    return vec;
   }
 
   inline static std::vector<uint8_t> stringToBytes(std::string &input) {

--- a/tests/chain/test.cpp
+++ b/tests/chain/test.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include "../../src/chain/merkle_tree.hpp"
+#include "../../src/chain/transaction.hpp"
 #include "../../src/utils/type_converter.hpp"
 
 using namespace std;
@@ -13,21 +14,18 @@ using namespace gruut;
 BOOST_AUTO_TEST_SUITE(Test_MerkleTree)
     BOOST_AUTO_TEST_CASE(generate_merkle_tree) {
         MerkleTree t;
-        vector<sha256> transaction_ids;
+        vector<Transaction> transactions;
 
-        const string id = "1";
-        auto transaction_id = Sha256::hash(id);
-
-        transaction_ids.emplace_back(transaction_id);
-        transaction_ids.emplace_back(transaction_id);
-        transaction_ids.emplace_back(transaction_id);
-        transaction_ids.emplace_back(transaction_id);
-        t.generate(transaction_ids);
+        transactions.emplace_back(Transaction());
+        transactions.emplace_back(Transaction());
+        transactions.emplace_back(Transaction());
+        transactions.emplace_back(Transaction());
+        t.generate(transactions);
 
         auto merkle_tree = t.getMerkleTree();
 
         auto parent_digest = merkle_tree.back();
         auto parent_digest_hex = Botan::hex_encode(parent_digest);
-        BOOST_CHECK_EQUAL(parent_digest_hex, "6C195BBC63D4168EFD589E6AEA788CE48F77DFD3F58F652A5E5923731970634A");
+        BOOST_CHECK_EQUAL(parent_digest_hex, "58279BE4DAC761BAA230F81672BA8B69906D426A9312CA1FE0626AC13C35DB79");
     }
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## 수정사항
- transaction_id_type의 타입을 vector -> array로 변경함
- `signature_requester.cpp`
  * `makePartialBlock` 에서 transaction_id가 설계서와 다르게 sha256으로 되어있었음, 설계서에 따르면 Tx id는 256bit이고, tx-digest가 sha256 타입이다.
    * 현재 Merkle tree를 생성할때 tx_digests로 생성해야 하는데 종전의 코드에서는 단순히 transaction_id를 sha256해서 넘겨주었다.
- `transaction_collector.cpp`
  * 타입에 맞게 코드 수정
- `transaction_generator.cpp`
  * `generateTransactionId` 타입에 맞게 코드 수정
- `sha256.hpp`
  * `hash(array)` 추가
    * 앞으로 array를 처리할 곳이 많아서 함수 추가함
- `type_converter.hpp`
  * `bytesToArray` 추가
- `merkle_tree.hpp`
  * tx_digests를 생성해서 MerkleTree#generate 에 넘겨주는 것보다 generate에서 직접 생성하는게 맞다고 판단해서 수정함