### PR TITLE
 # EDIT - Rpc Health check 수정

### DIFF
--- a/src/modules/communication/merger_client.hpp
+++ b/src/modules/communication/merger_client.hpp
@@ -2,6 +2,7 @@
 
 #include "../../services/output_queue.hpp"
 #include "connection_list.hpp"
+#include "protos/health.grpc.pb.h"
 #include "protos/protobuf_merger.grpc.pb.h"
 #include "protos/protobuf_se.grpc.pb.h"
 #include "protos/protobuf_signer.grpc.pb.h"
@@ -9,6 +10,7 @@
 #include <boost/asio.hpp>
 #include <grpc/support/log.h>
 #include <grpcpp/grpcpp.h>
+#include <grpcpp/health_check_service_interface.h>
 #include <iostream>
 #include <memory>
 using namespace grpc;

--- a/src/modules/communication/merger_server.cpp
+++ b/src/modules/communication/merger_server.cpp
@@ -12,12 +12,16 @@ void MergerServer::runServer(const std::string &port_num) {
   server_address += port_num;
   ServerBuilder builder;
 
+  EnableDefaultHealthCheckService(true);
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
   builder.RegisterService(&m_merger_service);
   builder.RegisterService(&m_se_service);
   builder.RegisterService(&m_signer_service);
   m_completion_queue = builder.AddCompletionQueue();
   m_server = builder.BuildAndStart();
+
+  HealthCheckServiceInterface *hc_service = m_server->GetHealthCheckService();
+  hc_service->SetServingStatus("healthy_service", true);
 
   m_is_started = true;
 

--- a/src/modules/communication/merger_server.hpp
+++ b/src/modules/communication/merger_server.hpp
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <grpc/support/log.h>
 #include <grpcpp/grpcpp.h>
+#include <grpcpp/health_check_service_interface.h>
 #include <iostream>
 #include <memory>
 


### PR DESCRIPTION
 ### 문제점
- Rpc Channel을 열어 state를 통해 Server의 상태를 확인하려 했으나
server의 상태와 관계없이 status가 IDLE이 나타남. 따라서 Server의 상태에 관계없이 connection list 에서 true값을 setting 함.

 ### 해결
- 기존에 사용하려고 했던 Rpc Health check protocol 사용하도록함
- 이전에 몇가지를 세팅하지 않아 default health check가 동작하지 않았던
문제 해결 하였음

 ### 테스트 사항
- Merger 2개를 실행하였을때, 연결 되지 않았을때는 "NoWhere to send
message" log가 나오고, 연결 되었을시 해당 주소의 log가 나오는걸
확인. 또한 도중에 하나가 연결이 끊겼을시 다른 곳에서는 다시 NoWhere to
send message"가 나오는 것을 확인 하였음.
