### PR TITLE
 # ADD - DB 디렉토리의 경로를 설정 및 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,10 @@ lib/leveldb/leveldbConfigVersion\.cmake
 
 my_setting.json
 !/src/config/my_setting.json
+
+db/block_header/*
+db/block_body/*
+db/block_raw/*
+db/blockid_height/*
+db/certificate/*
+db/latest_block_header/*

--- a/main.cpp
+++ b/main.cpp
@@ -23,8 +23,9 @@ json parseArg(int argc, char *argv[]){
   options.add_options("basic")("help", "Print help description")(
     "in", "Setting file", cxxopts::value<string>()->default_value("./setting.json"))
     ("pass","Password to decrypt secret key",cxxopts::value<string>()->default_value(""))
-    ("port", "Port number", cxxopts::value<string>()->default_value(""));
-
+    ("port", "Port number", cxxopts::value<string>()->default_value(""))
+    ("dbpath", "DB path", cxxopts::value<string>()->default_value("./db")
+    );
 
   if (argc == 1) {
     cout << options.help({"basic"}) << endl;
@@ -53,6 +54,10 @@ json parseArg(int argc, char *argv[]){
     auto parsed_port_num = result["port"].as<string>();
     if(!parsed_port_num.empty())
       setting_json["Self"]["port"] = parsed_port_num;
+
+    auto parsed_db_path = result["dbpath"].as<string>();
+    setting_json["dbpath"] = parsed_db_path;
+    boost::filesystem::create_directories(parsed_db_path);
 
     return setting_json;
 

--- a/src/services/setting.hpp
+++ b/src/services/setting.hpp
@@ -139,6 +139,7 @@ private:
   std::string m_port;
   local_chain_id_type m_localchain_id;
   std::string m_localchain_name;
+  std::string m_db_path;
 
   GruutAuthorityInfo m_gruut_authority;
   std::vector<ServiceEndpointInfo> m_service_endpoints;
@@ -158,6 +159,8 @@ public:
   }
 
   bool setJson(json &setting_json) {
+    m_db_path = setting_json["dbpath"].get<string>();
+    setting_json.erase("dbpath");
 
     if (!validateSchema(setting_json))
       return false;
@@ -219,6 +222,8 @@ public:
   inline std::string getMyPass() { return m_sk_pass; }
 
   inline local_chain_id_type getLocalChainId() { return m_localchain_id; }
+
+  inline std::string getMyDbPath() { return m_db_path; }
 
   inline GruutAuthorityInfo getGruutAuthorityInfo() {
     return m_gruut_authority;

--- a/src/services/storage.cpp
+++ b/src/services/storage.cpp
@@ -1,25 +1,30 @@
 #include "storage.hpp"
-
+#include "setting.hpp"
 namespace gruut {
 using namespace std;
 using namespace nlohmann;
 using namespace macaron;
 
 Storage::Storage() {
+  auto setting = Setting::getInstance();
+  m_db_path = setting->getMyDbPath();
+
   m_options.create_if_missing = true;
   m_write_options.sync = true;
 
+  errorOnCritical(leveldb::DB::Open(m_options, m_db_path + "/block_header",
+                                    &m_db_block_header));
   errorOnCritical(
-      leveldb::DB::Open(m_options, "./block_header", &m_db_block_header));
-  errorOnCritical(leveldb::DB::Open(m_options, "./block_raw", &m_db_block_raw));
-  errorOnCritical(leveldb::DB::Open(m_options, "./latest_block_header",
+      leveldb::DB::Open(m_options, m_db_path + "/block_raw", &m_db_block_raw));
+  errorOnCritical(leveldb::DB::Open(m_options,
+                                    m_db_path + "/latest_block_header",
                                     &m_db_latest_block_header));
-  errorOnCritical(
-      leveldb::DB::Open(m_options, "./block_body", &m_db_block_body));
-  errorOnCritical(
-      leveldb::DB::Open(m_options, "./certificate", &m_db_certificate));
-  errorOnCritical(
-      leveldb::DB::Open(m_options, "./blockid_height", &m_db_blockid_height));
+  errorOnCritical(leveldb::DB::Open(m_options, m_db_path + "/block_body",
+                                    &m_db_block_body));
+  errorOnCritical(leveldb::DB::Open(m_options, m_db_path + "/certificate",
+                                    &m_db_certificate));
+  errorOnCritical(leveldb::DB::Open(m_options, m_db_path + "/blockid_height",
+                                    &m_db_blockid_height));
 }
 
 Storage::~Storage() {
@@ -396,12 +401,12 @@ string Storage::findCertificate(const string &user_id,
 }
 
 void Storage::deleteAllDirectory() {
-  boost::filesystem::remove_all("./block_header");
-  boost::filesystem::remove_all("./block_raw");
-  boost::filesystem::remove_all("./certificate");
-  boost::filesystem::remove_all("./latest_block_header");
-  boost::filesystem::remove_all("./block_body");
-  boost::filesystem::remove_all("./blockid_height");
+  boost::filesystem::remove_all(m_db_path + "/block_header");
+  boost::filesystem::remove_all(m_db_path + "/block_raw");
+  boost::filesystem::remove_all(m_db_path + "/certificate");
+  boost::filesystem::remove_all(m_db_path + "/latest_block_header");
+  boost::filesystem::remove_all(m_db_path + "/block_body");
+  boost::filesystem::remove_all(m_db_path + "/blockid_height");
 }
 
 tuple<int, string, json> Storage::readBlock(int height) {

--- a/src/services/storage.hpp
+++ b/src/services/storage.hpp
@@ -81,6 +81,7 @@ private:
   string getPrefix(DBType what);
 
 private:
+  string m_db_path;
   leveldb::Options m_options;
   leveldb::WriteOptions m_write_options;
   leveldb::ReadOptions m_read_options;


### PR DESCRIPTION
 - 프로그램 실행 시 --dbpath로 DB 디렉토리 경로를 입력받을 수 있게 설정
 - 기본(입력 하지 않았을때) DB 디렉토리 경로 : --dbpath=./db
 - setting_json에 이 정보를 담아서(["dbpath"]) Setting 객체의 m_db_path
멤버 변수에 저장
 - 여기서 setting_json의 스키마 검사는 피하도록 ["dbpath"]는 erase
 - Storage 클래스에서는 Setting 객체의 함수인 getMyDbPath()를 호출하여
해당 경로를 적용