### PR TITLE
# EDIT - Merger id type 변경

### DIFF
--- a/src/chain/types.hpp
+++ b/src/chain/types.hpp
@@ -54,7 +54,7 @@ constexpr auto TRANSACTION_ID_TYPE_SIZE = 32;
 using transaction_id_type = std::array<uint8_t, TRANSACTION_ID_TYPE_SIZE>;
 
 using requestor_id_type = sha256;
-using merger_id_type = uint64_t;
+using merger_id_type = bytes;
 using signer_id_type = uint64_t;
 using transaction_root_type = sha256;
 using block_header_hash_type = sha256;

--- a/src/services/block_generator.cpp
+++ b/src/services/block_generator.cpp
@@ -15,7 +15,7 @@ BlockGenerator::generatePartialBlock(vector<sha256> &transactions_digest,
   PartialBlock block;
 
   // TODO: 설정파일이 없어서 하드코딩(1)
-  block.merger_id = 1;
+  block.merger_id = TypeConverter::toBytes(1);
   // TODO: 위와 같은 이유로 임시값 할당
   block.chain_id = 1;
   // TODO: 위와 같은 이유로 임시값 할당

--- a/src/services/message_factory.hpp
+++ b/src/services/message_factory.hpp
@@ -21,9 +21,7 @@ public:
     json j_partial_block;
 
     j_partial_block["time"] = Time::now();
-
-    auto merger_id_str = to_string(block.merger_id);
-    j_partial_block["mID"] = TypeConverter::toBase64Str(merger_id_str);
+    j_partial_block["mID"] = TypeConverter::toBase64Str(block.merger_id);
 
     string block_chain_id_str = to_string(block.chain_id);
     j_partial_block["cID"] = TypeConverter::toBase64Str(block_chain_id_str);

--- a/src/services/signature_pool.cpp
+++ b/src/services/signature_pool.cpp
@@ -57,8 +57,7 @@ bool SignaturePool::verifySignature(signer_id_type receiver_id,
     bytes_builder.append(timestamp_bytes);
 
     PartialBlock &partial_block = Application::app().getTemporaryPartialBlock();
-    string merger_id_str = to_string(partial_block.merger_id);
-    bytes_builder.append(merger_id_str);
+    bytes_builder.append(partial_block.merger_id);
 
     bytes_builder.append(partial_block.height);
 

--- a/src/services/signer_pool_manager.cpp
+++ b/src/services/signer_pool_manager.cpp
@@ -30,7 +30,7 @@ void SignerPoolManager::handleMessage(MessageType &message_type,
   MessageProxy proxy;
   vector<uint64_t> receiver_list{receiver_id};
   // TODO: 설정파일이 없어서 하드코딩(MERGER-1 => base64 => TUVSR0VSLTE)
-  merger_id_type merger_id = 1;
+  merger_id_type merger_id = TypeConverter::toBytes(1);
 
   auto now = std::chrono::duration_cast<std::chrono::seconds>(
                  std::chrono::system_clock::now().time_since_epoch())
@@ -46,7 +46,7 @@ void SignerPoolManager::handleMessage(MessageType &message_type,
           Time::from_now(config::JOIN_TIMEOUT_SEC);
 
       json message_body;
-      message_body["sender"] = merger_id;
+      message_body["sender"] = TypeConverter::toBase64Str(merger_id);
       message_body["time"] = timestamp;
 
       m_join_temporary_table[receiver_id]->merger_nonce =
@@ -75,7 +75,7 @@ void SignerPoolManager::handleMessage(MessageType &message_type,
       m_join_temporary_table[receiver_id]->signer_cert = decoded_cert_str;
 
       json message_body;
-      message_body["sender"] = merger_id;
+      message_body["sender"] = TypeConverter::toBase64Str(merger_id);
       message_body["time"] = timestamp;
       message_body["cert"] = getCertificate();
 
@@ -130,7 +130,7 @@ void SignerPoolManager::handleMessage(MessageType &message_type,
     signer_pool.updateStatus(receiver_id, SignerStatus::GOOD);
 
     json message_body;
-    message_body["sender"] = merger_id;
+    message_body["sender"] = TypeConverter::toBase64Str(merger_id);
     message_body["time"] = timestamp;
     message_body["val"] = true;
 

--- a/src/utils/type_converter.hpp
+++ b/src/utils/type_converter.hpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <botan/base64.h>
 #include <botan/secmem.h>
+#include <numeric>
 #include <string>
 #include <vector>
 
@@ -22,6 +23,8 @@ public:
       v.push_back(input & 0xFF);
       input >>= 8;
     }
+
+    reverse(v.begin(), v.end());
     return v;
   }
 
@@ -65,6 +68,18 @@ public:
     }
 
     return bytes;
+  }
+
+  inline static std::string digitBytesToIntegerStr(vector<uint8_t> &bytes) {
+    auto bit_shift_step = bytes.size() - 1;
+    auto num = std::accumulate(bytes.begin(), bytes.end(), 0,
+                               [&bit_shift_step](size_t sum, int value) {
+                                 sum |= (value << (bit_shift_step * 8));
+                                 --bit_shift_step;
+                                 return sum;
+                               });
+
+    return to_string(num);
   }
 
   template <typename T> inline static std::string toBase64Str(T &t) {

--- a/tests/utils/test.cpp
+++ b/tests/utils/test.cpp
@@ -11,6 +11,7 @@
 #include "../../src/utils/hmac.hpp"
 #include "../../src/utils/hmac_key_maker.hpp"
 #include "../../src/utils/bytes_builder.hpp"
+#include "../../src/utils/type_converter.hpp"
 #include "../../src/utils/time.hpp"
 
 using namespace std;
@@ -192,6 +193,18 @@ BOOST_AUTO_TEST_SUITE(Test_Time)
     auto ten_seconds_from_now = Time::from_now(10);
 
     BOOST_CHECK_EQUAL(now + 10, ten_seconds_from_now);
+  }
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(Test_TypeConverter)
+
+  BOOST_AUTO_TEST_CASE(digitBytesToIntegerStr) {
+    uint64_t original_val = 19999;
+    auto bytes = TypeConverter::toBytes(19999);
+    auto value = TypeConverter::digitBytesToIntegerStr(bytes);
+
+    BOOST_CHECK_EQUAL(to_string(original_val), value);
   }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## 수정사항
- Merger id type을 uint64_t 에서 vector<uint8_t>으로 변경함
  * 이전에는 고정 64bit였는데, Merger id가 64bit로 표현가능한 숫자 범위를 넘어갈때를 대비해서 vector로 변경
  * Merger id를 bytes로 변환할때 `TypeConverter::toBytes`를 통해 little endian 형식의 bytes vector를 생성했다. BytesBuilder에서는 Big endian 형식으로 바이트 vector를 만들기 때문에 통일성을 위해 big endian 형식으로 변경함
  * `TypeConverter::toBytes`로 변환된 바이트를 정수값으로 변환시키기 위해서 `digitBytesToIntegerStr`를 추가