### PR TITLE
# EDIT - modified messages between mergers

### DIFF
--- a/src/chain/reverse_type.hpp
+++ b/src/chain/reverse_type.hpp
@@ -1,9 +1,0 @@
-#pragma once
-
-#include "types.hpp"
-
-class RType {
-  static ErrorMsgType getErrorType(const std::string &type) {
-
-  }
-};

--- a/src/chain/reverse_type.hpp
+++ b/src/chain/reverse_type.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "types.hpp"
+
+class RType {
+  static ErrorMsgType getErrorType(const std::string &type) {
+
+  }
+};

--- a/src/chain/types.hpp
+++ b/src/chain/types.hpp
@@ -70,8 +70,10 @@ enum class ErrorMsgType : int {
   ECDH_MAX_SIGNER_POOL,
   ECDH_TIMEOUT,
   ECDH_INVALID_SIG,
-  ECDH_INVALID_PK
+  ECDH_INVALID_PK,
+  BSYNC_NO_BLOCK
 };
+
 
 enum class CompressionAlgorithmType : uint8_t { LZ4 = 0x04, NONE = 0xFF };
 

--- a/src/chain/types.hpp
+++ b/src/chain/types.hpp
@@ -73,9 +73,9 @@ enum class ErrorMsgType : int {
   ECDH_TIMEOUT = 23,
   ECDH_INVALID_SIG = 24,
   ECDH_INVALID_PK = 25,
-  TIME_SYNC = 61
+  TIME_SYNC = 61,
+  BSYNC_NO_BLOCK = 88
 };
-
 
 enum class CompressionAlgorithmType : uint8_t { LZ4 = 0x04, NONE = 0xFF };
 

--- a/src/modules/bootstraper/block_synchronizer.hpp
+++ b/src/modules/bootstraper/block_synchronizer.hpp
@@ -80,6 +80,8 @@ private:
 
   void saveBlock(int height);
 
+  void syncFinish();
+
   void blockSyncControl();
 
   void messageFetch();

--- a/src/modules/bootstraper/boot_straper.hpp
+++ b/src/modules/bootstraper/boot_straper.hpp
@@ -41,13 +41,12 @@ private:
 
     cout << "BST: sendMsgUp()" << endl;
 
-    nlohmann::json msg_up;
-    msg_up["mID"] = TypeConverter::toBase64Str(m_my_id);
-    msg_up["time"] = Time::now();
-    msg_up["ver"] = to_string(1);
-    msg_up["cID"] = TypeConverter::toBase64Str(m_my_localchain_id);
-
-    OutputMsgEntry output_msg(MessageType::MSG_UP, msg_up);
+    OutputMsgEntry output_msg;
+    output_msg.type = MessageType::MSG_UP;
+    output_msg.body["mID"] = TypeConverter::toBase64Str(m_my_id);
+    output_msg.body["time"] = Time::now();
+    output_msg.body["ver"] = to_string(1);
+    output_msg.body["cID"] = TypeConverter::toBase64Str(m_my_localchain_id);
 
     m_msg_proxy.deliverOutputMessage(output_msg);
   }

--- a/src/modules/communication/merger_client.hpp
+++ b/src/modules/communication/merger_client.hpp
@@ -19,12 +19,14 @@ class MergerClient {
 public:
   MergerClient() { m_rpc_receiver_list = RpcReceiverList::getInstance(); }
   void sendMessage(MessageType msg_type, std::vector<id_type> &receiver_list,
-                   std::vector<std::string> &packed_msg_list);
+                   std::vector<std::string> &packed_msg_list,
+                   OutputMsgEntry &output_msg);
 
 private:
   RpcReceiverList *m_rpc_receiver_list;
 
-  void sendToSE(std::string &packed_msg);
+  void sendToSE(std::vector<id_type> &receiver_list,
+                OutputMsgEntry &output_msg);
 
   void sendToMerger(std::vector<id_type> &receiver_list,
                     std::string &packed_msg);

--- a/src/modules/communication/message_handler.cpp
+++ b/src/modules/communication/message_handler.cpp
@@ -87,7 +87,8 @@ void MessageHandler::packMsg(OutputMsgEntry &output_msg) {
   }
 
   MergerClient merger_client;
