### PR TITLE
#EDIT - handling of GFp exception and its related issues

### DIFF
--- a/src/chain/join_temporary_data.hpp
+++ b/src/chain/join_temporary_data.hpp
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 
+#include "types.hpp"
+
 using namespace std;
 
 namespace gruut {
@@ -11,7 +13,7 @@ struct JoinTemporaryData {
   string merger_nonce;
   string signer_cert;
   vector<uint8_t> shared_secret_key;
-  uint64_t expires_at;
+  timestamp_type start_time;
 };
 } // namespace gruut
 #endif // GRUUT_ENTERPRISE_MERGER_JOINTEMPORARYDATA_HPP

--- a/src/chain/types.hpp
+++ b/src/chain/types.hpp
@@ -59,7 +59,12 @@ enum class MACAlgorithmType : uint8_t {
 };
 
 enum class ErrorMsgType : int {
-  MERGER_BOOTSTRAP = 3
+  MERGER_BOOTSTRAP = 3,
+  ECDH_ILLEGAL_ACCESS,
+  ECDH_MAX_SIGNER_POOL,
+  ECDH_TIMEOUT,
+  ECDH_INVALID_SIG,
+  ECDH_INVALID_PK
 };
 
 enum class CompressionAlgorithmType : uint8_t { LZ4 = 0x04, NONE = 0xFF };

--- a/src/modules/bootstraper/block_synchronizer.cpp
+++ b/src/modules/bootstraper/block_synchronizer.cpp
@@ -281,23 +281,24 @@ void BlockSynchronizer::blockSyncControl() {
   });
 }
 
