### PR TITLE
 # FIX - 가능한 SIgner의 숫자 체크하는 부분 수정

### DIFF
--- a/src/services/signature_requester.cpp
+++ b/src/services/signature_requester.cpp
@@ -166,7 +166,7 @@ Signers SignatureRequester::selectSigners() {
   auto signer_pool = SignerPool::getInstance();
   size_t num_available_signers =
       signer_pool->getNumSignerBy(SignerStatus::GOOD);
-  if (num_available_signers > config::MIN_SIGNATURE_COLLECT_SIZE) {
+  if (num_available_signers >= config::MIN_SIGNATURE_COLLECT_SIZE) {
     selected_signers = signer_pool->getRandomSigners(
         std::min(config::MAX_SIGNATURE_COLLECT_SIZE, num_available_signers));
   }


### PR DESCRIPTION
 ### 문제점
- 서명 가능한 signer 의 숫자를 비교하는 부분이 MIN값과 같을때도 드랍
해버림.

 ### 해결
- MIN값과 같을때도 확인하도록 수정