-  merger_client.sendMessage(msg_type, output_msg.receivers, packed_msg_list);
+  merger_client.sendMessage(msg_type, output_msg.receivers, packed_msg_list,
+                            output_msg);
 }
 
 bool MessageHandler::validateMsgFormat(MessageHeader &header) {

--- a/src/modules/communication/msg_schema.hpp
+++ b/src/modules/communication/msg_schema.hpp
@@ -365,13 +365,13 @@ const json SCHEMA_ERROR = R"({
     },
     "type": {
       "description": "Error Type",
-"type": "string"
-}
-},
-"required": [
-"sender",
-"time",
-"type"
+      "type": "string"
+    }
+  },
+  "required": [
+    "sender",
+    "time",
+    "type"
 ]
 })"_json;
 const json SCHEMA_TX = R"({

--- a/src/modules/communication/msg_schema.hpp
+++ b/src/modules/communication/msg_schema.hpp
@@ -6,24 +6,19 @@ namespace gruut {
 using nlohmann::json;
 const json SCHEMA_UP = R"({
   "title": "Up",
-  "description": "Merger가 Merger Network에 조인할 때",
   "type": "object",
   "properties": {
     "mID": {
-      "description": "송신자 Merger",
       "type": "string"
     },
     "time": {
-      "description": "송신 시간",
       "type": "string"
     },
     "ver": {
-      "description": "version",
-      "type": "string"
+       "type": "string"
     },
     "cID": {
-      "description": "local chain ID",
-      "type": "string"
+       "type": "string"
     }
   },
   "required": [
@@ -35,56 +30,45 @@ const json SCHEMA_UP = R"({
 })"_json;
 const json SCHEMA_PING = R"({
   "title": "Ping",
-  "description": "Merger가 살아있음을 알림",
   "type": "object",
   "properties": {
     "mID": {
-      "description": "송신자 Merger",
       "type": "string"
     },
     "time": {
-      "description": "송신 시간",
       "type": "string"
     },
     "sCnt": {
-      "description": "Merger가 연결하고 있는 Signer의 수",
-"type": "string"
-},
-"stat": {
-"description": "Merger's status",
-"type": "string"
-}
-},
-"required": [
-"mID",
-"time",
-"sCnt",
-"stat"
-]
+      "type": "string"
+    },
+    "stat": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "mID",
+    "time",
+    "sCnt",
+    "stat"
+  ]
 })"_json;
 const json SCHEMA_REQ_BLOCK = R"({
   "title": "block request",
-  "description": "블록 동기화를 위한 블록 요청",
   "type": "object",
   "properties": {
     "mID": {
-      "description": "송신자 Merger",
       "type": "string"
     },
     "time": {
-      "description": "송신 시간",
       "type": "string"
     },
     "mCert": {
-      "description": "인증서",
       "type": "string"
     },
     "hgt": {
-      "description": "block height",
       "type": "string"
     },
     "mSig": {
-      "description": "merger의 서명",
       "type": "string"
     }
   },
@@ -96,105 +80,89 @@ const json SCHEMA_REQ_BLOCK = R"({
     "mSig"
   ]
 })"_json;