-void BlockSynchronizer::sendErrorToSigner(InputMsgEntry &input_msg_entry){
+void BlockSynchronizer::sendErrorToSigner(InputMsgEntry &input_msg_entry) {
 
-  if(input_msg_entry.body["sID"].empty())
+  if (input_msg_entry.body["sID"].empty())
     return;
 
   std::string signer_id_b64 = input_msg_entry.body["sID"];
   signer_id_type signer_id = TypeConverter::decodeBase64(signer_id_b64);
 
-  OutputMsgEntry msg_req_block;
-  msg_req_block.type = MessageType::MSG_ERROR ;
-  msg_req_block.body["sender"] = TypeConverter::toBase64Str(m_my_id); // my_id
-  msg_req_block.body["time"] = Time::now();
-  msg_req_block.body["type"] = std::to_string(static_cast<int>(ErrorMsgType::MERGER_BOOTSTRAP));
-  msg_req_block.body["info"] = "Merger is in bootstrapping. Please, wait.";
-  msg_req_block.receivers = { signer_id };
+  OutputMsgEntry output_msg;
+  output_msg.type = MessageType::MSG_ERROR;
+  output_msg.body["sender"] = TypeConverter::toBase64Str(m_my_id); // my_id
+  output_msg.body["time"] = Time::now();
+  output_msg.body["type"] =
+      std::to_string(static_cast<int>(ErrorMsgType::MERGER_BOOTSTRAP));
+  output_msg.body["info"] = "Merger is in bootstrapping. Please, wait.";
+  output_msg.receivers = {signer_id};
 
-  m_msg_proxy.deliverOutputMessage(msg_req_block);
+  m_msg_proxy.deliverOutputMessage(output_msg);
 }
 
 void BlockSynchronizer::messageFetch() {
@@ -309,8 +310,7 @@ void BlockSynchronizer::messageFetch() {
     InputMsgEntry input_msg_entry = m_inputQueue->fetch();
     if (checkMsgFromOtherMerger(input_msg_entry.type)) {
       m_sync_alone = false; // Wow! I am not alone!
-    }
-    else if(checkMsgFromSigner(input_msg_entry.type)) {
+    } else if (checkMsgFromSigner(input_msg_entry.type)) {
       sendErrorToSigner(input_msg_entry);
     }
 
@@ -352,19 +352,15 @@ void BlockSynchronizer::startBlockSync(std::function<void(ExitCode)> callback) {
 }
 
 bool BlockSynchronizer::checkMsgFromOtherMerger(MessageType msg_type) {
-  return (
-      msg_type == MessageType::MSG_UP ||
-      msg_type == MessageType::MSG_PING ||
-      msg_type == MessageType::MSG_REQ_BLOCK
-  );
+  return (msg_type == MessageType::MSG_UP ||
+          msg_type == MessageType::MSG_PING ||
+          msg_type == MessageType::MSG_REQ_BLOCK);
 }
 
-bool BlockSynchronizer::checkMsgFromSigner(MessageType msg_type){
-  return (
-      msg_type == MessageType::MSG_JOIN ||
+bool BlockSynchronizer::checkMsgFromSigner(MessageType msg_type) {
+  return (msg_type == MessageType::MSG_JOIN ||
           msg_type == MessageType::MSG_RESPONSE_1 ||
           msg_type == MessageType::MSG_ECHO ||
-          msg_type == MessageType::MSG_LEAVE
-  );
+          msg_type == MessageType::MSG_LEAVE);
 }
 }; // namespace gruut

--- a/src/services/argv_parser.hpp
+++ b/src/services/argv_parser.hpp
@@ -9,23 +9,24 @@
 
 using namespace nlohmann;
 
-namespace gruut{
+namespace gruut {
 class ArgvParser {
 public:
   ArgvParser() = default;
 
-  json parse(int argc, char *argv[]){
+  json parse(int argc, char *argv[]) {
 
     json setting_json;
 
     cxxopts::Options options(argv[0],
                              "Merger for Gruut Enterprise Networks (C++)\n");
     options.add_options("basic")("help", "Print help description")(
-      "in", "Setting file", cxxopts::value<string>()->default_value("./setting.json"))
-      ("pass","Password to decrypt secret key",cxxopts::value<string>()->default_value(""))
-      ("port", "Port number", cxxopts::value<string>()->default_value(""))
-      ("dbpath", "DB path", cxxopts::value<string>()->default_value("./db")
-      );
+        "in", "Setting file",
+        cxxopts::value<string>()->default_value("./setting.json"))(
+        "pass", "Password to decrypt secret key",
+        cxxopts::value<string>()->default_value(""))(
+        "port", "Port number", cxxopts::value<string>()->default_value(""))(
+        "dbpath", "DB path", cxxopts::value<string>()->default_value("./db"));
 
     if (argc == 1) {
       cout << options.help({"basic"}) << endl;
@@ -44,7 +45,8 @@ public:
       string setting_json_str = FileIo::file2str(result["in"].as<string>());
 
       if (setting_json_str.empty()) {
-        cout << "error opening setting files " << result["in"].as<string>() << endl;
+        cout << "error opening setting files " << result["in"].as<string>()
+             << endl;
         return setting_json;
       }
 
@@ -57,7 +59,7 @@ public:
         setting_json["Self"]["port"] = parsed_port_num; // overwrite
 
       setting_json["dbpath"] = result["dbpath"].as<string>();
-      //boost::filesystem::create_directories(parsed_db_path);
+      // boost::filesystem::create_directories(parsed_db_path);
 
     } catch (json::parse_error &e) {
       cout << "error parsing setting files: " << e.what() << endl;
@@ -68,4 +70,4 @@ public:
     return setting_json;
   }
 };
-}
+} // namespace gruut

--- a/src/services/signer_pool_manager.hpp
+++ b/src/services/signer_pool_manager.hpp
@@ -9,6 +9,8 @@
 #include "../chain/join_temporary_data.hpp"
 #include "../chain/signer.hpp"
 #include "../chain/types.hpp"
+
+#include "message_proxy.hpp"
 #include "signer_pool.hpp"
 
 using namespace std;
@@ -24,15 +26,18 @@ private:
   bool verifySignature(signer_id_type &signer_id,
                        nlohmann::json &message_body_json);
   string signMessage(string, string, string, string, uint64_t);
-  void deliverErrorMessage(vector<signer_id_type> &);
+  void sendErrorMessage(vector<signer_id_type> &receiver_list,
+                        ErrorMsgType error_type, const std::string &info = "");
   bool isJoinable();
-  bool isTimeout(string &signer_id_b64);
+
+  bool isTimeout(std::string &signer_id_b64);
 
   // A temporary table for connection establishment.
-  unordered_map<string, unique_ptr<JoinTemporaryData>> m_join_temporary_table;
+  unordered_map<string, unique_ptr<JoinTemporaryData>> m_join_temp_table;
 
   string m_my_cert;
   merger_id_type m_my_id;
+  MessageProxy m_proxy;
 };
 } // namespace gruut
 #endif

--- a/src/utils/type_converter.hpp
+++ b/src/utils/type_converter.hpp
@@ -44,7 +44,7 @@ public:
   }
 
   template <size_t S>
-  inline static std::array<uint8_t, S> bytesToArray(std::vector<uint8_t> b) {
+  inline static std::array<uint8_t, S> bytesToArray(std::vector<uint8_t> &b) {
     using Array = std::array<uint8_t, S>;
 
     Array arr;
@@ -54,7 +54,7 @@ public:
   }
 
   template <size_t S>
-  inline static std::vector<uint8_t> arrayToVector(std::array<uint8_t, S> arr) {
+  inline static std::vector<uint8_t> arrayToVector(std::array<uint8_t, S> &arr) {
     vector<uint8_t> vec(arr.begin(), arr.end());
 
     return vec;
@@ -97,12 +97,12 @@ public:
     return to_string(num);
   }
 
-  template <typename T> inline static std::string toBase64Str(T &t) {
+  template <typename T> inline static std::string toBase64Str(T &&t) {
     return Botan::base64_encode(vector<uint8_t>(begin(t), end(t)));
   }
 
   template <typename T>
-  inline static std::vector<uint8_t> decodeBase64(T &input) {
+  inline static std::vector<uint8_t> decodeBase64(T &&input) {
     try {
       auto s_vector = Botan::base64_decode(input);
       return std::vector<uint8_t>(s_vector.begin(), s_vector.end());
@@ -113,7 +113,7 @@ public:
     return std::vector<uint8_t>();
   }
   template <class Container>
-  static inline std::string toString(const Container &bytes) {
+  static inline std::string toString(const Container &&bytes) {
     return std::string(bytes.cbegin(), bytes.cend());
   }
 };

--- a/src/utils/type_converter.hpp
+++ b/src/utils/type_converter.hpp
@@ -54,7 +54,8 @@ public:
   }
 
   template <size_t S>
-  inline static std::vector<uint8_t> arrayToVector(std::array<uint8_t, S> &arr) {
+  inline static std::vector<uint8_t>
+  arrayToVector(std::array<uint8_t, S> &arr) {
     vector<uint8_t> vec(arr.begin(), arr.end());
 
     return vec;


### PR DESCRIPTION
### 수정 내역
- 잘못된 값이 넣어져 GFp 클래스에서 Exception이 발생하는 경우 signer에게 오류 메시지 전송
- 서명자 조인 중 잘못된 접근을 차단하고 오류 메시지 전송
- 관련 코드의 가독성 향상을 위해 코드 정리 (디버깅용 오류 메시지 삽입)

### 테스트 내역 (최신 signer 이용)
- boostraping 중 join 메시지를 보냈을 때, boostraping 시간이 늘지 않음 (현재 signer는 관련 오류 메시지에 대한 처리를 하지 않음)
- boostraping이 끝나고 잘 조인됨
- Intel Xeon E3-1230v3에서 1시간 30분 이상 문제없이 동작
- BP 스케쥴러 초기 비정상 동작 확인 (signer가 1기 이상 연결되어 있어야 함) - 치명적이지 않지만 수정요망

### BP 스케쥴러 초기 비정상 동작 내역
- 정상인 경우 (예상)
```
BPS: sendPing(TUVSR0VSLTE=,1,IDLE)
BPS: sendPing(TUVSR0VSLTE=,1,PRIMARY)
BPS: sendPing(TUVSR0VSLTE=,1,PRIMARY)
....
```

- 현재
```
BPS: sendPing(TUVSR0VSLTE=,1,IN_BOOT_WAIT)
BPS: sendPing(TUVSR0VSLTE=,1,IDLE)
BPS: sendPing(TUVSR0VSLTE=,1,PRIMARY)
BPS: sendPing(TUVSR0VSLTE=,1,PRIMARY)
...
```

### 스토리
- 시작은 GFp에 관련된 Botan::Exception 처리 (완료)
- 관련된 코드 부분은 서명자 조인 부분 코드 분석
- DH키 교환 코드가 매뉴얼과 다르게 작성된 것 발견
- 안드로이드 서명자 코드 분석, 여기도 매뉴얼과 다르게 작성된 것 발견
- 의도와는 다르나 오류는 발생하지 않을 것으로 판단
- 매뉴얼을 코드에 맞춰서 수정