### PR TITLE
 # ADD - Message Validator 추가

### DIFF
--- a/src/chain/types.hpp
+++ b/src/chain/types.hpp
@@ -101,6 +101,33 @@ enum class ExitCode {
   ERROR_SKIP_STAGE
 };
 
+enum class EntryName {
+  S_ID,
+  TIME,
+  C_ID,
+  SN,
+  DHX,
+  DHY,
+  TX_ID,
+  R_ID,
+  TYPE,
+  M_ID,
+  S_CNT,
+  SENDER,
+  D_ID,
+  HGT,
+  CONTENT,
+  TX
+};
+
+enum class EntryLength : int {
+  ID = 12,        // AAAAAAAAAAE=
+  SIG_NONCE = 44, // luLSQgVDnMyZjkAh8h2HNokaY1Oe9Md6a4VpjcdGgzs=
+  DIFFIE_HELLMAN =
+      64, // 92943e52e02476bd1a4d74c2498db3b01c204f29a32698495b4ed0a274e12294
+  TX_ID = 44, // Sv0pJ9tbpvFJVYCE3HaCRZSKFkX6Z9M8uKaI+Y6LtVg=
+};
+
 using sha256 = std::vector<uint8_t>;
 using bytes = std::vector<uint8_t>;
 using timestamp_type = uint64_t;

--- a/src/services/message_proxy.cpp
+++ b/src/services/message_proxy.cpp
@@ -3,6 +3,7 @@
 #include "../application.hpp"
 #include "../chain/message.hpp"
 #include "../chain/types.hpp"
+#include "message_validator.hpp"
 
 using namespace nlohmann;
 
