### PR TITLE
# FIX - bug of hangup in bootstrap-blocksync

### DIFF
--- a/src/modules/bootstraper/block_synchronizer.cpp
+++ b/src/modules/bootstraper/block_synchronizer.cpp
@@ -37,6 +37,11 @@ bool BlockSynchronizer::pushMsgToBlockList(InputMsgEntry &msg_block) {
 
   size_t block_height = new_block.getHeight();
 
+  if(m_my_last_height >= block_height) {
+    CLOG(INFO, "BSYN") << "Block dropped (old block)";
+    return false;
+  }
+
   auto it_map = m_recv_block_list.find(new_block.getHeight());
 
   bool is_new_block = false;

--- a/src/modules/bootstraper/bootstrapper.cpp
+++ b/src/modules/bootstraper/bootstrapper.cpp
@@ -53,7 +53,7 @@ void Bootstrapper::startSync() {
 }
 
 void Bootstrapper::endSync(ExitCode exit_code) {
-
+  /*
   if (exit_code == ExitCode::NORMAL ||
       exit_code == ExitCode::ERROR_SYNC_ALONE) { // complete done or alone
     sendMsgUp();
@@ -65,6 +65,11 @@ void Bootstrapper::endSync(ExitCode exit_code) {
         std::chrono::seconds(config::BOOTSTRAP_RETRY_TIMEOUT));
     startSync();
   }
+  */
+
+  // TODO : rewrite these codes after fixing boot-hang bug
+  sendMsgUp();
+  stageOver(exit_code);
 }
 
 } // namespace gruut


### PR DESCRIPTION
### 버그
- 부트스트래핑 중 내가 가진 최신 블록과 동일한 블록이 도착했을 때, 멈추는 버그

### 기타
- 네트워크가 상태가 좋지 않으면 중간에 블록을 잃어 버릴 수 도 있음
- 이 패치가 적용되면 동시에 머저를 켰을 때 멈추지 않음 (근본적인 해결책은 아님)