### PR TITLE
 # EDIT - Network에서 MSG_REQ_CHECK MSG_RES_CHECK 처리

### DIFF
--- a/src/chain/types.hpp
+++ b/src/chain/types.hpp
@@ -45,7 +45,6 @@ enum class MessageType : uint8_t {
   MSG_RESPONSE_2 = 0x57,
   MSG_SUCCESS = 0x58,
   MSG_ACCEPT = 0x59,
-  MSG_ECHO = 0x5A,
   MSG_LEAVE = 0x5B,
   MSG_TX = 0xB1,
   MSG_REQ_SSIG = 0xB2,

--- a/src/modules/bootstraper/block_synchronizer.cpp
+++ b/src/modules/bootstraper/block_synchronizer.cpp
@@ -446,7 +446,6 @@ inline bool BlockSynchronizer::checkMsgFromOtherMerger(MessageType msg_type) {
 inline bool BlockSynchronizer::checkMsgFromSigner(MessageType msg_type) {
   return (msg_type == MessageType::MSG_JOIN ||
           msg_type == MessageType::MSG_RESPONSE_1 ||
-          msg_type == MessageType::MSG_ECHO ||
           msg_type == MessageType::MSG_LEAVE);
 }
 }; // namespace gruut

--- a/src/modules/communication/merger_client.cpp
+++ b/src/modules/communication/merger_client.cpp
@@ -272,7 +272,6 @@ bool MergerClient::checkSignerMsgType(MessageType msg_type) {
   return (msg_type == MessageType::MSG_CHALLENGE ||
           msg_type == MessageType::MSG_RESPONSE_2 ||
           msg_type == MessageType::MSG_ACCEPT ||
-          msg_type == MessageType::MSG_ECHO ||
           msg_type == MessageType::MSG_REQ_SSIG ||
           msg_type == MessageType::MSG_ERROR);
 }
@@ -281,6 +280,7 @@ bool MergerClient::checkSEMsgType(MessageType msg_type) {
   return (msg_type == MessageType::MSG_UP ||
           msg_type == MessageType::MSG_PING ||
           msg_type == MessageType::MSG_HEADER ||
+          msg_type == MessageType::MSG_RES_CHECK ||
           msg_type == MessageType::MSG_ERROR);
 }
 }; // namespace gruut

--- a/src/modules/communication/msg_schema.hpp
+++ b/src/modules/communication/msg_schema.hpp
@@ -80,22 +80,6 @@ const json SCHEMA_REQ_BLOCK = R"({
     "mSig"
   ]
 })"_json;
-const json SCHEMA_ECHO = R"({
-  "title": "Echo",
-  "type": "object",
-  "properties": {
-    "sender": {
-      "type": "string"
-    },
-    "time": {
-      "type": "string"
-    }
-  },
-  "required": [
-    "sender",
-    "time"
-  ]
-})"_json;
 const json SCHEMA_BLOCK = R"({
   "title": "Block",
   "type": "object",
@@ -229,22 +213,6 @@ const json SCHEMA_SUCCESS = R"({
     "val"
   ]
 })"_json;
-const json SCHEMA_LEAVE = R"({
-  "title": "Echo",
-  "type": "object",
-  "properties": {
-    "sender": {
-      "type": "string"
-    },
-    "time": {
-      "type": "string"
-    }
-  },
-  "required": [
-    "sender",
-    "time"
-  ]
-})"_json;
 const json SCHEMA_REQ_SSIG = R"({
   "title": "Partial Block",
   "type": "object",
@@ -351,21 +319,44 @@ const json SCHEMA_TX = R"({
     "rSig"
   ]
 })"_json;
+const json SCHEMA_REQ_CHECK = R"({
+  "title": "Request Check",
+  "type": "object",
+  "properties": {
+    "sender": {
+      "type": "string"
+    },
+    "time": {
+      "type": "string"
+    },
+    "dID": {
+      "type": "string"
+    },
+    "txid": {
+      "type": "string"
+    }
+  },
+  "required": [
+  "sender",
+  "time",
+  "dID",
+  "txid"
+  ]
+})"_json;
 
 const std::map<MessageType, json> MSG_SCHEMA_MAP = {
     {MessageType::MSG_UP, SCHEMA_UP},
     {MessageType::MSG_PING, SCHEMA_PING},
     {MessageType::MSG_REQ_BLOCK, SCHEMA_REQ_BLOCK},
-    {MessageType::MSG_ECHO, SCHEMA_ECHO},
     {MessageType::MSG_BLOCK, SCHEMA_BLOCK},
     {MessageType::MSG_JOIN, SCHEMA_JOIN},
     {MessageType::MSG_RESPONSE_1, SCHEMA_RESPONSE_FIRST},
     {MessageType::MSG_SUCCESS, SCHEMA_SUCCESS},
-    {MessageType::MSG_LEAVE, SCHEMA_LEAVE},
     {MessageType::MSG_REQ_SSIG, SCHEMA_REQ_SSIG},
     {MessageType::MSG_SSIG, SCHEMA_SSIG},
     {MessageType::MSG_ERROR, SCHEMA_ERROR},
-    {MessageType::MSG_TX, SCHEMA_TX}};
+    {MessageType::MSG_TX, SCHEMA_TX},
+    {MessageType::MSG_REQ_CHECK, SCHEMA_REQ_CHECK}};
 
 class MessageSchema {
 public:

--- a/src/services/signer_pool_manager.cpp
+++ b/src/services/signer_pool_manager.cpp
@@ -155,8 +155,6 @@ void SignerPoolManager::handleMessage(MessageType &message_type,
     }
 
   } break;
-  case MessageType::MSG_ECHO:
-    break;
   default:
     break;
   }


### PR DESCRIPTION
### 수정 사항
- REQ_CHECK의 json schema 추가
- MSG_LEAVE, MSG_ECHO에 대해서 json schema 확인을 할 필요가
없어져 삭제 (LEAVE의 경우 Internal msg , ECHO는 더 이상 사용하지 않음)

- MergerClient에서 checkSEMsgType()에서 RES_CHECK를
확인하고 SE로 메시지를 보내도록함.