@@ -18,31 +19,33 @@ void MessageProxy::deliverInputMessage(InputMsgEntry &input_message) {
   auto message_type = input_message.type;
   auto message_body_json = input_message.body;
 
-  switch (message_type) {
-  case MessageType::MSG_JOIN:
-  case MessageType::MSG_RESPONSE_1:
-  case MessageType::MSG_SUCCESS: {
-    Application::app().getSignerPoolManager().handleMessage(message_type,
-                                                            message_body_json);
-  } break;
-  case MessageType::MSG_TX: {
-    Application::app().getTransactionCollector().handleMessage(
-        message_body_json);
-  } break;
-  case MessageType::MSG_SSIG: {
-    Application::app().getSignaturePool().handleMessage(message_body_json);
-  } break;
-  case MessageType::MSG_PING:
-  case MessageType::MSG_UP: {
-    Application::app().getBpScheduler().handleMessage(input_message);
-  } break;
-  case MessageType::MSG_REQ_CHECK:
-  case MessageType::MSG_BLOCK:
-  case MessageType::MSG_REQ_BLOCK: {
-    Application::app().getBlockProcessor().handleMessage(input_message);
-  } break;
-  default:
-    break;
+  if (MessageValidator::validate(message_type, message_body_json)) {
+    switch (message_type) {
+    case MessageType::MSG_JOIN:
+    case MessageType::MSG_RESPONSE_1:
+    case MessageType::MSG_SUCCESS: {
+      Application::app().getSignerPoolManager().handleMessage(
+          message_type, message_body_json);
+    } break;
+    case MessageType::MSG_TX: {
+      Application::app().getTransactionCollector().handleMessage(
+          message_body_json);
+    } break;
+    case MessageType::MSG_SSIG: {
+      Application::app().getSignaturePool().handleMessage(message_body_json);
+    } break;
+    case MessageType::MSG_PING:
+    case MessageType::MSG_UP: {
+      Application::app().getBpScheduler().handleMessage(input_message);
+    } break;
+    case MessageType::MSG_REQ_CHECK:
+    case MessageType::MSG_BLOCK:
+    case MessageType::MSG_REQ_BLOCK: {
+      Application::app().getBlockProcessor().handleMessage(input_message);
+    } break;
+    default:
+      break;
+    }
   }
 }
 

--- a/src/services/message_validator.hpp
+++ b/src/services/message_validator.hpp
@@ -1,9 +1,205 @@
 #ifndef GRUUT_ENTERPRISE_MERGER_MESSAGE_VALIDATOR_HPP
 #define GRUUT_ENTERPRISE_MERGER_MESSAGE_VALIDATOR_HPP
+#include "../chain/types.hpp"
+#include "../config/config.hpp"
+#include "../utils/time.hpp"
+#include "nlohmann/json.hpp"
 
 namespace gruut {
+using namespace nlohmann;
+using namespace std;
+
+const map<EntryName, string> ENTRY_NAME_TO_STRING = {
+    {EntryName::S_ID, "sID"},        {EntryName::TIME, "time"},
+    {EntryName::C_ID, "cID"},        {EntryName::SN, "sN"},
+    {EntryName::DHX, "dhx"},         {EntryName::DHY, "dhy"},
+    {EntryName::TX_ID, "txid"},      {EntryName::R_ID, "rID"},
+    {EntryName::TYPE, "type"},       {EntryName::M_ID, "mID"},
+    {EntryName::S_CNT, "sCnt"},      {EntryName::SENDER, "sender"},
+    {EntryName::D_ID, "dID"},        {EntryName::HGT, "hgt"},
+    {EntryName::CONTENT, "content"}, {EntryName::TX, "tx"}};
+
+const vector<EntryName> MSG_JOIN_INFO = {EntryName::S_ID, EntryName::TIME,
+                                         EntryName::C_ID};
+const vector<EntryName> MSG_RESPONSE_1_INFO = {EntryName::S_ID, EntryName::TIME,
+                                               EntryName::SN, EntryName::DHX,
+                                               EntryName::DHY};
+const vector<EntryName> MSG_SUCCESS_INFO = {EntryName::S_ID, EntryName::TIME};
+const vector<EntryName> MSG_TX_INFO = {EntryName::TX_ID, EntryName::TIME,
+                                       EntryName::R_ID, EntryName::TYPE,
+                                       EntryName::CONTENT};
+const vector<EntryName> MSG_SSIG_INFO = {EntryName::S_ID, EntryName::TIME};
+const vector<EntryName> MSG_PING_INFO = {EntryName::M_ID, EntryName::TIME,
+                                         EntryName::S_CNT};
+const vector<EntryName> MSG_UP_INFO = {EntryName::M_ID, EntryName::TIME,
+                                       EntryName::C_ID};
+const vector<EntryName> MSG_REQ_CHECK_INFO = {
+    EntryName::SENDER, EntryName::TIME, EntryName::D_ID, EntryName::TX_ID};
+const vector<EntryName> MSG_BLOCK_INFO = {EntryName::M_ID, EntryName::TX};
+const vector<EntryName> MSG_REQ_BLOCK_INFO = {EntryName::M_ID, EntryName::TIME,
+                                              EntryName::HGT};
+
 class MessageValidator {
-  static bool validate() { return true; }
+public:
+  static string getEntryName(EntryName entry_name) {
+    string name;
+    auto it_map = ENTRY_NAME_TO_STRING.find(entry_name);
+    if (it_map != ENTRY_NAME_TO_STRING.end())
+      name = it_map->second;
+    return name;
+  }
+
+  inline static bool idValidate(const string &id) {
+    return id.length() == static_cast<int>(EntryLength::ID);
+  }
+
+  inline static bool txIdValidate(const string &txid) {
+    return txid.length() == static_cast<int>(EntryLength::TX_ID);
+  }
+
+  inline static bool signerNonceValidate(const string &s_n) {
+    return s_n.length() == static_cast<int>(EntryLength::SIG_NONCE);
+  }
+
+  inline static bool diffieHellmanValidate(const string &dh) {
+    return dh.length() == static_cast<int>(EntryLength::DIFFIE_HELLMAN);
+  }
+
+  inline static bool typeValidate(const string &type) {
+    return (type == TXTYPE_CERTIFICATES || type == TXTYPE_DIGESTS);
+  }
+
+  inline static bool signerCountValidate(const string &my_signer_cnt) {
+    return ((0 < stoi(my_signer_cnt)) &&
+            (stoi(my_signer_cnt) <= config::MAX_SIGNER_NUM));
+  }
+
+  inline static bool heightValidate(const string &hgt) {
+    return (stoi(hgt) == -1 || stoi(hgt) > 0);
+  }
+
+  static bool timeValidate(MessageType message_type, const string &my_time) {
+    auto time_difference = abs(stoll(my_time) - stoll(Time::now()));
+    switch (message_type) {
+    case MessageType::MSG_JOIN:
+      return (0 <= time_difference &&
+              time_difference < config::JOIN_TIMEOUT_SEC);
+    default:
+      return (0 <= time_difference && time_difference < config::MAX_WAIT_TIME);
+    }
+  }
+
+  static bool contentIdValidate(json content_json) {
+    for (size_t i = 0; i < content_json.size(); i += 2) {
+      if (!idValidate(content_json[i].get<string>()))
+        return false;
+    }
+    return true;
+  }
+
+  static bool entryValidate(MessageType message_type,
+                            vector<EntryName> message_type_info,
+                            json message_body_json) {
+    for (auto &item : message_type_info) {
+      string entry_name = getEntryName(item);
+      if (entry_name.empty())
+        return false;
+
+      if (item == EntryName::CONTENT) { // MSG_TX의 content 처리
+        if (!contentIdValidate(message_body_json[entry_name]))
+          return false;
+        else
+          continue;
+      }
+
+      if (item == EntryName::TX) { // MSG_BLOCK의 tx 처리
+        for (size_t i = 0; i < message_body_json[entry_name].size(); ++i) {
+          if (!entryValidate(message_type, MSG_TX_INFO,
+                             message_body_json[entry_name][i]))
+            return false;
+        }
+        continue;
+      }
+
+      string entry_value = message_body_json[entry_name].get<string>();
+      if (entry_value.empty())
+        return false;
+
+      bool is_entry_valid = true;
+      switch (item) {
+      case EntryName::S_ID:
+      case EntryName::C_ID:
+      case EntryName::SENDER:
+      case EntryName::D_ID:
+      case EntryName::R_ID:
+      case EntryName::M_ID:
+        is_entry_valid = idValidate(entry_value);
+        break;
+      case EntryName::TX_ID:
+        is_entry_valid = txIdValidate(entry_value);
+        break;
+      case EntryName::TIME:
+        is_entry_valid = timeValidate(message_type, entry_value);
+        break;
+      case EntryName::SN:
+        is_entry_valid = signerNonceValidate(entry_value);
+        break;
+      case EntryName::DHX:
+      case EntryName::DHY:
+        is_entry_valid = diffieHellmanValidate(entry_value);
+        break;
+      case EntryName::TYPE:
+        is_entry_valid = typeValidate(entry_value);
+        break;
+      case EntryName::S_CNT:
+        is_entry_valid = signerCountValidate(entry_value);
+        break;
+      case EntryName::HGT:
+        is_entry_valid = heightValidate(entry_value);
+        break;
+      default:
+        break;
+      }
+      if (!is_entry_valid)
+        return false;
+    }
+    return true;
+  }
+
+  static bool validate(MessageType message_type, json message_body_json) {
+    switch (message_type) {
+    case MessageType::MSG_JOIN:
+      return entryValidate(MessageType::MSG_JOIN, MSG_JOIN_INFO,
+                           message_body_json);
+    case MessageType::MSG_RESPONSE_1:
+      return entryValidate(MessageType::MSG_RESPONSE_1, MSG_RESPONSE_1_INFO,
+                           message_body_json);
+    case MessageType::MSG_SUCCESS:
+      return entryValidate(MessageType::MSG_SUCCESS, MSG_SUCCESS_INFO,
+                           message_body_json);
+    case MessageType::MSG_TX:
+      return entryValidate(MessageType::MSG_TX, MSG_TX_INFO, message_body_json);
+    case MessageType::MSG_SSIG:
+      return entryValidate(MessageType::MSG_SSIG, MSG_SSIG_INFO,
+                           message_body_json);
+    case MessageType::MSG_PING:
+      return entryValidate(MessageType::MSG_PING, MSG_PING_INFO,
+                           message_body_json);
+    case MessageType::MSG_UP:
+      return entryValidate(MessageType::MSG_UP, MSG_UP_INFO, message_body_json);
+    case MessageType::MSG_REQ_CHECK:
+      return entryValidate(MessageType::MSG_REQ_CHECK, MSG_REQ_CHECK_INFO,
+                           message_body_json);
+    case MessageType::MSG_BLOCK:
+      return entryValidate(MessageType::MSG_BLOCK, MSG_BLOCK_INFO,
+                           message_body_json);
+    case MessageType::MSG_REQ_BLOCK:
+      return entryValidate(MessageType::MSG_REQ_BLOCK, MSG_REQ_BLOCK_INFO,
+                           message_body_json);
+    default:
+      return true;
+    }
+  }
 };
 } // namespace gruut
 #endif

--- a/src/services/message_validator.hpp
+++ b/src/services/message_validator.hpp
@@ -90,6 +90,8 @@ public:
   }
 
   static bool contentIdValidate(json content_json) {
+    if (!content_json.is_array())
+      return false;
     for (size_t i = 0; i < content_json.size(); i += 2) {
       if (!idValidate(content_json[i].get<string>()))
         return false;
@@ -113,6 +115,8 @@ public:
       }
 
       if (item == EntryName::TX) { // MSG_BLOCK의 tx 처리
+        if (!message_body_json[entry_name].is_array())
+          return false;
         for (size_t i = 0; i < message_body_json[entry_name].size(); ++i) {
           if (!entryValidate(message_type, MSG_TX_INFO,
                              message_body_json[entry_name][i]))
@@ -121,7 +125,9 @@ public:
         continue;
       }
 
-      string entry_value = message_body_json[entry_name].get<string>();
+      string entry_value = message_body_json[entry_name].empty()
+                               ? ""
+                               : message_body_json[entry_name].get<string>();
       if (entry_value.empty())
         return false;
 

--- a/tests/services/test.cpp
+++ b/tests/services/test.cpp
@@ -13,6 +13,7 @@
 #include "../../src/services/block_generator.hpp"
 #include "../../src/services/input_queue.hpp"
 #include "../../src/services/output_queue.hpp"
+#include "../../src/services/message_validator.hpp"
 
 #include "../../src/utils/compressor.hpp"
 #include "../../src/utils/type_converter.hpp"
@@ -277,6 +278,141 @@ BOOST_AUTO_TEST_SUITE(Test_BlockGenerator_for_storage)
     BOOST_CHECK_EQUAL(tx_id, encoded_tx_id);
 
     storage->deleteAllDirectory();
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(Test_MessageValidator)
+  BOOST_AUTO_TEST_CASE(validate) {
+    json msg_join_json = R"({
+      "sID": "UAABACACAAE=",
+      "time": "1543323592",
+      "ver": "1020181127",
+      "cID": "AAAAAAAAAAE="
+    })"_json;
+    msg_join_json["time"] = Time::now();
+
+    json msg_response_1_json = R"({
+      "sID": "UAABACACAAE=",
+      "time": "1543323592",
+      "cert": "-----BEGIN CERTIFICATE-----\nMIIDLDCCAhQCBgEZlK1CPjA....\n-----END CERTIFICATE-----",
+      "sN": "luLSQgVDnMyZjkAh8h2HNokaY1Oe9Md6a4VpjcdGgzs=",
+      "dhx": "92943e52e02476bd1a4d74c2498db3b01c204f29a32698495b4ed0a274e12294",
+      "dhy": "96e2d24205439ccc998e4021f21d8736891a63539ef4c77a6b85698dc746833b",
+      "sig": "QWVMP1UfUJIemaLFqnXvQfGqghVCmYH0yXo1/g5hUWAbouuXdTI/O7Gkgz3C5kXhnIWZ+dHp...."
+    })"_json;
+    msg_response_1_json["time"] = Time::now();
+
+    json msg_success_json = R"({
+      "sID": "UAABACACAAE=",
+      "time": "1543323592",
+      "val": true
+    })"_json;
+    msg_success_json["time"] = Time::now();
+
+    json msg_tx_json = R"({
+      "txid": "Sv0pJ9tbpvFJVYCE3HaCRZSKFkX6Z9M8uKaI+Y6LtVg=",
+      "time": "1543323592",
+      "rID": "AAAAAAAAAAE=",
+      "type": "CERTIFICATES",
+      "content": [
+          "UAABACACAAE=","-----BEGIN CERTIFICATE-----\n....\n-----END CERTIFICATE-----",
+          "UAABACACEAE=","-----BEGIN CERTIFICATE-----\n....\n-----END CERTIFICATE-----",
+          "UAABACCCAAE=","-----BEGIN CERTIFICATE-----\n....\n-----END CERTIFICATE-----"
+      ],
+      "rSig": "SM49AwEHA0IABBXqXQz72KPYPp9lwiQeqKaO9MF313icIj8GC2Il0Cy6QuDAiEC....."
+    })"_json;
+    msg_tx_json["time"] = Time::now();
+
+    json msg_ssig_json = R"({
+      "sID": "UAABACACAAE=",
+      "time": "1543323592",
+      "sig": "QWVMP1UfUJIemaLFqnXvQfGqghVCmYH0yXo1/g5hUWAbouuXdTI/O7Gkgz3C5kXhnIWZ+dHp...."
+    })"_json;
+    msg_ssig_json["time"] = Time::now();
+
+    json msg_ping_json = R"({
+      "mID": "AAAAAAAAAAE=",
+      "time": "1543323592",
+      "sCnt": "25",
+      "stat": "p"
+    })"_json;
+    msg_ping_json["time"] = Time::now();
+
+    json msg_up_json = R"({
+      "mID": "AAAAAAAAAAE=",
+      "time": "1543323592",
+      "ver": "1020181127",
+      "cID": "AAAAAAAAAAE="
+    })"_json;
+    msg_up_json["time"] = Time::now();
+
+    json msg_req_check_json = R"({
+      "sender": "AAAAAAAAAAE=",
+      "time": "1543323592",
+      "dID": "AAAAAAAAAAE=",
+      "txid": "Sv0pJ9tbpvFJVYCE3HaCRZSKFkX6Z9M8uKaI+Y6LtVg="
+    })"_json;
+    msg_req_check_json["time"] = Time::now();
+
+    json msg_block_json = R"({
+      "mID": "AAAAAAAAAAE=",
+      "blockraw": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "tx":[
+        {
+          "txid": "Sv0pJ9tbpvFJVYCE3HaCRZSKFkX6Z9M8uKaI+Y6LtVg=",
+          "time": "1543323592",
+          "rID": "AAAAAAAAAAE=",
+          "type": "CERTIFICATES",
+          "content": [
+            "UAABACACAAE=","-----BEGIN CERTIFICATE-----\n....\n-----END CERTIFICATE-----",
+            "UAABACACEAE=","-----BEGIN CERTIFICATE-----\n....\n-----END CERTIFICATE-----",
+            "UAABACCCAAE=","-----BEGIN CERTIFICATE-----\n....\n-----END CERTIFICATE-----"
+          ],
+          "rSig": "SM49AwEHA0IABBXqXQz72KPYPp9lwiQeqKaO9MF313icIj8GC2Il0Cy6QuDAiEC....."
+        },
+        {
+          "txid": "Av0pJ9tbpvFJVYCE3HaCRZSKFkX6Z9M8uKaI+Y6LtVg=",
+          "time": "1543323592",
+          "rID": "AAAAAAAAAAE=",
+          "type": "CERTIFICATES",
+          "content": [
+            "UAABACACAAE=","-----BEGIN CERTIFICATE-----\n....\n-----END CERTIFICATE-----",
+            "UAABACACEAE=","-----BEGIN CERTIFICATE-----\n....\n-----END CERTIFICATE-----",
+            "UAABACCCAAE=","-----BEGIN CERTIFICATE-----\n....\n-----END CERTIFICATE-----"
+          ],
+          "rSig": "SM49AwEHA0IABBXqXQz72KPYPp9lwiQeqKaO9MF313icIj8GC2Il0Cy6QuDAiEC....."
+        }
+      ]
+    })"_json;
+    msg_block_json["tx"][0]["time"] = Time::now();
+    msg_block_json["tx"][1]["time"] = Time::now();
+
+    json msg_req_block_json = R"({
+      "mID": "AAAAAAAAAAE=",
+      "time": "1543323592",
+      "mCert": "-----BEGIN CERTIFICATE-----\nMIIDLDCCAhQCBgEZlK1CPjA....\n-----END CERTIFICATE-----",
+      "hgt": "-1",
+      "mSig": "vQPcP1sloKtQzEP+cOgYwbf0F3QhblPsABOtJrq8nNAEXtibe5J/9B4d4t920JLnQsbZtSMHo...."
+    })"_json;
+    msg_req_block_json["time"] = Time::now();
+
+    BOOST_CHECK_EQUAL(MessageValidator::validate(MessageType::MSG_JOIN, msg_join_json), true);
+    BOOST_CHECK_EQUAL(MessageValidator::validate(MessageType::MSG_RESPONSE_1, msg_response_1_json), true);
+    BOOST_CHECK_EQUAL(MessageValidator::validate(MessageType::MSG_SUCCESS, msg_success_json), true);
+    BOOST_CHECK_EQUAL(MessageValidator::validate(MessageType::MSG_TX, msg_tx_json), true);
+    BOOST_CHECK_EQUAL(MessageValidator::validate(MessageType::MSG_SSIG, msg_ssig_json), true);
+    BOOST_CHECK_EQUAL(MessageValidator::validate(MessageType::MSG_PING, msg_ping_json), true);
+    BOOST_CHECK_EQUAL(MessageValidator::validate(MessageType::MSG_UP, msg_up_json), true);
+    BOOST_CHECK_EQUAL(MessageValidator::validate(MessageType::MSG_REQ_CHECK, msg_req_check_json), true);
+    BOOST_CHECK_EQUAL(MessageValidator::validate(MessageType::MSG_BLOCK, msg_block_json), true);
+    BOOST_CHECK_EQUAL(MessageValidator::validate(MessageType::MSG_REQ_BLOCK, msg_req_block_json), true);
+
+    msg_join_json["time"] = to_string(stoll(Time::now()) + config::JOIN_TIMEOUT_SEC);
+    BOOST_CHECK_EQUAL(MessageValidator::validate(MessageType::MSG_JOIN, msg_join_json), false);
+
+    msg_response_1_json["time"] = to_string(stoll(Time::now()) + config::MAX_WAIT_TIME);
+    BOOST_CHECK_EQUAL(MessageValidator::validate(MessageType::MSG_RESPONSE_1, msg_response_1_json), false);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
 - 각 메시지에 대한 JSON Entry 검사
 - ID, Signer Nonce, Diffie Hellman, TX ID의 경우 길이가 정해져 있으므로
enum class로 생성 후 길이가 동일하면 true
 - Type은 CERTIFICATES / DIGESTS 가 맞다면 true
 - Signer Count는 0 < signer_count <= config::MAX_SIGNER_NUM(200)면 true
 - Height는 height == -1 || height > 0면 true
 - Time은
   1. MSG_JOIN은 시간차(현재시간-["time"])가 config::JOIN_TIMEOUT_SEC(10초)면 true
   2. 나머지 MSG는 시간차(현재시간-["time"])가 config::MAX_WAIT_TIME(5초)면 true
 - 실패하는 테스트 케이스 추가
