### PR TITLE
 # REFACTOR - rpc server에서 다수 메시지 발생 시 처리속도 문제 해결

### DIFF
--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -40,6 +40,8 @@ constexpr size_t MAX_WAIT_TIME = 5;
 
 constexpr int SYNC_CONTROL_INTERVAL = 500;
 
+constexpr int AVAILABLE_INPUT_SIZE = 20;
+
 const std::string DEFAULT_PORT_NUM = "50051";
 
 constexpr uint8_t G = 'G';

--- a/src/modules/communication/merger_server.hpp
+++ b/src/modules/communication/merger_server.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../../application.hpp"
+#include "../../services/input_queue.hpp"
 #include "protos/protobuf_merger.grpc.pb.h"
 #include "protos/protobuf_se.grpc.pb.h"
 #include "protos/protobuf_signer.grpc.pb.h"
@@ -18,6 +19,7 @@ namespace gruut {
 
 class MergerServer {
 public:
+  MergerServer() { m_input_queue = InputQueueAlt::getInstance(); }
   ~MergerServer() {
     m_server->Shutdown();
     m_completion_queue->Shutdown();
@@ -32,7 +34,7 @@ private:
   GruutSeService::AsyncService m_se_service;
   GruutNetworkService::AsyncService m_signer_service;
   RpcReceiverList *m_rpc_receivers;
-
+  InputQueueAlt *m_input_queue;
   void recvMessage();
 };
 

--- a/src/services/input_queue.hpp
+++ b/src/services/input_queue.hpp
@@ -56,6 +56,8 @@ public:
 
   inline bool empty() { return m_input_msg_pool.empty(); }
 
+  inline size_t size() { return m_input_msg_pool.size(); }
+
   inline void clearInputQueue() { m_input_msg_pool.clear(); }
 };
 } // namespace gruut

--- a/src/services/output_queue.hpp
+++ b/src/services/output_queue.hpp
@@ -69,6 +69,8 @@ public:
 
   inline bool empty() { return m_output_msg_pool.empty(); }
 
+  inline size_t size() { return m_output_msg_pool.size(); }
+
   inline void clearOutputQueue() { m_output_msg_pool.clear(); }
 };
 } // namespace gruut


### PR DESCRIPTION
 #문제
- rpc server에서 받은 메시지를 MessageHandler에게 넘겨 unpack하는 과정이
순차 처리였음.

 #해결
- 메시지를 받아 unpack하는 과정을 io_service에 post 하는 형태로 바꿈

 #기타
- InputQueueAlt / OutputQueueAlt 클래스에 size() 함수 추가

- MergerSrever의 recvMessage() 에서 InputQueue의 size가 특정 값보다
커지면 completion_queue(rpc_queue)에서 InputQueue로 보내지 않게 함

- MergerServer의 recvMessage() 에서 Sleep 이 더이상 필요없다고 생각하여
삭제. 메시지가 없을 때는 Next() 부분에서 더이상 진행이 안되는 것을
확인하였음.

  * 현재 컴퓨터의 문제로 테스트는 해보지 못한 상태입니다.