### PR TITLE
# EDIT - local_chain_id_type 1바이트를 8바이트로 수정

### DIFF
--- a/src/chain/block.hpp
+++ b/src/chain/block.hpp
@@ -13,7 +13,7 @@ using namespace std;
 namespace gruut {
 struct PartialBlock {
   merger_id_type merger_id;
-  chain_id_type chain_id;
+  local_chain_id_type chain_id;
   block_height_type height;
   transaction_root_type transaction_root;
 

--- a/src/chain/message.hpp
+++ b/src/chain/message.hpp
@@ -16,7 +16,7 @@ struct MessageHeader {
   CompressionAlgorithmType compression_algo_type;
   uint8_t dummy;
   uint8_t total_length[4];
-  local_chain_id_type local_chain_id[8];
+  local_chain_id_type local_chain_id;
   uint8_t sender_id[8];
   uint8_t reserved_space[6];
 };

--- a/src/chain/types.hpp
+++ b/src/chain/types.hpp
@@ -53,13 +53,15 @@ using block_height_type = uint64_t;
 constexpr auto TRANSACTION_ID_TYPE_SIZE = 32;
 using transaction_id_type = std::array<uint8_t, TRANSACTION_ID_TYPE_SIZE>;
 
+constexpr auto CHAIN_ID_TYPE_SIZE = 8;
+using local_chain_id_type = std::array<uint8_t, CHAIN_ID_TYPE_SIZE>;
+
 using requestor_id_type = sha256;
 using merger_id_type = bytes;
 using signer_id_type = uint64_t;
 using transaction_root_type = sha256;
 using block_header_hash_type = sha256;
 using block_id_type = sha256;
-using chain_id_type = uint64_t;
 using signature_type = bytes;
 using version_type = uint32_t;
 using header_length_type = uint32_t;
@@ -67,8 +69,5 @@ using header_length_type = uint32_t;
 using content_type = std::string;
 
 using hmac_key_type = Botan::secure_vector<uint8_t>;
-
-// Message
-using local_chain_id_type = uint8_t;
 } // namespace gruut
 #endif

--- a/src/services/block_generator.cpp
+++ b/src/services/block_generator.cpp
@@ -1,6 +1,7 @@
 #include "block_generator.hpp"
 #include "../chain/merkle_tree.hpp"
 #include "../chain/signature.hpp"
+#include "../chain/types.hpp"
 #include "../utils/bytes_builder.hpp"
 #include "../utils/rsa.hpp"
 #include "../utils/time.hpp"
@@ -17,7 +18,7 @@ BlockGenerator::generatePartialBlock(vector<sha256> &transactions_digest,
   // TODO: 설정파일이 없어서 하드코딩(1)
   block.merger_id = TypeConverter::integerToBytes(1);
   // TODO: 위와 같은 이유로 임시값 할당
-  block.chain_id = 1;
+  block.chain_id = TypeConverter::integerToArray<CHAIN_ID_TYPE_SIZE>(1);
   // TODO: 위와 같은 이유로 임시값 할당
   block.height = 1;
   block.transaction_root = transactions_digest.back();

--- a/src/services/message_factory.hpp
+++ b/src/services/message_factory.hpp
@@ -22,9 +22,7 @@ public:
 
     j_partial_block["time"] = Time::now();
     j_partial_block["mID"] = TypeConverter::toBase64Str(block.merger_id);
-
-    string block_chain_id_str = to_string(block.chain_id);
-    j_partial_block["cID"] = TypeConverter::toBase64Str(block_chain_id_str);
+    j_partial_block["cID"] = TypeConverter::toBase64Str(block.chain_id);
     j_partial_block["txrt"] =
         TypeConverter::toBase64Str(block.transaction_root);
     j_partial_block["hgt"] = block.height;

--- a/src/utils/type_converter.hpp
+++ b/src/utils/type_converter.hpp
@@ -29,6 +29,16 @@ public:
     return v;
   }
 
+  template <size_t S, typename T = uint8_t>
+  inline static std::array<uint8_t, S> integerToArray(T input) {
+    using Array = std::array<uint8_t, S>;
+
+    auto bytes = integerToBytes(input);
+    Array arr = bytesToArray<S>(bytes);
+
+    return arr;
+  }
+
   template <size_t S>
   inline static std::array<uint8_t, S> bytesToArray(std::vector<uint8_t> b) {
     using Array = std::array<uint8_t, S>;
@@ -84,7 +94,7 @@ public:
   }
 
   template <typename T> inline static std::string toBase64Str(T &t) {
-    return Botan::base64_encode(vector<uint8_t>(t.begin(), t.end()));
+    return Botan::base64_encode(vector<uint8_t>(begin(t), end(t)));
   }
 
   template <typename T>

--- a/tests/modules/test.cpp
+++ b/tests/modules/test.cpp
@@ -106,7 +106,10 @@ BOOST_AUTO_TEST_SUITE(Test_HeaderController)
                    static_cast<uint8_t>(compare_hdr.compression_algo_type));
         BOOST_TEST(origin_hdr.dummy == compare_hdr.dummy);
         BOOST_TEST(memcmp(origin_hdr.total_length, compare_hdr.total_length, 4) == 0);
-        BOOST_TEST(memcmp(origin_hdr.local_chain_id, compare_hdr.local_chain_id, 8) == 0);
+
+        bool is_equal_local_chain_id = origin_hdr.local_chain_id == compare_hdr.local_chain_id;
+        BOOST_TEST(is_equal_local_chain_id);
+
         BOOST_TEST(memcmp(origin_hdr.sender_id, compare_hdr.sender_id, 8) == 0);
         BOOST_TEST(memcmp(origin_hdr.reserved_space, compare_hdr.reserved_space, 6) == 0);
     }


### PR DESCRIPTION
## 수정사항
- 설계서에서 8바이트이므로 `using local_chain_id_type = std::array<uint8_t, S>` 로 변경
- integer -> array로 변환하는 유틸 함수 추가(`integerToArray`)
- array로 변경됨에 따라 관련 코드 수정