-const json SCHEMA_ECHO = R"(
-            {
-                "title": "Echo",
-                        "description": "노드 간에 네트워크 유지를 위해 보내는 Echo",
-                        "type": "object",
-                        "properties": {
-                    "sender": {
-                        "description": "송신자",
-                                "type": "string"
-                    },
-                    "time": {
-                        "description": "송신 시간",
-                                "type": "string"
-                    }
-                },
-                "required": [
-                "sender",
-                "time"
-                ]
-            }
-            )"_json;
-const json SCHEMA_BLOCK = R"(
-			{
-			  "title": "Block",
-			  "description": "Merger가 브로드캐스팅할 블록",
-			  "type": "object",
-			  "properties": {
-                "mID": {
-                  "description": "sender's id",
-				  "type": "string"
-                },
-				"blockraw": {
-				  "description": "meta, compressed JSON, mSig",
-				  "type": "string"
-				},
-				"tx": {
-				  "description": "트랜잭션",
-				  "type": "array",
-				  "items": {
-						"type": "object",
-						"properties": {
-						  "txid": {
-							"type": "string"
-						  },
-						  "time": {
-							"type": "string"
-						  },
-						  "rID": {
-							"type": "string"
-						  },
-						  "type": {
-							"type": "string"
-						  },
-						  "content": {
-							"type": "array",
-							"item": {
-							  "type": "string"
-							}
-						  },
-						  "rSig": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "txid",
-						  "time",
-						  "rID",
-						  "type",
-						  "content",
-						  "rSig"
-						  ]
-				  }
-				}
-			  },
-			  "required": [
-				"blockraw",
-				"tx"
-			  ]
-			}
-            )"_json;
-const json SCHEMA_JOIN = R"({
-  "title": "Join",
-  "description": "Signer의 네트워크 참여 요청",
+const json SCHEMA_ECHO = R"({
+  "title": "Echo",
   "type": "object",
   "properties": {
-    "sID": {
-      "description": "송신자",
+    "sender": {
       "type": "string"
     },
     "time": {
-      "description": "송신 시간",
+      "type": "string"
+    }
+  },
+  "required": [
+    "sender",
+    "time"
+  ]
+})"_json;
+const json SCHEMA_BLOCK = R"({
+  "title": "Block",
+  "type": "object",
+  "properties": {
+    "mID": {
+      "type": "string"
+    },
+    "blockraw": {
+      "type": "string"
+    },
+    "tx": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "txid": {
+            "type": "string"
+          },
+          "time": {
+            "type": "string"
+          },
+          "rID": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "array",
+            "item": {
+              "type": "string"
+            }
+          },
+          "rSig": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "txid",
+          "time",
+          "rID",
+          "type",
+          "content",
+          "rSig"
+        ]
+      }
+    }
+  },
+  "required": [
+    "blockraw",
+    "tx"
+  ]
+})"_json;
+const json SCHEMA_JOIN = R"({
+  "title": "Join",
+  "type": "object",
+  "properties": {
+    "sID": {
+      "type": "string"
+    },
+    "time": {
       "type": "string"
     },
     "ver": {
-      "description": "version",
       "type": "string"
     },
     "cID": {
-      "description": "local chain ID",
       "type": "string"
     }
   },
@@ -207,35 +175,27 @@ const json SCHEMA_JOIN = R"({
 })"_json;
 const json SCHEMA_RESPONSE_FIRST = R"({
   "title": "Response 1 to Challenge",
-  "description": "Signer가 Merger에게 보내는 신원 검증 요청에 대한 응답",
   "type": "object",
   "properties": {
     "sID": {
-      "description": "송신자",
       "type": "string"
     },
     "time": {
-      "description": "송신 시간",
       "type": "string"
     },
      "cert": {
-      "description": "송신자의 인증서",
       "type": "string"
     },
     "sN": {
-      "description": "signer's random nonce",
       "type": "string"
     },
     "dhx": {
-      "description": "Diffie-Hellman public key x",
       "type": "string"
     },
     "dhy": {
-      "description": "Diffie-Hellman public key y",
       "type": "string"
     },
     "sig": {
-      "description": "Signer의 nonce, Merger의 nonce, dh1, time으로 만든 서명",
       "type": "string"
     }
   },
@@ -251,19 +211,15 @@ const json SCHEMA_RESPONSE_FIRST = R"({
 })"_json;
 const json SCHEMA_SUCCESS = R"({
   "title": "Success in Key Exchange",
-  "description": "Diffie–Hellman 키 교환의 성공을 알림",
   "type": "object",
   "properties": {
     "sID": {
-      "description": "송신자",
       "type": "string"
     },
     "time": {
-      "description": "송신 시간",
       "type": "string"
     },
      "val": {
-      "description": "성공 여부",
       "type": "boolean"
     }
   },
@@ -275,15 +231,12 @@ const json SCHEMA_SUCCESS = R"({
 })"_json;
 const json SCHEMA_LEAVE = R"({
   "title": "Echo",
-  "description": "노드 간에 네트워크 유지를 위해 보내는 Echo",
   "type": "object",
   "properties": {
     "sender": {
-      "description": "송신자",
       "type": "string"
     },
     "time": {
-      "description": "송신 시간",
       "type": "string"
     }
   },
@@ -294,27 +247,21 @@ const json SCHEMA_LEAVE = R"({
 })"_json;
 const json SCHEMA_REQ_SSIG = R"({
   "title": "Partial Block",
