### PR TITLE
# FIX - handling Botan::Base64_decode exception

### DIFF
--- a/src/services/signer_pool_manager.cpp
+++ b/src/services/signer_pool_manager.cpp
@@ -3,7 +3,6 @@
 #include <chrono>
 #include <iostream>
 
-#include <botan-2/botan/base64.h>
 #include <botan-2/botan/pem.h>
 #include <botan-2/botan/pubkey.h>
 #include <botan-2/botan/rsa.h>
@@ -202,7 +201,7 @@ string SignerPoolManager::signMessage(string merger_nonce, string signer_nonce,
   auto message_bytes = builder.getBytes();
   auto signature = RSA::doSign(rsa_sk_pem, message_bytes, true, rsa_sk_pass);
 
-  return Botan::base64_encode(signature);
+  return TypeConverter::toBase64Str(signature);
 }
 
 bool SignerPoolManager::isJoinable() {

--- a/src/utils/random_number_generator.hpp
+++ b/src/utils/random_number_generator.hpp
@@ -1,8 +1,9 @@
 #ifndef GRUUT_ENTERPRISE_MERGER_RANDOM_NUM_GENERATOR_HPP
 #define GRUUT_ENTERPRISE_MERGER_RANDOM_NUM_GENERATOR_HPP
 
+#include "../utils/type_converter.hpp"
+
 #include <botan-2/botan/auto_rng.h>
-#include <botan-2/botan/base64.h>
 #include <botan-2/botan/rng.h>
 #include <random>
 #include <vector>
@@ -23,8 +24,8 @@ public:
     return random_number;
   }
 
-  static string toString(vector<uint8_t> random_number_list) {
-    return Botan::base64_encode(random_number_list);
+  static string toString(vector<uint8_t> &&random_number_list) {
+    return TypeConverter::toBase64Str(random_number_list);
   }
 
   static int getRange(int min, int max) {

--- a/src/utils/type_converter.hpp
+++ b/src/utils/type_converter.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include <botan-2/botan/base64.h>
+#include <botan-2/botan/exceptn.h>
 #include <botan-2/botan/secmem.h>
 
 #include "../chain/types.hpp"
@@ -102,9 +103,14 @@ public:
 
   template <typename T>
   inline static std::vector<uint8_t> decodeBase64(T &input) {
-    auto s_vector = Botan::base64_decode(input);
+    try {
+      auto s_vector = Botan::base64_decode(input);
+      return std::vector<uint8_t>(s_vector.begin(), s_vector.end());
+    } catch (Botan::Exception &e) {
+      cout << e.what() << endl;
+    }
 
-    return std::vector<uint8_t>(s_vector.begin(), s_vector.end());
+    return std::vector<uint8_t>();
   }
   template <class Container>
   static inline std::string toString(const Container &bytes) {


### PR DESCRIPTION
### 수정 내용
- 우연이지만, 루이지 테스트 도중에 dos가 ID를 문자열로 그냥 보냈음.
- 규칙대로 머저가 base64 디코딩을 하였더니, merger가 바로 종료
- 이에 대한 try/catch 삽입

### 기타
- botan base64 관련 코드가  type_converter에만 있도록 수정 (중앙 관리?)