### PR TITLE
# EDIT - added block_id for MSG_RES_CHECK and edited its related codes

### DIFF
--- a/src/chain/merkle_tree.hpp
+++ b/src/chain/merkle_tree.hpp
@@ -88,6 +88,12 @@ public:
 
   vector<sha256> getMerkleTree() { return m_merkle_tree; }
 
+  static bool isValidSiblings(proof_type &proof,
+                              const std::string &root_val_b64) {
+    return isValidSiblings(proof.siblings, proof.siblings[0].second,
+                           root_val_b64);
+  }
+
   static bool
   isValidSiblings(std::vector<std::pair<bool, std::string>> &siblings_b64,
                   const std::string &my_val_b64,

--- a/src/chain/types.hpp
+++ b/src/chain/types.hpp
@@ -5,6 +5,7 @@
 #include <botan-2/botan/secmem.h>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace gruut {
@@ -118,6 +119,11 @@ using header_length_type = uint32_t;
 using content_type = std::string;
 
 using hmac_key_type = Botan::secure_vector<uint8_t>;
+
+using proof_type = struct proof_t {
+  std::string block_id;
+  std::vector<std::pair<bool, std::string>> siblings;
+};
 
 // 아래는 모두 동일한 타입, 문맥에 맞춰서 쓸 것
 // 구별이 안되거나 혼용되어 있으면, id_type을 쓸 것

--- a/src/services/block_processor.cpp
+++ b/src/services/block_processor.cpp
@@ -104,11 +104,11 @@ bool BlockProcessor::handleMsgReqCheck(InputMsgEntry &entry) {
   merger_id_type my_mid = setting->getMyId();
   timestamp_type timestamp = Time::now_int();
 
-  std::vector<std::pair<bool, std::string>> siblings =
+  proof_type proof =
       m_storage->findSibling(entry.body["txid"].get<std::string>());
 
   json proof_json = json::array();
-  for (auto &sibling : siblings) {
+  for (auto &sibling : proof.siblings) {
     proof_json.push_back(
         nlohmann::json{{"side", sibling.first}, {"val", sibling.second}});
   }
@@ -116,6 +116,7 @@ bool BlockProcessor::handleMsgReqCheck(InputMsgEntry &entry) {
   msg_res_check.type = MessageType::MSG_RES_CHECK;
   msg_res_check.body["mID"] = TypeConverter::toBase64Str(my_mid);
   msg_res_check.body["time"] = to_string(timestamp);
+  msg_res_check.body["blockID"] = proof.block_id;
   msg_res_check.body["proof"] = proof_json;
 
   m_msg_proxy.deliverOutputMessage(msg_res_check);

--- a/src/services/storage.hpp
+++ b/src/services/storage.hpp
@@ -64,8 +64,7 @@ public:
                               const timestamp_type &at_this_time = 0);
   void deleteAllDirectory();
   std::tuple<int, std::string, json> readBlock(int height);
-  std::vector<std::pair<bool, std::string>>
-  findSibling(const std::string &tx_id);
+  proof_type findSibling(const std::string &tx_id);
 
 private:
   bool errorOnCritical(const leveldb::Status &status);

--- a/tests/services/test.cpp
+++ b/tests/services/test.cpp
@@ -219,16 +219,16 @@ BOOST_AUTO_TEST_SUITE(Test_Storage_Service)
 
   BOOST_AUTO_TEST_CASE(find_sibling) {
     StorageFixture storage_fixture;
-    std::vector<std::pair<bool,std::string>> siblings = storage_fixture.m_storage->findSibling("c");
+    proof_type proof = storage_fixture.m_storage->findSibling("c");
 
-    if(!siblings.empty()){
+    if(!proof.block_id.empty() || !proof.siblings.empty()){
 
-      BOOST_TEST(siblings[0].first == false);
-      BOOST_TEST(siblings[0].second == "U22Yg38t0WWlXV7q6RSFlURy1W8kbfJWvzyuGTUqEjw=");
+      BOOST_TEST(proof.siblings[0].first == false);
+      BOOST_TEST(proof.siblings[0].second == "U22Yg38t0WWlXV7q6RSFlURy1W8kbfJWvzyuGTUqEjw=");
 
       std::string root_val_b64 = TypeConverter::toBase64Str(storage_fixture.m_mtree_root_1);
 
-      BOOST_TEST(MerkleTree::isValidSiblings(siblings,siblings[0].second,root_val_b64));
+      BOOST_TEST(MerkleTree::isValidSiblings(proof,root_val_b64));
 
     } else
       BOOST_TEST("EMPTY");


### PR DESCRIPTION
### 수정 내역
- MSG_RES_CHECK에 block_id를 포함하도록 했음 (이게 없으면 merkle root를 알 수가 없음)
- 관련해서 storage 의 findSiblings의 리턴 타입이 복잡해서 proof_type을 정의했음
- 또 이와 관련해서 MerkleTree의 isValidSiblings의 인자를 proof_type을 받을 수 있도록 했음
- 테스트 코드도 같이 고침
- 컨플루언스에는 이미 반영