### PR TITLE
# REFACTOR - Message Header 관련 상수 위치 수정

### DIFF
--- a/src/chain/message.hpp
+++ b/src/chain/message.hpp
@@ -3,11 +3,22 @@
 
 #include "nlohmann/json.hpp"
 #include "types.hpp"
+#include <array>
 #include <tuple>
 
 using namespace std;
 
 namespace gruut {
+constexpr int HEADER_LENGTH = 32;
+constexpr int SENDER_ID_LENGTH = 8;
+constexpr int RESERVED_LENGTH = 6;
+constexpr int MSG_LENGTH_SIZE = 4;
+
+constexpr uint8_t G = 'G';
+constexpr uint8_t VERSION = '1';
+constexpr uint8_t NOT_USED = 0x00;
+constexpr array<uint8_t, RESERVED_LENGTH> RESERVED{{0x00}};
+
 struct MessageHeader {
   uint8_t identifier;
   message_version_type version;
@@ -15,18 +26,10 @@ struct MessageHeader {
   MACAlgorithmType mac_algo_type;
   CompressionAlgorithmType compression_algo_type;
   uint8_t dummy;
-  uint8_t total_length[4];
+  array<uint8_t, MSG_LENGTH_SIZE> total_length;
   local_chain_id_type local_chain_id;
   id_type sender_id;
-  uint8_t reserved_space[6];
-};
-
-struct Message : public MessageHeader {
-  Message() = delete;
-
-  Message(MessageHeader &header) : MessageHeader(header) {}
-
-  json data;
+  array<uint8_t, RESERVED_LENGTH> reserved_space;
 };
 } // namespace gruut
 #endif

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -61,16 +61,6 @@ const std::string GENESIS_BLOCK_PREV_HASH_B64 =
     "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
 const std::string GENESIS_BLOCK_PREV_ID_B64 =
     "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
-
-constexpr uint8_t G = 'G';
-constexpr uint8_t VERSION = '1';
-constexpr uint8_t NOT_USED = 0x00;
-constexpr uint8_t RESERVED[6] = {0x00};
-constexpr int HEADER_LENGTH = 32;
-constexpr int SENDER_ID_LENGTH = 8;
-constexpr int RESERVED_LENGTH = 6;
-constexpr int MSG_LENGTH_SIZE = 4;
-
 } // namespace config
 } // namespace gruut
 #endif

