### PR TITLE
# REFACTER - improved application structure

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -76,22 +76,7 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  // stage 0  modules
-  shared_ptr<BootStraper> module_bootstraper = make_shared<BootStraper>();
-  shared_ptr<Communication> moudle_communication = make_shared<Communication>();
-  shared_ptr<OutMessageFetcher> module_out_message_fetcher = make_shared<OutMessageFetcher>();
-
-  // stage 1 modules
-  shared_ptr<MessageFetcher> module_message_fetcher = make_shared<MessageFetcher>();
-  //shared_ptr<BpScheduler> module_bp_scheduler = make_shared<BpScheduler>();
-
-  Application::app().regModule(moudle_communication, 0);
-  Application::app().regModule(module_out_message_fetcher, 0);
-  Application::app().regModule(module_bootstraper, 0, true);
-
-  Application::app().regModule(module_message_fetcher, 1);
-  //Application::app().regModule(module_bp_scheduler, 1);
-
+  Application::app().setup();
   Application::app().start();
   Application::app().exec();
   Application::app().quit();

--- a/src/application.hpp
+++ b/src/application.hpp
@@ -58,13 +58,14 @@ public:
 
   BpScheduler &getBpScheduler();
 
-  void regModule(shared_ptr<Module> module, int stage,
-                 bool runover_flag = false);
+  void setup();
   void start();
   void exec();
   void quit();
 
 private:
+  void registerModule(shared_ptr<Module> module, int stage,
+                      bool runover_flag = false);
   void runNextStage(ExitCode exit_code);
 
   shared_ptr<boost::asio::io_service> m_io_serv;
@@ -80,8 +81,11 @@ private:
   std::vector<std::vector<shared_ptr<Module>>> m_modules;
 
   shared_ptr<BpScheduler> m_bp_scheduler;
-
   shared_ptr<BlockProcessor> m_block_processor;
+  shared_ptr<Communication> m_communication;
+  shared_ptr<OutMessageFetcher> m_out_message_fetcher;
+  shared_ptr<BootStraper> m_bootstraper;
+  shared_ptr<MessageFetcher> m_message_fetcher;
 
   int m_running_stage{0};
 


### PR DESCRIPTION
### 도대체 왜?!
- Application에서 사용하는 모듈/서비스가 다시 Application을 참조할 경우 hpp/cpp 나눔이 필수
- 컴파일은 되나 Application이 생성이 안되어 멈추어 있는 경우를 몇 차례 확인. 클래스가 서로 참조하므로 순환 참조가 어떻게 이루어지는지 파악하기가 어려워짐
- 스테이지 개념을 도입한 Application에서는 외부에 모듈을 생성하고 이를 등록하도록 하였으나 Application 객체의 역할이 main.cpp로 옮겨지는 것
- 상기와 같은 사항들을 정리하도록 하기 위해서 Application 객체가 생성시간에 생성해야하는 클래스를 제한하여 순환참조에 따른 문제를 완화하도록 setup에서 클래스를 생성하고 모듈을 등록하도록 함.
