### PR TITLE
 # ADD - faster block generation when gathering max ssigs

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -42,7 +42,7 @@ json parseArg(int argc, char *argv[]){
     string setting_json_str = FileIo::file2str(result["in"].as<string>());
 
     if(setting_json_str.empty()) {
-      cout << "error opening setting files" << endl;
+      cout << "error opening setting files " << result["in"].as<string>() << endl;
       exit(1);
     }
 

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -1,5 +1,6 @@
 #include "application.hpp"
 #include "chain/transaction.hpp"
+#include "config/config.hpp"
 #include "modules/module.hpp"
 
 namespace gruut {
@@ -37,7 +38,7 @@ void Application::start(const vector<shared_ptr<Module>> &modules) {
 }
 
 void Application::exec() {
-  for (auto i = 0; i < 4; i++) {
+  for (auto i = 0; i < config::MAX_THREAD; i++) {
     m_thread_group->emplace_back([this]() { m_io_serv->run(); });
   }
 

--- a/src/chain/signer.hpp
+++ b/src/chain/signer.hpp
@@ -17,7 +17,7 @@ struct Signer {
 
   bool isNew() {
     auto cert = Storage::getInstance()->findCertificate(user_id);
-    return cert.empty();
+    return (cert.empty() || cert != pk_cert);
   }
 };
 } // namespace gruut

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -24,11 +24,11 @@ constexpr size_t JOIN_TIMEOUT_SEC = 10;
 constexpr size_t MAX_SIGNER_NUM = 200;
 constexpr size_t REQ_SSIG_SIGNERS_NUM = 10;
 
-constexpr size_t INQUEUE_MSG_FETCHER_INTVAL = 100;
-constexpr size_t OUTQUEUE_MSG_FETCHER_INTVAL = 100;
+constexpr size_t INQUEUE_MSG_FETCHER_INTERVAL = 100;
+constexpr size_t OUTQUEUE_MSG_FETCHER_INTERVAL = 100;
 
 constexpr size_t SIGNATURE_COLLECTION_INTERVAL = 3000;
-constexpr size_t SIGNATURE_COLLECTION_CHECK_INTVAL = 500;
+constexpr size_t SIGNATURE_COLLECTION_CHECK_INTERVAL = 500;
 
 const std::string PORT_NUM = "50051";
 } // namespace config

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -3,8 +3,12 @@
 
 #include "../chain/types.hpp"
 
+#include <string>
+
 namespace gruut {
 namespace config {
+
+constexpr size_t MAX_THREAD = 10;
 constexpr CompressionAlgorithmType COMPRESSION_ALGO_TYPE =
     CompressionAlgorithmType::LZ4;
 
@@ -12,13 +16,19 @@ constexpr size_t MAX_MERKLE_LEAVES = 4096;
 
 constexpr size_t MAX_COLLECT_TRANSACTION_SIZE = 4096;
 
-constexpr size_t MIN_SIGNATURE_COLLECT_SIZE =
-    1; // TODO: 테스트를 위해 임시로 1개로 설정
-constexpr size_t MAX_SIGNATURE_COLLECT_SIZE = 4096;
+constexpr size_t MIN_SIGNATURE_COLLECT_SIZE = 1;
+constexpr size_t MAX_SIGNATURE_COLLECT_SIZE = 20;
 
-constexpr uint64_t JOIN_TIMEOUT_SEC = 10;
+constexpr size_t JOIN_TIMEOUT_SEC = 10;
 
+constexpr size_t MAX_SIGNER_NUM = 200;
 constexpr size_t REQ_SSIG_SIGNERS_NUM = 10;
+
+constexpr size_t INQUEUE_MSG_FETCHER_INTVAL = 100;
+constexpr size_t OUTQUEUE_MSG_FETCHER_INTVAL = 100;
+
+constexpr size_t SIGNATURE_COLLECTION_INTERVAL = 3000;
+constexpr size_t SIGNATURE_COLLECTION_CHECK_INTVAL = 500;
 
 const std::string PORT_NUM = "50051";
 } // namespace config

--- a/src/modules/message_fetcher/message_fetcher.cpp
+++ b/src/modules/message_fetcher/message_fetcher.cpp
@@ -4,6 +4,7 @@
 
 #include "../../application.hpp"
 #include "../../chain/types.hpp"
+#include "../../config/config.hpp"
 #include "../../services/message_proxy.hpp"
 #include "message_fetcher.hpp"
 
@@ -28,8 +29,8 @@ void MessageFetcher::fetch() {
     }
   });
 
-  // TODO: 임시로 1000(1초)
-  m_timer->expires_from_now(boost::posix_time::milliseconds(1000));
+  m_timer->expires_from_now(
+      boost::posix_time::milliseconds(config::INQUEUE_MSG_FETCHER_INTVAL));
   m_timer->async_wait([this](const boost::system::error_code &ec) {
     if (ec == boost::asio::error::operation_aborted) {
       std::cout << "MessageFetcher: Timer was cancelled or retriggered."

--- a/src/modules/message_fetcher/message_fetcher.cpp
+++ b/src/modules/message_fetcher/message_fetcher.cpp
@@ -30,7 +30,7 @@ void MessageFetcher::fetch() {
   });
 
   m_timer->expires_from_now(
-      boost::posix_time::milliseconds(config::INQUEUE_MSG_FETCHER_INTVAL));
+      boost::posix_time::milliseconds(config::INQUEUE_MSG_FETCHER_INTERVAL));
   m_timer->async_wait([this](const boost::system::error_code &ec) {
     if (ec == boost::asio::error::operation_aborted) {
       std::cout << "MessageFetcher: Timer was cancelled or retriggered."

--- a/src/modules/message_fetcher/out_message_fetcher.cpp
+++ b/src/modules/message_fetcher/out_message_fetcher.cpp
@@ -30,7 +30,7 @@ void OutMessageFetcher::fetch() {
   });
 
   m_timer->expires_from_now(
-      boost::posix_time::milliseconds(config::OUTQUEUE_MSG_FETCHER_INTVAL));
+      boost::posix_time::milliseconds(config::OUTQUEUE_MSG_FETCHER_INTERVAL));
   m_timer->async_wait([this](const boost::system::error_code &ec) {
     if (ec == boost::asio::error::operation_aborted) {
       std::cout << "Out MessageFetcher: Timer was cancelled or retriggered."

--- a/src/modules/message_fetcher/out_message_fetcher.cpp
+++ b/src/modules/message_fetcher/out_message_fetcher.cpp
@@ -1,6 +1,7 @@
 #include "out_message_fetcher.hpp"
 #include "../../application.hpp"
 #include "../../chain/types.hpp"
+#include "../../config/config.hpp"
 #include "../communication/message_handler.hpp"
 #include <chrono>
 #include <iostream>
@@ -28,7 +29,8 @@ void OutMessageFetcher::fetch() {
     }
   });
 
-  m_timer->expires_from_now(boost::posix_time::milliseconds(1000));
+  m_timer->expires_from_now(
+      boost::posix_time::milliseconds(config::OUTQUEUE_MSG_FETCHER_INTVAL));
   m_timer->async_wait([this](const boost::system::error_code &ec) {
     if (ec == boost::asio::error::operation_aborted) {
       std::cout << "Out MessageFetcher: Timer was cancelled or retriggered."

--- a/src/services/output_queue.hpp
+++ b/src/services/output_queue.hpp
@@ -13,11 +13,11 @@ namespace gruut {
 struct OutputMsgEntry {
   MessageType type;
   nlohmann::json body;
-  std::vector<std::string> receivers;
+  std::vector<id_type> receivers;
   OutputMsgEntry()
       : type(MessageType::MSG_NULL), body(nullptr), receivers({}) {}
   OutputMsgEntry(MessageType msg_type_, nlohmann::json &msg_body_,
-                 std::vector<std::string> &msg_receivers_)
+                 std::vector<id_type> &msg_receivers_)
       : type(msg_type_), body(msg_body_), receivers(msg_receivers_) {}
 };
 
@@ -27,7 +27,7 @@ private:
   std::mutex m_queue_mutex;
 
 public:
-  void push(std::tuple<MessageType, nlohmann::json, std::vector<std::string>>
+  void push(std::tuple<MessageType, nlohmann::json, std::vector<id_type>>
                 &msg_entry_tuple) {
     OutputMsgEntry tmp_msg_entry(std::get<0>(msg_entry_tuple),
                                  std::get<1>(msg_entry_tuple),
@@ -37,13 +37,13 @@ public:
   }
 
   void push(MessageType msg_type, nlohmann::json &msg_body) {
-    std::vector<std::string> msg_receivers;
+    std::vector<id_type> msg_receivers;
     OutputMsgEntry tmp_msg_entry(msg_type, msg_body, msg_receivers);
     push(tmp_msg_entry);
   }
 
   void push(MessageType msg_type, nlohmann::json &msg_body,
-            std::vector<std::string> &msg_receivers) {
+            std::vector<id_type> &msg_receivers) {
     OutputMsgEntry tmp_msg_entry(msg_type, msg_body, msg_receivers);
     push(tmp_msg_entry);
   }

--- a/src/services/signature_pool.cpp
+++ b/src/services/signature_pool.cpp
@@ -58,8 +58,8 @@ bool SignaturePool::verifySignature(signer_id_type &receiver_id,
   signer_id_type signer_id = TypeConverter::decodeBase64(signer_id_b64);
   bytes_builder.append(signer_id);
 
-  auto timestamp =
-      (timestamp_type)stoll(message_body_json["time"].get<string>());
+  auto timestamp = static_cast<timestamp_type>(
+      stoll(message_body_json["time"].get<string>()));
   bytes_builder.append(timestamp);
 
   PartialBlock &partial_block = Application::app().getTemporaryPartialBlock();

--- a/src/services/signature_pool.hpp
+++ b/src/services/signature_pool.hpp
@@ -24,6 +24,11 @@ public:
 
   Signatures fetchN(size_t n);
 
+  inline void clear() {
+    std::lock_guard<std::mutex> guard(m_mutex);
+    m_signature_pool.clear();
+  }
+
 private:
   bool verifySignature(signer_id_type &, json &);
 

--- a/src/services/signature_requester.cpp
+++ b/src/services/signature_requester.cpp
@@ -30,9 +30,9 @@ void SignatureRequester::checkProcess() {
 
   m_check_timer.reset(
       new boost::asio::deadline_timer(Application::app().getIoService()));
-  m_timer->expires_from_now(boost::posix_time::milliseconds(
-      config::SIGNATURE_COLLECTION_CHECK_INTVAL));
-  m_timer->async_wait([&](const boost::system::error_code &ec) {
+  m_check_timer->expires_from_now(boost::posix_time::milliseconds(
+      config::SIGNATURE_COLLECTION_CHECK_INTERVAL));
+  m_check_timer->async_wait([&](const boost::system::error_code &ec) {
     if (ec == boost::asio::error::operation_aborted) {
       std::cout << "startSignatureCollectTimer: CheckTimer was cancelled or "
                    "retriggered."
@@ -82,6 +82,8 @@ void SignatureRequester::timerStopAndCreateBlock() {
     BlockGenerator generator;
     generator.generateBlock(temp_partial_block, signatures, m_merkle_tree);
   }
+
+  signature_pool.clear();
 }
 
 void SignatureRequester::startSignatureCollectTimer() {

--- a/src/services/signature_requester.cpp
+++ b/src/services/signature_requester.cpp
@@ -15,8 +15,40 @@
 using namespace gruut::config;
 
 namespace gruut {
+
+void SignatureRequester::checkProcess() {
+  if (!m_is_timer_running)
+    return;
+
+  auto &io_service = Application::app().getIoService();
+  io_service.post([this]() {
+    auto &signature_pool = Application::app().getSignaturePool();
+    if (signature_pool.size() >= m_max_signers) {
+      timerStopAndCreateBlock();
+    }
+  });
+
+  m_check_timer.reset(
+      new boost::asio::deadline_timer(Application::app().getIoService()));
+  m_timer->expires_from_now(boost::posix_time::milliseconds(
+      config::SIGNATURE_COLLECTION_CHECK_INTVAL));
+  m_timer->async_wait([&](const boost::system::error_code &ec) {
+    if (ec == boost::asio::error::operation_aborted) {
+      std::cout << "startSignatureCollectTimer: CheckTimer was cancelled or "
+                   "retriggered."
+                << std::endl;
+    } else if (ec.value() == 0) {
+      checkProcess();
+    } else {
+      std::cout << "ERROR: " << ec.message() << std::endl;
+      throw;
+    }
+  });
+}
 void SignatureRequester::requestSignatures() {
   auto signers = selectSigners();
+
+  m_max_signers = signers.size();
 
   auto transactions = std::move(fetchTransactions());
 
@@ -24,36 +56,49 @@ void SignatureRequester::requestSignatures() {
   Application::app().getTemporaryPartialBlock() = partial_block;
 
   requestSignature(partial_block, signers);
-  startSignatureCollectTimer(transactions);
+  startSignatureCollectTimer();
+  checkProcess();
 }
 
-void SignatureRequester::startSignatureCollectTimer(
-    Transactions &transactions) {
+void SignatureRequester::timerStopAndCreateBlock() {
+
+  m_is_timer_running = false;
+
+  m_timer->cancel();
+  m_check_timer->cancel();
+
+  auto &signature_pool = Application::app().getSignaturePool();
+  if (signature_pool.size() >= config::MIN_SIGNATURE_COLLECT_SIZE &&
+      signature_pool.size() <= config::MAX_SIGNATURE_COLLECT_SIZE) {
+    cout << "SIG POOL SIZE: " << signature_pool.size() << endl;
+    std::cout << "CREATE BLOCK!" << std::endl;
+
+    auto temp_partial_block = Application::app().getTemporaryPartialBlock();
+
+    auto signatures_size =
+        min(signature_pool.size(), config::MAX_SIGNATURE_COLLECT_SIZE);
+    auto signatures = signature_pool.fetchN(signatures_size);
+
+    BlockGenerator generator;
+    generator.generateBlock(temp_partial_block, signatures, m_merkle_tree);
+  }
+}
+
+void SignatureRequester::startSignatureCollectTimer() {
+  m_is_timer_running = true;
+
   m_timer.reset(
       new boost::asio::deadline_timer(Application::app().getIoService()));
   m_timer->expires_from_now(
-      boost::posix_time::milliseconds(SIGNATURE_COLLECTION_INTERVAL));
+      boost::posix_time::milliseconds(config::SIGNATURE_COLLECTION_INTERVAL));
   m_timer->async_wait([&](const boost::system::error_code &ec) {
     if (ec == boost::asio::error::operation_aborted) {
       std::cout
           << "startSignatureCollectTimer: Timer was cancelled or retriggered."
           << std::endl;
     } else if (ec.value() == 0) {
-      auto &signature_pool = Application::app().getSignaturePool();
-      if (signature_pool.size() >= MIN_SIGNATURE_COLLECT_SIZE &&
-          signature_pool.size() <= MAX_SIGNATURE_COLLECT_SIZE) {
-        cout << "SIG POOL SIZE: " << signature_pool.size() << endl;
-        std::cout << "CREATE BLOCK!" << std::endl;
-
-        auto temp_partial_block = Application::app().getTemporaryPartialBlock();
-
-        auto signatures_size =
-            min(signature_pool.size(), MAX_SIGNATURE_COLLECT_SIZE);
-        auto signatures = signature_pool.fetchN(signatures_size);
-
-        BlockGenerator generator;
-        generator.generateBlock(temp_partial_block, signatures, m_merkle_tree);
-      }
+      if (m_is_timer_running)
+        timerStopAndCreateBlock();
     } else {
       std::cout << "ERROR: " << ec.message() << std::endl;
       throw;
@@ -65,7 +110,8 @@ Transactions SignatureRequester::fetchTransactions() {
   auto &transaction_pool = Application::app().getTransactionPool();
 
   const size_t transactions_size = transaction_pool.size();
-  auto t_size = std::min(transactions_size, MAX_COLLECT_TRANSACTION_SIZE);
+  auto t_size =
+      std::min(transactions_size, config::MAX_COLLECT_TRANSACTION_SIZE);
 
   Transactions transactions_list;
   for (unsigned int i = 0; i < t_size; i++) {
@@ -89,7 +135,7 @@ PartialBlock SignatureRequester::makePartialBlock(Transactions &transactions) {
 
 void SignatureRequester::requestSignature(PartialBlock &block,
                                           Signers &signers) {
-  if (signers.size() > 0) {
+  if (!signers.empty()) {
     auto message = MessageFactory::createSigRequestMessage(block, signers);
     MessageProxy proxy;
     proxy.deliverOutputMessage(message);

--- a/src/services/signature_requester.hpp
+++ b/src/services/signature_requester.hpp
@@ -12,10 +12,10 @@
 #include "../chain/message.hpp"
 #include "../chain/signer.hpp"
 
+#include "../config/config.hpp"
+
 namespace gruut {
 class Transaction;
-
-const int SIGNATURE_COLLECTION_INTERVAL = 10000;
 
 using RandomSignerIndices = std::set<int>;
 using Transactions = std::vector<Transaction>;
@@ -27,8 +27,12 @@ public:
 
   void requestSignatures();
 
+  void checkProcess();
+
 private:
-  void startSignatureCollectTimer(Transactions &transactions);
+  void startSignatureCollectTimer();
+
+  void timerStopAndCreateBlock();
 
   Transactions fetchTransactions();
 
@@ -39,7 +43,11 @@ private:
   Signers selectSigners();
 
   std::unique_ptr<boost::asio::deadline_timer> m_timer;
+  std::unique_ptr<boost::asio::deadline_timer> m_check_timer;
   MerkleTree m_merkle_tree;
+
+  bool m_is_timer_running{false};
+  size_t m_max_signers;
 };
 } // namespace gruut
 #endif

--- a/src/services/signer_pool.cpp
+++ b/src/services/signer_pool.cpp
@@ -153,10 +153,14 @@ Signer SignerPool::getSigner(int index) {
 void SignerPool::createTransactions() {
   TransactionGenerator generator;
 
+  vector<Signer> signers;
   for (auto &signer : m_signer_pool) {
     if (signer.status == SignerStatus::GOOD && signer.isNew()) {
-      generator.generate(signer);
+      signers.emplace_back(signer);
     }
   }
+
+  if (!signers.empty())
+    generator.generate(signers);
 }
 } // namespace gruut

--- a/src/services/signer_pool_manager.cpp
+++ b/src/services/signer_pool_manager.cpp
@@ -205,7 +205,7 @@ string SignerPoolManager::signMessage(string merger_nonce, string signer_nonce,
 }
 
 bool SignerPoolManager::isJoinable() {
-  return (config::MAX_SIGNER_NUM < Application::app().getSignerPool().size());
+  return (config::MAX_SIGNER_NUM > Application::app().getSignerPool().size());
 }
 
 bool SignerPoolManager::isTimeout(string &signer_id_b64) {

--- a/src/services/transaction_collector.cpp
+++ b/src/services/transaction_collector.cpp
@@ -33,7 +33,7 @@ void TransactionCollector::handleMessage(json message_body_json) {
     bytes_builder.append(txid_bytes);
 
     string t_str = message_body_json["time"].get<string>();
-    auto sent_time = (timestamp_type)stoll(t_str);
+    auto sent_time = static_cast<timestamp_type>(stoll(t_str));
     transaction.sent_time = sent_time;
     bytes_builder.append(sent_time);
 
@@ -78,6 +78,9 @@ void TransactionCollector::handleMessage(json message_body_json) {
         endpoint_cert = item.cert;
       }
     }
+
+    if (endpoint_cert.empty())
+      return;
 
     auto signature_message_bytes = bytes_builder.getBytes();
     bool is_verified = RSA::doVerify(endpoint_cert, signature_message_bytes,

--- a/src/services/transaction_collector.cpp
+++ b/src/services/transaction_collector.cpp
@@ -33,7 +33,7 @@ void TransactionCollector::handleMessage(json message_body_json) {
     bytes_builder.append(txid_bytes);
 
     string t_str = message_body_json["time"].get<string>();
-    timestamp_type sent_time = (timestamp_type)stoll(t_str);
+    auto sent_time = (timestamp_type)stoll(t_str);
     transaction.sent_time = sent_time;
     bytes_builder.append(sent_time);
 

--- a/src/services/transaction_generator.cpp
+++ b/src/services/transaction_generator.cpp
@@ -9,39 +9,47 @@
 #include <random>
 
 namespace gruut {
-void TransactionGenerator::generate(Signer &signer) {
-  if (signer.isNew()) {
-    Transaction new_transaction;
-    bytes signature_message;
-    BytesBuilder msg_builder;
-
-    Setting *setting = Setting::getInstance();
-    string rsa_sk_pem = setting->getMySK();
-    string rsa_sk_pass = setting->getMyPass();
-
-    new_transaction.transaction_id = generateTransactionId();
-
-    timestamp_type timestamp = (timestamp_type)Time::now_int();
-    new_transaction.sent_time = timestamp;
-    new_transaction.requestor_id = setting->getMyId();
-    new_transaction.transaction_type = TransactionType::CERTIFICATE;
-
-    auto user_id_str = TypeConverter::toBase64Str(signer.user_id);
-    new_transaction.content_list.emplace_back(user_id_str);
-    new_transaction.content_list.emplace_back(signer.pk_cert);
-
-    msg_builder.append(new_transaction.transaction_id);
-    msg_builder.append(timestamp);
-    msg_builder.append(new_transaction.requestor_id);
-    msg_builder.append(TXTYPE_CERTIFICATES);
-    msg_builder.append(user_id_str);
-    msg_builder.append(signer.pk_cert);
-
-    new_transaction.signature =
-        RSA::doSign(rsa_sk_pem, msg_builder.getBytes(), true, rsa_sk_pass);
-
-    Application::app().getTransactionPool().push(new_transaction);
+void TransactionGenerator::generate(vector<Signer> &signers) {
+  if (signers.empty()) {
+    return;
   }
+
+  Transaction new_transaction;
+  bytes signature_message;
+  BytesBuilder msg_builder;
+
+  Setting *setting = Setting::getInstance();
+  string rsa_sk_pem = setting->getMySK();
+  string rsa_sk_pass = setting->getMyPass();
+
+  new_transaction.transaction_id = generateTransactionId();
+
+  auto timestamp = (timestamp_type)Time::now_int();
+  new_transaction.sent_time = timestamp;
+  new_transaction.requestor_id = setting->getMyId();
+  new_transaction.transaction_type = TransactionType::CERTIFICATE;
+
+  msg_builder.append(new_transaction.transaction_id);
+  msg_builder.append(timestamp);
+  msg_builder.append(new_transaction.requestor_id);
+  msg_builder.append(TXTYPE_CERTIFICATES);
+
+  for (auto &signer : signers) {
+    if (signer.isNew()) {
+
+      auto user_id_str = TypeConverter::toBase64Str(signer.user_id);
+      new_transaction.content_list.emplace_back(user_id_str);
+      new_transaction.content_list.emplace_back(signer.pk_cert);
+
+      msg_builder.append(user_id_str);
+      msg_builder.append(signer.pk_cert);
+    }
+  }
+
+  new_transaction.signature =
+      RSA::doSign(rsa_sk_pem, msg_builder.getBytes(), true, rsa_sk_pass);
+
+  Application::app().getTransactionPool().push(new_transaction);
 }
 
 transaction_id_type TransactionGenerator::generateTransactionId() {

--- a/src/services/transaction_generator.cpp
+++ b/src/services/transaction_generator.cpp
@@ -24,8 +24,8 @@ void TransactionGenerator::generate(vector<Signer> &signers) {
 
   new_transaction.transaction_id = generateTransactionId();
 
-  auto timestamp = (timestamp_type)Time::now_int();
-  new_transaction.sent_time = timestamp;
+  auto timestamp = Time::now_int();
+  new_transaction.sent_time = static_cast<timestamp_type>(timestamp);
   new_transaction.requestor_id = setting->getMyId();
   new_transaction.transaction_type = TransactionType::CERTIFICATE;
 

--- a/src/services/transaction_generator.hpp
+++ b/src/services/transaction_generator.hpp
@@ -6,7 +6,7 @@
 namespace gruut {
 class TransactionGenerator {
 public:
-  void generate(Signer &signer);
+  void generate(vector<Signer> &signers);
 
 private:
   transaction_id_type generateTransactionId();

--- a/tests/services/test.cpp
+++ b/tests/services/test.cpp
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_SUITE(Test_MessageIOQueues)
 
   BOOST_AUTO_TEST_CASE(pushMessages) {
     nlohmann::json msg_body = "{}"_json;
-    std::vector<std::string> msg_receiver = {};
+    std::vector<id_type> msg_receiver = {};
 
     InputQueueAlt * input_queue = InputQueueAlt::getInstance();
     InputMsgEntry test_input_msg(MessageType::MSG_ACCEPT, msg_body);


### PR DESCRIPTION
### 추가 및 변경
- 현재는 지지 서명이 모두 모이더라도 timer가 만료되어야 블록을 생성하도록 되어 있음. 만료되기 전에라도 블록을 생성하도록 수정.
- 서명자의 인증서가 새로운 것인지 아닌지 검사하는 부분 수정 (설령 DB에 있어도 인증서가 새로운 것이면 TX을 생성해야함)
- 새로운 인증서에 대한 TX를 1개만 만들도록 수정
- config에 상수 추가 및 적용
- OutputQueueAlt의 id_type 적용
- 그외 사소한 내용