--- a/src/modules/communication/grpc_util.cpp
+++ b/src/modules/communication/grpc_util.cpp
@@ -19,9 +19,9 @@ HeaderController::attachHeader(std::string &compressed_json,
   uint32_t total_length =
       static_cast<uint32_t>(HEADER_LENGTH + compressed_json.size());
 
-  header.resize(config::HEADER_LENGTH);
-  header[0] = config::G;
-  header[1] = config::VERSION;
+  header.resize(HEADER_LENGTH);
+  header[0] = G;
+  header[1] = VERSION;
   header[2] = static_cast<uint8_t>(msg_type);
   if (msg_type == MessageType::MSG_ACCEPT ||
       msg_type == MessageType::MSG_REQ_SSIG) {
@@ -43,19 +43,18 @@ HeaderController::attachHeader(std::string &compressed_json,
 
   memcpy(&header[10], &chain_id[0], CHAIN_ID_TYPE_SIZE);
 
-  if (sender_id.size() >= config::SENDER_ID_LENGTH)
-    memcpy(&header[10 + CHAIN_ID_TYPE_SIZE], &sender_id[0],
-           config::SENDER_ID_LENGTH);
+  if (sender_id.size() >= SENDER_ID_LENGTH)
+    memcpy(&header[10 + CHAIN_ID_TYPE_SIZE], &sender_id[0], SENDER_ID_LENGTH);
 
-  memcpy(&header[10 + CHAIN_ID_TYPE_SIZE + config::SENDER_ID_LENGTH],
-         &config::RESERVED[0], config::RESERVED_LENGTH);
+  memcpy(&header[10 + CHAIN_ID_TYPE_SIZE + SENDER_ID_LENGTH], &RESERVED[0],
+         RESERVED_LENGTH);
 
   return header + compressed_json;
 }
 
 MessageHeader HeaderController::parseHeader(std::string &raw_data) {
   MessageHeader msg_header;
-  msg_header.sender_id.resize(config::SENDER_ID_LENGTH);
+  msg_header.sender_id.resize(SENDER_ID_LENGTH);
   msg_header.identifier = static_cast<uint8_t>(raw_data[0]);
   msg_header.version = static_cast<uint8_t>(raw_data[1]);
   msg_header.message_type = static_cast<MessageType>(raw_data[2]);
@@ -63,18 +62,19 @@ MessageHeader HeaderController::parseHeader(std::string &raw_data) {
   msg_header.compression_algo_type =
       static_cast<CompressionAlgorithmType>(raw_data[4]);
   msg_header.dummy = static_cast<uint8_t>(raw_data[5]);
-  memcpy(&msg_header.total_length[0], &raw_data[6], config::MSG_LENGTH_SIZE);
+  memcpy(&msg_header.total_length[0], &raw_data[6], MSG_LENGTH_SIZE);
   memcpy(&msg_header.local_chain_id[0], &raw_data[10], CHAIN_ID_TYPE_SIZE);
   memcpy(&msg_header.sender_id[0], &raw_data[10 + CHAIN_ID_TYPE_SIZE],
-         config::SENDER_ID_LENGTH);
+         SENDER_ID_LENGTH);
   memcpy(&msg_header.reserved_space[0],
-         &raw_data[10 + CHAIN_ID_TYPE_SIZE + config::SENDER_ID_LENGTH],
-         config::RESERVED_LENGTH);
+         &raw_data[10 + CHAIN_ID_TYPE_SIZE + SENDER_ID_LENGTH],
+         RESERVED_LENGTH);
 
   return msg_header;
 }
 
-int HeaderController::convertU8ToU32BE(uint8_t *len_bytes) {
+int HeaderController::convertU8ToU32BE(
+    std::array<uint8_t, MSG_LENGTH_SIZE> &len_bytes) {
   return static_cast<int>(len_bytes[0] << 24 | len_bytes[1] << 16 |
                           len_bytes[2] << 8 | len_bytes[3]);
 }

--- a/src/modules/communication/grpc_util.hpp
+++ b/src/modules/communication/grpc_util.hpp
@@ -18,7 +18,7 @@ public:
   attachHeader(std::string &compressed_json, MessageType msg_type,
                CompressionAlgorithmType compression_algo_type);
   static MessageHeader parseHeader(std::string &raw_data);
-  static int convertU8ToU32BE(uint8_t *len_bytes);
+  static int convertU8ToU32BE(std::array<uint8_t, MSG_LENGTH_SIZE> &len_bytes);
 };
 class JsonValidator {
 public:

--- a/src/modules/communication/message_handler.cpp
+++ b/src/modules/communication/message_handler.cpp
@@ -17,7 +17,7 @@ MessageHandler::MessageHandler() {
 void MessageHandler::unpackMsg(std::string &packed_msg,
                                grpc::Status &rpc_status, id_type &recv_id) {
   using namespace grpc;
-  if (packed_msg.size() < config::HEADER_LENGTH) {
+  if (packed_msg.size() < HEADER_LENGTH) {
     rpc_status = Status(StatusCode::INVALID_ARGUMENT,
                         "Wrong Message (MessageHandler::unpackMsg)");
     return;
@@ -32,9 +32,8 @@ void MessageHandler::unpackMsg(std::string &packed_msg,
   std::string recv_str_id = TypeConverter::encodeBase64(recv_id);
 
   if (header.mac_algo_type == MACAlgorithmType::HMAC) {
-    std::string msg = packed_msg.substr(0, config::HEADER_LENGTH + body_size);
-    std::vector<uint8_t> hmac(packed_msg.begin() + config::HEADER_LENGTH +
-                                  body_size,
+    std::string msg = packed_msg.substr(0, HEADER_LENGTH + body_size);
+    std::vector<uint8_t> hmac(packed_msg.begin() + HEADER_LENGTH + body_size,
                               packed_msg.end());
 
     auto signer_pool = SignerPool::getInstance();
@@ -98,7 +97,7 @@ void MessageHandler::packMsg(OutputMsgEntry &output_msg) {
 
 bool MessageHandler::validateMsgFormat(MessageHeader &header) {
   // TODO : Message header에서 확인해야 하는 사항이 있을때 추가예정
-  bool check = (header.identifier == config::G);
+  bool check = (header.identifier == G);
   if (header.mac_algo_type == MACAlgorithmType::HMAC) {
     check &= (header.message_type == MessageType::MSG_SUCCESS ||
               header.message_type == MessageType::MSG_SSIG);
@@ -108,12 +107,12 @@ bool MessageHandler::validateMsgFormat(MessageHeader &header) {
 
 int MessageHandler::getMsgBodySize(MessageHeader &header) {
   int total_size = HeaderController::convertU8ToU32BE(header.total_length);
-  int body_size = total_size - static_cast<int>(config::HEADER_LENGTH);
+  int body_size = total_size - static_cast<int>(HEADER_LENGTH);
   return body_size;
 }
 
 std::string MessageHandler::getMsgBody(std::string &packed_msg, int body_size) {
-  std::string packed_body = packed_msg.substr(config::HEADER_LENGTH, body_size);
+  std::string packed_body = packed_msg.substr(HEADER_LENGTH, body_size);
   return packed_body;
 }
 


### PR DESCRIPTION
- Msg header관련 상수 config/config.hpp -> chain/message.hpp 이동
- 이동에 따른 관련 코드 수정
- message.hpp에서 Message structure를 더 이상 사용하지 않으므로 삭제
- 일반 배열을 사용 했었던 부분 std::array로 변경