### PR TITLE
# EDIT - toBytes -> integerToBytes 로 함수명 변경

### DIFF
--- a/src/services/block_generator.cpp
+++ b/src/services/block_generator.cpp
@@ -15,7 +15,7 @@ BlockGenerator::generatePartialBlock(vector<sha256> &transactions_digest,
   PartialBlock block;
 
   // TODO: 설정파일이 없어서 하드코딩(1)
-  block.merger_id = TypeConverter::toBytes(1);
+  block.merger_id = TypeConverter::integerToBytes(1);
   // TODO: 위와 같은 이유로 임시값 할당
   block.chain_id = 1;
   // TODO: 위와 같은 이유로 임시값 할당

--- a/src/services/signer_pool_manager.cpp
+++ b/src/services/signer_pool_manager.cpp
@@ -30,7 +30,7 @@ void SignerPoolManager::handleMessage(MessageType &message_type,
   MessageProxy proxy;
   vector<uint64_t> receiver_list{receiver_id};
   // TODO: 설정파일이 없어서 하드코딩(MERGER-1 => base64 => TUVSR0VSLTE)
-  merger_id_type merger_id = TypeConverter::toBytes(1);
+  merger_id_type merger_id = TypeConverter::integerToBytes(1);
 
   auto now = std::chrono::duration_cast<std::chrono::seconds>(
                  std::chrono::system_clock::now().time_since_epoch())

--- a/src/services/transaction_generator.cpp
+++ b/src/services/transaction_generator.cpp
@@ -62,7 +62,7 @@ transaction_id_type TransactionGenerator::generateTransactionId() {
   std::uniform_int_distribution<std::mt19937::result_type> dist;
   auto random_number = dist(mt);
 
-  auto bytes = TypeConverter::toBytes(random_number);
+  auto bytes = TypeConverter::integerToBytes(random_number);
   transaction_id_type tx_id =
       TypeConverter::bytesToArray<TRANSACTION_ID_TYPE_SIZE>(bytes);
 

--- a/src/utils/type_converter.hpp
+++ b/src/utils/type_converter.hpp
@@ -15,7 +15,8 @@ using namespace std;
 
 class TypeConverter {
 public:
-  template <class T> inline static std::vector<uint8_t> toBytes(T input) {
+  template <class T>
+  inline static std::vector<uint8_t> integerToBytes(T input) {
     std::vector<uint8_t> v;
     v.reserve(sizeof(input));
 

--- a/tests/utils/test.cpp
+++ b/tests/utils/test.cpp
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_SUITE(Test_TypeConverter)
 
   BOOST_AUTO_TEST_CASE(digitBytesToIntegerStr) {
     uint64_t original_val = 19999;
-    auto bytes = TypeConverter::toBytes(19999);
+    auto bytes = TypeConverter::integerToBytes(19999);
     auto value = TypeConverter::digitBytesToIntegerStr(bytes);
 
     BOOST_CHECK_EQUAL(to_string(original_val), value);


### PR DESCRIPTION
## 수정사항
- toBytes는 어떤 타입과 관계없이 바이트로 만들 것 같은 오해가 생긴다.
- integer -> bytes로 변경할때 사용되고 있으므로, integerToBytes로 함수명 변경함