-  "description": "Merger가 Signer에게 서명을 요청하는 임시블록",
   "type": "object",
   "properties": {
     "time": {
-      "description": "송신 시간",
       "type": "string"
     },
     "mID": {
-      "description": "메시지 송신자",
       "type": "string"
     },
     "cID": {
-      "description": "chain ID",
       "type": "string"
     },
     "hgt": {
-      "description": "block height",
       "type": "string"
     },
     "txrt": {
-      "description": "transaction root",
       "type": "string"
     }
   },
@@ -328,19 +275,15 @@ const json SCHEMA_REQ_SSIG = R"({
 })"_json;
 const json SCHEMA_SSIG = R"({
   "title": "Signer's Signature",
-  "description": "Signer가 Merger에게 보내는 서명",
   "type": "object",
   "properties": {
     "sID": {
-      "description": "signer's ID",
       "type": "string"
     },
     "time": {
-      "description": "송신 시간",
       "type": "string"
     },
     "sig": {
-      "description": "signer's signature",
       "type": "string"
     }
   },
@@ -352,19 +295,18 @@ const json SCHEMA_SSIG = R"({
 })"_json;
 const json SCHEMA_ERROR = R"({
   "title": "Error",
-  "description": "요청 거부 및 오류",
   "type": "object",
   "properties": {
     "sender": {
-      "description": "송신자",
       "type": "string"
     },
     "time": {
-      "description": "송신 시간",
       "type": "string"
     },
-    "type": {
-      "description": "Error Type",
+    "code": {
+      "type": "string"
+    },
+    "info": {
       "type": "string"
     }
   },
@@ -376,34 +318,27 @@ const json SCHEMA_ERROR = R"({
 })"_json;
 const json SCHEMA_TX = R"({
   "title": "Transaction",
-  "description": "트랜잭션",
   "type": "object",
   "properties": {
     "txid": {
-      "description": "transaction ID",
       "type": "string"
     },
     "time": {
-      "description": "송신 시간",
       "type": "string"
     },
     "rID": {
-      "description": "requestor's ID",
       "type": "string"
     },
     "type": {
-      "description": "트랜잭션 타입",
       "type": "string"
     },
     "content": {
-      "description": "트랜잭션 내용. 체크섬 혹은 Signer의 인증서",
       "type": "array",
       "item": {
         "type": "string"
       }
     },
     "rSig": {
-      "description": "requestor's signature",
       "type": "string"
     }
   },
@@ -424,6 +359,7 @@ public:
 private:
   static std::map<MessageType, json> schema_list;
 };
+
 std::map<MessageType, json> MessageSchema::schema_list = {
     {MessageType::MSG_UP, SCHEMA_UP},
     {MessageType::MSG_PING, SCHEMA_PING},
@@ -438,4 +374,5 @@ std::map<MessageType, json> MessageSchema::schema_list = {
     {MessageType::MSG_SSIG, SCHEMA_SSIG},
     {MessageType::MSG_ERROR, SCHEMA_ERROR},
     {MessageType::MSG_TX, SCHEMA_TX}};
+
 }; // namespace gruut

--- a/src/modules/communication/msg_schema.hpp
+++ b/src/modules/communication/msg_schema.hpp
@@ -123,6 +123,10 @@ const json SCHEMA_BLOCK = R"(
 			  "description": "Merger가 브로드캐스팅할 블록",
 			  "type": "object",
 			  "properties": {
+                "mID": {
+                  "description": "sender's id",
+				  "type": "string"
+                },
 				"blockraw": {
 				  "description": "meta, compressed JSON, mSig",
 				  "type": "string"

--- a/src/modules/message_fetcher/message_fetcher.cpp
+++ b/src/modules/message_fetcher/message_fetcher.cpp
@@ -40,7 +40,7 @@ void MessageFetcher::fetch() {
       fetch();
     } else {
       std::cout << "ERROR: " << ec.message() << std::endl;
-      throw;
+      // throw;
     }
   });
 }

--- a/src/modules/message_fetcher/out_message_fetcher.cpp
+++ b/src/modules/message_fetcher/out_message_fetcher.cpp
@@ -38,7 +38,7 @@ void OutMessageFetcher::fetch() {
       fetch();
     } else {
       std::cout << "ERROR: " << ec.message() << std::endl;
-      throw;
+      // throw;
     }
   });
 }

