### PR TITLE
# FIX - stroage.hpp쪽 Ambiguous Error build 에러

### DIFF
--- a/src/services/storage.cpp
+++ b/src/services/storage.cpp
@@ -330,7 +330,7 @@ vector<string> Storage::findLatestTxIdList() {
       json tx_ids_json = json::parse(tx_ids);
       for (size_t tx_ids_idx = 0; tx_ids_idx < tx_ids_json.size();
            ++tx_ids_idx) {
-        tx_ids_list.emplace_back(tx_ids_json[tx_ids_idx]);
+        tx_ids_list.emplace_back(tx_ids_json[tx_ids_idx].get<string>());
       }
     }
   }


### PR DESCRIPTION
## 원인
- `tx_ids_json[tx_ids_idx]`가 `nlohmann::basic_json<basic_string, long long, unsigned long long double>` 타입이므로 빌드시 오류 생김

## 수정사항
- Ambiguous 하다는 오류가 발생하는 것을 막기 위해서 확실한 type_casting을 함