### PR TITLE
# FIX - added strand for block genrating one-by-one

### DIFF
--- a/src/services/block_generator.cpp
+++ b/src/services/block_generator.cpp
@@ -40,8 +40,8 @@ BlockGenerator::generatePartialBlock(vector<sha256> &transactions_digest,
 }
 
 void BlockGenerator::generateBlock(PartialBlock partial_block,
-                                   vector<Signature> &support_sigs,
-                                   MerkleTree &merkle_tree) {
+                                   vector<Signature> support_sigs,
+                                   MerkleTree merkle_tree) {
 
   // step 1) preparing basic data
 

--- a/src/services/block_generator.hpp
+++ b/src/services/block_generator.hpp
@@ -15,9 +15,9 @@ class BlockGenerator {
 public:
   PartialBlock generatePartialBlock(vector<sha256> &transactions_digest,
                                     vector<Transaction> &);
-  // partial_block must be call-by-value due to multi-thread
-  void generateBlock(PartialBlock partial_block,
-                     vector<Signature> &support_sigs, MerkleTree &merkle_tree);
+  // argument must be call-by-value due to multi-thread safe
+  void generateBlock(PartialBlock partial_block, vector<Signature> support_sigs,
+                     MerkleTree merkle_tree);
 };
 } // namespace gruut
 

--- a/src/services/signature_requester.hpp
+++ b/src/services/signature_requester.hpp
@@ -44,6 +44,8 @@ private:
 
   std::unique_ptr<boost::asio::deadline_timer> m_collect_timer;
   std::unique_ptr<boost::asio::deadline_timer> m_check_timer;
+  std::unique_ptr<boost::asio::io_service::strand> m_block_gen_strand;
+
   MerkleTree m_merkle_tree;
   PartialBlock m_partial_block;
 


### PR DESCRIPTION
### 이건?!
- 블록 생성 요청이 Asio의 큐에 쌓이다 보니 블록 생성 완료 순서를 보장해주지 않음. 순서가 뒤바뀌었을 때 최신 height 등에 대하여 잘못된 정보를 출력할 수 있음.

### 수정
- strand을 이용하여 순차적으로 블록을 생성하도록 강제 하였음.
- 블록 생성이 기존 데이터에 영향을 받지 않도록 call-by-value를 이용하여 데이터를 넘겨줌
- 사실 이러한 내용은 블록 저장 속도가 향상 되면, 고민하지 않아도 될 문제이지만 예외를 최대한 배제하는 측면에서 작업