--- a/src/services/block_generator.cpp
+++ b/src/services/block_generator.cpp
@@ -74,6 +74,8 @@ void BlockGenerator::generateBlock(PartialBlock partial_block,
   auto block_id =
       static_cast<block_id_type>(Sha256::hash(block_id_builder.getString()));
 
+  std::string my_id_b64 = TypeConverter::toBase64Str(partial_block.merger_id);
+
   // step 2) making block_header (JSON)
 
   json block_header;
@@ -103,7 +105,7 @@ void BlockGenerator::generateBlock(PartialBlock partial_block,
         TypeConverter::toBase64Str(support_sigs[i].signer_signature);
   }
 
-  block_header["mID"] = TypeConverter::toBase64Str(partial_block.merger_id);
+  block_header["mID"] = my_id_b64;
 
   // step-3) making block_raw with mSig
 
@@ -167,6 +169,7 @@ void BlockGenerator::generateBlock(PartialBlock partial_block,
 
   OutputMsgEntry msg_block_msg;
   msg_block_msg.type = MessageType::MSG_BLOCK; // MSG_BLOCK = 0xB4
+  msg_block_msg.body["mID"] = my_id_b64;
   msg_block_msg.body["blockraw"] = block_raw_b64;
   msg_block_msg.body["tx"] = block_body["tx"];
   msg_block_msg.receivers = vector<id_type>{};

--- a/src/services/block_processor.cpp
+++ b/src/services/block_processor.cpp
@@ -46,15 +46,18 @@ bool BlockProcessor::handleMsgReqBlock(InputMsgEntry &entry) {
   auto saved_block =
       m_storage->readBlock(stoi(entry.body["hgt"].get<std::string>()));
 
-  id_type recv_id = TypeConverter::decodeBase64(entry.body["mID"].get<std::string>());
+  id_type recv_id =
+      TypeConverter::decodeBase64(entry.body["mID"].get<std::string>());
 
   if (std::get<0>(saved_block) < 0) {
 
     OutputMsgEntry output_message;
     output_message.type = MessageType::MSG_ERROR;
-    output_message.body["sender"] = TypeConverter::toBase64Str(m_my_id); // my_id
+    output_message.body["sender"] =
+        TypeConverter::toBase64Str(m_my_id); // my_id
     output_message.body["time"] = Time::now();
-    output_message.body["type"] = std::to_string(static_cast<int>(ErrorMsgType::BSYNC_NO_BLOCK));
+    output_message.body["type"] =
+        std::to_string(static_cast<int>(ErrorMsgType::BSYNC_NO_BLOCK));
     output_message.body["info"] = "no block!";
     output_message.receivers = {recv_id};
 

--- a/src/services/block_processor.cpp
+++ b/src/services/block_processor.cpp
@@ -68,6 +68,7 @@ bool BlockProcessor::handleMsgReqBlock(InputMsgEntry &entry) {
 
   OutputMsgEntry msg_block;
   msg_block.type = MessageType::MSG_BLOCK;
+  msg_block.body["mID"] = TypeConverter::toBase64Str(m_my_id);
   msg_block.body["blockraw"] =
       TypeConverter::toBase64Str(std::get<1>(saved_block));
   msg_block.body["tx"] = std::get<2>(saved_block);

--- a/src/services/block_processor.hpp
+++ b/src/services/block_processor.hpp
@@ -28,6 +28,7 @@ class BlockProcessor {
 private:
   MessageProxy m_msg_proxy;
   Storage *m_storage;
+  merger_id_type m_my_id;
 
 public:
   BlockProcessor();


### PR DESCRIPTION
### 수정내역
- MSG_REQ_BLOCK(-1)이 왔을 때, 지금까지 생성된 블록이 없다면 MSG_ERROR(88)를 보내 부트스트래핑을 바로 끝내게 함. (만약  BLOCK을 보내는 머저가 있다면, 이는 Queue에 쌓여 block processor가 처리할 것)
- MSG_ERROR가 모든 참여자에게 전송받을 수 있게 수정
- MSG_BLOCK에 mID를 추가하여 보낸 merger를 특정할 수 있게 함
- 스키마에서 필요없는 description 삭제 및 정리