### PR TITLE
# ADD - Merger가 SE로 MSG_HEADER를 보낼 수 있도록 구현

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ compiler:
 - clang
 cache: ccache
 before_install:
-  - docker pull doscode/merger-build-env:1.1
-  - docker run -d --name build-env --rm -i -t doscode/merger-build-env:1.1 bash
+  - docker pull doscode/merger-build-env:latest
+  - docker run -d --name build-env --rm -i -t doscode/merger-build-env:latest bash
 install:
 script:
   - docker exec build-env sh -c "

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ add_definitions(-DBOOST_LOG_DYN_LINK)
 
 include(cmake/clang-cxx-dev-tools.cmake)
 find_package(Boost REQUIRED COMPONENTS system thread filesystem)
+find_package(CURL REQUIRED)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 add_executable(gruut_enterprise_merger main.cpp)
 
@@ -68,12 +69,17 @@ IF (Boost_FOUND)
     include_directories(${Boost_INCLUDE_DIR})
 ENDIF (Boost_FOUND)
 
+IF (CURL_FOUND)
+    include_directories(${CURL_INCLUDE_DIR})
+ENDIF (CURL_FOUND)
+
 add_subdirectory(lib/leveldb)
 
 target_include_directories(gruut_enterprise_merger PRIVATE include/ /usr/local/include)
 target_link_libraries(gruut_enterprise_merger
         PRIVATE
         ${Boost_LIBRARIES}
+        ${CURL_LIBRARIES}
         leveldb
         ${LZ4_LIBS}
         ${BOTAN_LIBS}

--- a/include/curlpp.hpp
+++ b/include/curlpp.hpp
@@ -1,0 +1,421 @@
+#ifndef CURLPP_HPP
+#define CURLPP_HPP
+
+#include <cstddef>
+#include <initializer_list>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+#include <curl/curl.h>
+
+namespace curlpp
+{
+  void init(long flags = CURL_GLOBAL_DEFAULT);
+  void cleanup();
+
+  namespace util
+  {
+    std::string escape(const std::string& string);
+    std::string unescape(const std::string& string);
+  }
+
+  namespace write
+  {
+    std::size_t none(char*, std::size_t size, std::size_t nmemb, void*);
+    std::size_t toStream(char* data, std::size_t size, std::size_t nmemb, std::ostream* stream);
+    std::size_t toString(char* data, std::size_t size, std::size_t nmemb, std::string* string);
+  }
+
+  // Easy
+  class Easy
+  {
+  public:
+    typedef CURLcode codeType;
+    typedef CURL handleType;
+    typedef CURLINFO infoType;
+    typedef CURLoption optionType;
+
+    Easy();
+    ~Easy();
+
+    Easy(const Easy&) = delete;
+    Easy& operator=(const Easy&) = delete;
+
+    handleType* getHandle();
+
+    std::string escape(std::string string);
+    std::string unescape(std::string string);
+
+    void pause(int bitmask);
+    void perform();
+    void reset();
+
+    template <typename T>
+    void getInfo(infoType info, T arg);
+
+    template <typename T>
+    void setOpt(optionType option, T arg);
+
+  private:
+    handleType* handle_ = nullptr;
+  };
+
+  // Form
+  class Form
+  {
+  public:
+    typedef CURLFORMcode codeType;
+    typedef curl_httppost handleType;
+
+    Form() = default;
+    ~Form();
+
+    Form(const Form&) = delete;
+    Form& operator=(const Form&) = delete;
+
+    handleType* getHandle() const;
+
+    void addContent(const std::string& name, const std::string& value);
+    void addContent(const std::string& name, const std::string& value, const std::string& type);
+
+    void addFile(const std::string& name, const std::string& filename);
+    void addFile(const std::string& name, const std::string& filename, const std::string& type);
+
+  private:
+    handleType* last_ = nullptr;
+    handleType* post_ = nullptr;
+  };
+
+  // List
+  class List
+  {
+  public:
+    typedef curl_slist handleType;
+
+    List() = default;
+    List(std::initializer_list<std::string> fields);
+    ~List();
+
+    List(const List&) = delete;
+    List& operator=(const List&) = delete;
+
+    handleType* getHandle() const;
+
+    void add(const std::string& field);
+
+  private:
+    mutable handleType* list_ = nullptr;
+  };
+
+
+  // Exception
+  class Exception : public std::runtime_error
+  {
+  public:
+    Exception(const std::string& message);
+  };
+
+  // EasyException
+  class EasyException : public Exception
+  {
+  public:
+    EasyException(Easy::codeType errorId);
+
+    Easy::codeType getErrorId() const;
+
+  private:
+    const Easy::codeType errorId_;
+  };
+
+  // FormException
+  class FormException : public Exception
+  {
+  public:
+    FormException(Form::codeType errorId);
+
+    Form::codeType getErrorId() const;
+
+  private:
+    const Form::codeType errorId_;
+  };
+}
+
+// general
+inline void curlpp::init(long flags)
+{
+  curl_global_init(flags);
+}
+
+inline void curlpp::cleanup()
+{
+  curl_global_cleanup();
+}
+
+// util
+inline std::string curlpp::util::escape(const std::string& string)
+{
+  static Easy easy;
+  return easy.escape(string);
+}
+
+inline std::string curlpp::util::unescape(const std::string& string)
+{
+  static Easy easy;
+  return easy.unescape(string);
+}
+
+// write
+inline std::size_t curlpp::write::none(char*, std::size_t size, std::size_t nmemb, void*)
+{
+  return size * nmemb;
+}
+
+inline std::size_t curlpp::write::toStream(char* data, std::size_t size, std::size_t nmemb, std::ostream* stream)
+{
+  if (!stream)
+  {
+    return 0;
+  }
+
+  stream->write(data, size * nmemb);
+  stream->flush();
+
+  return size * nmemb;
+}
+
+inline std::size_t curlpp::write::toString(char* data, std::size_t size, std::size_t nmemb, std::string* string)
+{
+  if (!string)
+  {
+    return 0;
+  }
+
+  string->append(data, size * nmemb);
+
+  return size * nmemb;
+}
+
+// Easy
+inline curlpp::Easy::Easy()
+        : handle_(curl_easy_init())
+{
+  setOpt(CURLOPT_WRITEFUNCTION, write::none);
+}
+
+inline curlpp::Easy::~Easy()
+{
+  curl_easy_cleanup(handle_);
+}
+
+inline curlpp::Easy::handleType* curlpp::Easy::getHandle()
+{
+  return handle_;
+}
+
+inline std::string curlpp::Easy::escape(std::string string)
+{
+  char* ret = curl_easy_escape(handle_, string.c_str(), string.size());
+
+  string = std::string(ret);
+
+  curl_free(ret);
+
+  return string;
+}
+
+inline std::string curlpp::Easy::unescape(std::string string)
+{
+  int out = 0;
+  char* ret = curl_easy_unescape(handle_, string.c_str(), string.size(), &out);
+
+  string = std::string(ret, out);
+
+  curl_free(ret);
+
+  return string;
+}
+
+inline void curlpp::Easy::pause(int bitmask)
+{
+  const codeType error = curl_easy_pause(handle_, bitmask);
+
+  if (error != CURLE_OK)
+  {
+    throw EasyException(error);
+  }
+}
+
+inline void curlpp::Easy::perform()
+{
+  const codeType error = curl_easy_perform(handle_);
+
+  if (error != CURLE_OK)
+  {
+    throw EasyException(error);
+  }
+}
+
+inline void curlpp::Easy::reset()
+{
+  curl_easy_reset(handle_);
+}
+
+template <typename T>
+inline void curlpp::Easy::getInfo(infoType info, T arg)
+{
+  const codeType error = curl_easy_getinfo(handle_, info, arg);
+
+  if (error != CURLE_OK)
+  {
+    throw EasyException(error);
+  }
+}
+
+template <typename T>
+inline void curlpp::Easy::setOpt(optionType option, T arg)
+{
+  const codeType error = curl_easy_setopt(handle_, option, arg);
+
+  if (error != CURLE_OK)
+  {
+    throw EasyException(error);
+  }
+}
+
+// Form
+inline curlpp::Form::~Form()
+{
+  curl_formfree(post_);
+}
+
+inline curlpp::Form::handleType* curlpp::Form::getHandle() const
+{
+  return post_;
+}
+
+inline void curlpp::Form::addContent(const std::string& name, const std::string& value)
+{
+  const codeType error = curl_formadd(
+          &post_,
+          &last_,
+          CURLFORM_COPYNAME,
+          name.c_str(),
+          CURLFORM_COPYCONTENTS,
+          value.c_str(),
+          CURLFORM_END
+  );
+
+  if (error != CURL_FORMADD_OK)
+  {
+    throw FormException(error);
+  }
+}
+
+inline void curlpp::Form::addContent(const std::string& name, const std::string& value, const std::string& type)
+{
+  const codeType error = curl_formadd(
+          &post_,
+          &last_,
+          CURLFORM_COPYNAME,
+          name.c_str(),
+          CURLFORM_COPYCONTENTS,
+          value.c_str(),
+          CURLFORM_CONTENTTYPE,
+          type.c_str(),
+          CURLFORM_END
+  );
+
+  if (error != CURL_FORMADD_OK)
+  {
+    throw FormException(error);
+  }
+}
+
+inline void curlpp::Form::addFile(const std::string& name, const std::string& filename)
+{
+  const codeType error = curl_formadd(
+          &post_,
+          &last_,
+          CURLFORM_COPYNAME,
+          name.c_str(),
+          CURLFORM_FILE,
+          filename.c_str(),
+          CURLFORM_END
+  );
+
+  if (error != CURL_FORMADD_OK)
+  {
+    throw FormException(error);
+  }
+}
+
+inline void curlpp::Form::addFile(const std::string& name, const std::string& filename, const std::string& type)
+{
+  const codeType error = curl_formadd(
+          &post_,
+          &last_,
+          CURLFORM_COPYNAME,
+          name.c_str(),
+          CURLFORM_FILE,
+          filename.c_str(),
+          CURLFORM_CONTENTTYPE,
+          type.c_str(),
+          CURLFORM_END
+  );
+
+  if (error != CURL_FORMADD_OK)
+  {
+    throw FormException(error);
+  }
+}
+
+// List
+inline curlpp::List::List(std::initializer_list<std::string> fields)
+{
+  for (const std::string& field : fields)
+  {
+    add(field);
+  }
+}
+
+inline curlpp::List::~List()
+{
+  curl_slist_free_all(list_);
+}
+
+inline curlpp::List::handleType* curlpp::List::getHandle() const
+{
+  return list_;
+}
+
+inline void curlpp::List::add(const std::string& field)
+{
+  list_ = curl_slist_append(list_, field.c_str());
+}
+
+// Exception
+inline curlpp::Exception::Exception(const std::string& message)
+        : std::runtime_error(message)
+{}
+
+// EasyException
+inline curlpp::EasyException::EasyException(Easy::codeType errorId)
+        : Exception(curl_easy_strerror(errorId)), errorId_(errorId)
+{}
+
+inline curlpp::Easy::codeType curlpp::EasyException::getErrorId() const
+{
+  return errorId_;
+}
+
+// FormException
+inline curlpp::FormException::FormException(Form::codeType errorId)
+        : Exception("Form error"), errorId_(errorId)
+{}
+
+inline curlpp::Form::codeType curlpp::FormException::getErrorId() const
+{
+  return errorId_;
+}
+
+#endif

--- a/my_setting.json
+++ b/my_setting.json
@@ -77,7 +77,8 @@
   "SE" : [
     {
       "id": "R0VOVFNFLTE=",
-      "address" : "10.10.10.201",
+      "address" : "10.10.10.108",
+      "port": "3000",
       "cert" : [
         "-----BEGIN CERTIFICATE-----",
         "MIID+zCCAmOgAwIBAgIRAPUuiEOLwpSCAxKaoHit29QwDQYJKoZIhvcNAQELBQAw",

--- a/src/modules/communication/http_client.cpp
+++ b/src/modules/communication/http_client.cpp
@@ -1,0 +1,32 @@
+#include "http_client.hpp"
+#include <iostream>
+
+using namespace std;
+
+namespace gruut {
+HttpClient::HttpClient(const string &m_address) : m_address(m_address) {}
+
+CURLcode HttpClient::post(const string &packed_msg) {
+  try {
+    const string post_field = getPostField("blockraw", packed_msg);
+
+    m_curl.setOpt(CURLOPT_URL, m_address.data());
+    m_curl.setOpt(CURLOPT_POST, 1L);
+    m_curl.setOpt(CURLOPT_POSTFIELDS, post_field.data());
+    m_curl.setOpt(CURLOPT_POSTFIELDSIZE, post_field.size());
+
+    m_curl.perform();
+  } catch (curlpp::EasyException &err) {
+    cout << "HttpClient post error: " << err.what() << endl;
+    cout << "HttpClient Code: " << err.getErrorId() << endl;
+    return err.getErrorId();
+  }
+
+  return CURLE_OK;
+}
+
+std::string HttpClient::getPostField(const string &key, const string &value) {
+  const string post_field = key + "=" + value;
+  return post_field;
+}
+} // namespace gruut

--- a/src/modules/communication/http_client.hpp
+++ b/src/modules/communication/http_client.hpp
@@ -1,0 +1,24 @@
+#ifndef GRUUT_ENTERPRISE_MERGER_HTTP_CLIENT_HPP
+#define GRUUT_ENTERPRISE_MERGER_HTTP_CLIENT_HPP
+
+#include <memory>
+#include <string>
+
+#include "../../../include/curlpp.hpp"
+
+namespace gruut {
+class HttpClient {
+public:
+  HttpClient() = delete;
+  HttpClient(const std::string &m_address);
+
+  CURLcode post(const std::string &packed_msg);
+
+private:
+  std::string getPostField(const std::string &key, const std::string &value);
+
+  curlpp::Easy m_curl;
+  std::string m_address;
+};
+} // namespace gruut
+#endif

--- a/src/modules/communication/merger_client.hpp
+++ b/src/modules/communication/merger_client.hpp
@@ -24,8 +24,8 @@ public:
 private:
   RpcReceiverList *m_rpc_receiver_list;
 
-  void sendToSE(MessageType msg_type, std::vector<id_type> &receiver_list,
-                std::string &packed_msg);
+  void sendToSE(std::string &packed_msg);
+
   void sendToMerger(MessageType msg_type, std::vector<id_type> &receiver_list,
                     std::string &packed_msg);
   void sendToSigner(MessageType msg_type, std::vector<id_type> &receiver_list,

--- a/src/services/setting.hpp
+++ b/src/services/setting.hpp
@@ -23,6 +23,7 @@ struct GruutAuthorityInfo {
 struct ServiceEndpointInfo {
   id_type id;
   std::string address;
+  std::string port;
   std::string cert;
 };
 

--- a/tests/modules/CMakeLists.txt
+++ b/tests/modules/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 set(CMAKE_CXX_STANDARD 11)
 
 find_package(Boost REQUIRED COMPONENTS system thread unit_test_framework random filesystem)
+find_package(CURL REQUIRED)
 
 file(GLOB UNIT_TEST_SOURCE_FILES
         "test.cpp"
@@ -17,6 +18,7 @@ file(GLOB HEADER_FILES
         "../../src/services/*.hpp"
         "../../src/modules/communication/msg_schema.hpp"
         "../../src/modules/communication/grpc_util.hpp"
+        "../../src/modules/communication/http_client.hpp"
         "../../src/config/config.hpp"
         )
 
@@ -26,6 +28,7 @@ file(GLOB SOURCE_FILES
         "../../src/modules/*.cpp"
         "../../src/services/*.cpp"
         "../../src/modules/communication/grpc_util.cpp"
+        "../../src/modules/communication/http_client.cpp"
         "../../include/*.cpp"
         )
 
@@ -36,6 +39,11 @@ if(APPLE)
 else()
     set(GRPC_LIBS "${LIB_PREFIX}/libgrpc++.so")
 endif()
+
+IF (CURL_FOUND)
+    include_directories(${CURL_INCLUDE_DIR})
+ENDIF (CURL_FOUND)
+
 
 add_definitions(-DBOOST_TEST_DYN_LINK)
 add_executable(modules_test ${UNIT_TEST_SOURCE_FILES})
@@ -52,6 +60,7 @@ target_link_libraries(modules_test
         PRIVATE
         ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
         ${Boost_LIBRARIES}
+        ${CURL_LIBRARIES}
         ${LZ4_LIBS}
         /usr/local/lib/libbotan-2.a
         leveldb

--- a/tests/modules/test.cpp
+++ b/tests/modules/test.cpp
@@ -6,6 +6,7 @@
 #include "../../src/modules/module.hpp"
 #include "../../src/application.hpp"
 #include "../../src/modules/communication/grpc_util.hpp"
+#include "../../src/modules/communication/http_client.hpp"
 #include "../../src/chain/transaction.hpp"
 #include "../../src/modules/message_fetcher/message_fetcher.hpp"
 #include "../../src/config/config.hpp"
@@ -88,4 +89,13 @@ BOOST_AUTO_TEST_SUITE(Test_JsonValidator)
         BOOST_TEST(!false_sample);
     }
 
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(Test_HttpClient)
+  BOOST_AUTO_TEST_CASE(post) {
+    HttpClient client("10.10.10.108:3000/api/blocks");
+
+    CURLcode status = client.post("Hello world");
+    BOOST_TEST(true);
+  }
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## 구현사항
- HttpClient 추가
  * 주소(address + port)를 입력받아 새로운 객체를 생성하고, post하면 해당 주소로 request가 가도록 수정
  * 테스트 코드로 SE에 request가 가는 것을 확인했지만, 실제 블럭이 생성된 이후에 요청이 제대로 가는지 테스트는 못함(**현재 Signer쪽 버그때문에 테스트 못함**)
- 실제 SE로 요청보내는 곳 수정(merger_client)
- my_setting.json address, port를 추가 및 수정, ServiceEndpointInfo에 port 필드 추가