### PR TITLE
 # FIX - Compressed msg를 전송할 수 없던 문제 해결

### DIFF
--- a/src/modules/communication/message_handler.cpp
+++ b/src/modules/communication/message_handler.cpp
@@ -63,9 +63,7 @@ void MessageHandler::packMsg(OutputMsgEntry &output_msg) {
   MessageHeader header;
   header.message_type = msg_type;
 
-  // TODO: 현재 압축해서 메시지를 보내려고 시도할때, 메시지가 전송되지 않습니다.
-  //문제 수정후 압축타입 지정 할 것입니다. 현재는 NONE 입니다.
-  header.compression_algo_type = CompressionAlgorithmType::NONE;
+  header.compression_algo_type = config::COMPRESSION_ALGO_TYPE;
   std::string packed_msg = genPackedMsg(header, body);
   std::vector<std::string> packed_msg_list;
 
@@ -117,8 +115,7 @@ MessageHandler::getJson(CompressionAlgorithmType compression_type,
   nlohmann::json unpacked_body;
   switch (compression_type) {
   case CompressionAlgorithmType::LZ4: {
-    std::string origin_data;
-    Compressor::decompressData(body, origin_data, body.size());
+    std::string origin_data = Compressor::decompressData(body);
     unpacked_body = nlohmann::json::parse(origin_data);
   } break;
   case CompressionAlgorithmType::NONE: {
@@ -136,8 +133,7 @@ std::string MessageHandler::genPackedMsg(MessageHeader &header,
 
   switch (header.compression_algo_type) {
   case CompressionAlgorithmType::LZ4: {
-    std::string compressed_body;
-    Compressor::compressData(body_dump, compressed_body);
+    std::string compressed_body = Compressor::compressData(body_dump);
     body_dump = compressed_body;
   } break;
   case CompressionAlgorithmType ::NONE:

--- a/src/services/block_validator.hpp
+++ b/src/services/block_validator.hpp
@@ -39,8 +39,7 @@ public:
                                   block_raw.begin() + header_end);
     std::string block_json_str;
     if (block_raw[0] == static_cast<uint8_t>(CompressionAlgorithmType::LZ4)) {
-      Compressor::decompressData(block_header_comp, block_json_str,
-                                 (int)header_end - 5);
+      block_json_str = Compressor::decompressData(block_header_comp);
     } else if (block_raw[0] ==
                static_cast<uint8_t>(CompressionAlgorithmType::NONE)) {
       block_json_str.assign(block_header_comp);

--- a/src/utils/compressor.hpp
+++ b/src/utils/compressor.hpp
@@ -8,12 +8,15 @@
 using namespace std;
 class Compressor {
 public:
-  static int compressData(const string &src, string &dest) {
+  static string compressData(const string &src) {
     int src_size = static_cast<int>(src.size());
     int dst_size = LZ4_compressBound(src_size);
+    string dest;
     dest.resize(dst_size);
-    return LZ4_compress_default(src.data(), (char *)dest.data(), src_size,
-                                dst_size);
+    int dest_length = LZ4_compress_default(src.data(), (char *)dest.data(),
+                                           src_size, dst_size);
+    string dest2(dest.begin(), dest.begin() + dest_length);
+    return dest2;
   }
 
   static vector<uint8_t> compressData(const vector<uint8_t> &src) {
@@ -26,26 +29,15 @@ public:
     return dest2;
   }
 
-  static int decompressData(string &src, string &dest, int compressed_size) {
-    // TODO: decompressed data의 최대 capacity는 현재 compressed data의 3배로
-    // 설정해 놓았습니다. 수정 될수 있습니다.
-    int dest_capacity = compressed_size * 3;
-    dest.resize(dest_capacity);
-    int dest_length = LZ4_decompress_safe(src.data(), (char *)dest.data(),
-                                          compressed_size, dest_capacity);
-    dest = dest.substr(0, dest_length);
-    return dest_length;
-  }
-  // TODO: 위의 함수는 삭제될 예정입니다. 위의 함수는 현재 사용하고 있는 곳이
-  // 있습니다.
-  static int decompressData(string &src, string &dest) {
+  static string decompressData(string &src) {
     int compressed_size = static_cast<int>(src.size());
     int dest_capacity = compressed_size * 3;
+    string dest;
     dest.resize(dest_capacity);
     int dest_length = LZ4_decompress_safe(src.data(), (char *)dest.data(),
                                           compressed_size, dest_capacity);
-    dest = dest.substr(0, dest_length);
-    return dest_length;
+    string dest2 = dest.substr(0, dest_length);
+    return dest2;
   }
 
   static vector<uint8_t> decompressData(vector<uint8_t> &src) {

--- a/tests/utils/test.cpp
+++ b/tests/utils/test.cpp
@@ -42,8 +42,8 @@ BOOST_AUTO_TEST_SUITE(Test_Compressor)
         string original = "2013-01-07 00:00:04,0.98644,0.98676 2013-01-07 00:01:19,0.98654,0.98676 2013-01-07 00:01:38,0.98644,0.98696";
         string compressed_data, decompressed_data;
 
-        int compressed_size = Compressor::compressData(original, compressed_data);
-        Compressor::decompressData(compressed_data, decompressed_data, compressed_size);
+        compressed_data = Compressor::compressData(original);
+        decompressed_data = Compressor::decompressData(compressed_data);
 
         BOOST_TEST(decompressed_data == original);
     }


### PR DESCRIPTION
- 원인 : LZ4 압축 함수 문제
  * LZ4 압축을 할때 destination의 capacity를 지정한다. 수정 전에는
capacity 사이즈 그대로 데이터를 리턴하여 압축되고 남은 사이즈만큼
더미값이 들어가 있었다.

- 해결 : 압축된 사이즈로 반환하도록 함수 수정

- compress/decompress 함수를 사용하는 부분 수정