### PR TITLE
# FIX - Storage, Block Generator, Message Validator 오류 수정

### DIFF
--- a/src/services/block_generator.cpp
+++ b/src/services/block_generator.cpp
@@ -64,7 +64,8 @@ void BlockGenerator::generateBlock(PartialBlock partial_block,
     prev_header_hash_b64 = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
   } else {
     prev_header_id_b64 = std::get<0>(latest_block_info);
-    prev_header_hash_b64 = std::get<1>(latest_block_info);
+    prev_header_hash_b64 =
+        TypeConverter::toBase64Str(std::get<1>(latest_block_info));
   }
 
   std::vector<transaction_id_type> transaction_ids;

--- a/src/services/message_validator.hpp
+++ b/src/services/message_validator.hpp
@@ -89,11 +89,11 @@ public:
     }
   }
 
-  static bool contentIdValidate(json content_json) {
+  static bool contentIdValidate(json &content_json) {
     if (!content_json.is_array())
       return false;
-    for (size_t i = 0; i < content_json.size(); i += 2) {
-      if (!idValidate(content_json[i].get<string>()))
+    for (size_t i = 0; i < content_json.size(); ++i) {
+      if (!content_json[i].is_string())
         return false;
     }
     return true;
@@ -101,7 +101,7 @@ public:
 
   static bool entryValidate(MessageType message_type,
                             vector<EntryName> message_type_info,
-                            json message_body_json) {
+                            json &message_body_json) {
     for (auto &item : message_type_info) {
       string entry_name = getEntryName(item);
       if (entry_name.empty())
@@ -172,7 +172,7 @@ public:
     return true;
   }
 
-  static bool validate(MessageType message_type, json message_body_json) {
+  static bool validate(MessageType message_type, json &message_body_json) {
     switch (message_type) {
     case MessageType::MSG_JOIN:
       return entryValidate(MessageType::MSG_JOIN, MSG_JOIN_INFO,

--- a/src/services/storage.cpp
+++ b/src/services/storage.cpp
@@ -52,7 +52,7 @@ Storage::~Storage() {
 
 bool Storage::saveBlock(bytes &block_raw, json &block_header,
                         json &block_body) {
-  string block_id = block_header["bID"];
+  string block_id = block_header["bID"].get<string>();
 
   if (putBlockHeader(block_header, block_id) &&
       putBlockHeight(block_header, block_id) &&


### PR DESCRIPTION
1. Storage
 - Block ID(JSON)의 type error
 - .get<'string'>()이 빠져서 추가함

2. Block Generator
 - 블록헤더의 해시의 type error
 - 해시는 raw 데이터 형태인데 그대로 저장하다보니 invalid UTF-8 문제 발생
 - raw데이터를 base64로 변환하여 저장


3. Message Validator
 - Content validate 오류
 - CERTIFICATES만 체크하고 있어서 DIGESTS일 때 문제가 발생함
 - content의 원소들이 string인지만 체크

