### PR TITLE
# REFACTOR - Merger / Signer Rpc 수정

### DIFF
--- a/src/modules/communication/merger_client.cpp
+++ b/src/modules/communication/merger_client.cpp
@@ -215,49 +215,11 @@ void MergerClient::sendToSigner(MessageType msg_type,
   for (size_t i = 0; i < num_of_signer; ++i) {
     SignerRpcInfo signer_rpc_info =
         m_rpc_receiver_list->getSignerRpcInfo(receiver_list[i]);
-    switch (msg_type) {
-    case MessageType::MSG_CHALLENGE: {
-      auto tag = static_cast<Join *>(signer_rpc_info.tag_join);
-      *signer_rpc_info.join_status = RpcCallStatus::FINISH;
 
-      GrpcMsgChallenge reply;
-      reply.set_message(packed_msg_list[i]);
-
-      signer_rpc_info.send_challenge->Finish(reply, Status::OK, tag);
-    } break;
-
-    case MessageType::MSG_RESPONSE_2: {
-      auto tag = static_cast<DHKeyEx *>(signer_rpc_info.tag_dhkeyex);
-      *signer_rpc_info.dhkeyex_status = RpcCallStatus::FINISH;
-
-      GrpcMsgResponse2 reply;
-      reply.set_message(packed_msg_list[i]);
-
-      signer_rpc_info.send_response2->Finish(reply, Status::OK, tag);
-    } break;
-
-    case MessageType::MSG_ACCEPT: {
-      auto tag =
-          static_cast<KeyExFinished *>(signer_rpc_info.tag_keyexfinished);
-      *signer_rpc_info.keyexfinished_status = RpcCallStatus::FINISH;
-
-      GrpcMsgAccept reply;
-      reply.set_message(packed_msg_list[i]);
-
-      signer_rpc_info.send_accept->Finish(reply, Status::OK, tag);
-    } break;
-
-    case MessageType::MSG_REQ_SSIG: {
-      auto tag = static_cast<Identity *>(signer_rpc_info.tag_identity);
-
-      GrpcMsgReqSsig reply;
-      reply.set_message(packed_msg_list[i]);
-      signer_rpc_info.send_req_ssig->Write(reply, tag);
-    } break;
-
-    default:
-      break;
-    }
+    auto tag = static_cast<Identity *>(signer_rpc_info.tag_identity);
+    ReplyMsg reply;
+    reply.set_message(packed_msg_list[i]);
+    signer_rpc_info.send_msg->Write(reply, tag);
   }
 }
 

--- a/src/modules/communication/merger_server.cpp
+++ b/src/modules/communication/merger_server.cpp
@@ -38,6 +38,7 @@ void MergerServer::runServer(const std::string &port_num) {
   new RecvFromMerger(&m_merger_service, m_completion_queue.get());
   new RecvFromSE(&m_se_service, m_completion_queue.get());
   new OpenChannel(&m_signer_service, m_completion_queue.get());
+  new SignerService(&m_signer_service, m_completion_queue.get());
 
   recvMessage();
 }

--- a/src/modules/communication/protos/protobuf_signer.grpc.pb.cc
+++ b/src/modules/communication/protos/protobuf_signer.grpc.pb.cc
@@ -15,150 +15,72 @@
 #include <grpcpp/impl/codegen/sync_stream.h>
 namespace grpc_signer {
 
-static const char* GruutNetworkService_method_names[] = {
-  "/grpc_signer.GruutNetworkService/join",
-  "/grpc_signer.GruutNetworkService/dhKeyEx",
-  "/grpc_signer.GruutNetworkService/keyExFinished",
-  "/grpc_signer.GruutNetworkService/sigSend",
-  "/grpc_signer.GruutNetworkService/openChannel",
+static const char* GruutSignerService_method_names[] = {
+  "/grpc_signer.GruutSignerService/openChannel",
+  "/grpc_signer.GruutSignerService/signerService",
 };
 
-std::unique_ptr< GruutNetworkService::Stub> GruutNetworkService::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
+std::unique_ptr< GruutSignerService::Stub> GruutSignerService::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
   (void)options;
-  std::unique_ptr< GruutNetworkService::Stub> stub(new GruutNetworkService::Stub(channel));
+  std::unique_ptr< GruutSignerService::Stub> stub(new GruutSignerService::Stub(channel));
   return stub;
 }
 
-GruutNetworkService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel)
-  : channel_(channel), rpcmethod_join_(GruutNetworkService_method_names[0], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_dhKeyEx_(GruutNetworkService_method_names[1], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_keyExFinished_(GruutNetworkService_method_names[2], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_sigSend_(GruutNetworkService_method_names[3], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_openChannel_(GruutNetworkService_method_names[4], ::grpc::internal::RpcMethod::BIDI_STREAMING, channel)
+GruutSignerService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel)
+  : channel_(channel), rpcmethod_openChannel_(GruutSignerService_method_names[0], ::grpc::internal::RpcMethod::BIDI_STREAMING, channel)
+  , rpcmethod_signerService_(GruutSignerService_method_names[1], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
-::grpc::Status GruutNetworkService::Stub::join(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgJoin& request, ::grpc_signer::GrpcMsgChallenge* response) {
-  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_join_, context, request, response);
+::grpc::ClientReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>* GruutSignerService::Stub::openChannelRaw(::grpc::ClientContext* context) {
+  return ::grpc::internal::ClientReaderWriterFactory< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>::Create(channel_.get(), rpcmethod_openChannel_, context);
 }
 
-::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgChallenge>* GruutNetworkService::Stub::AsyncjoinRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgJoin& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_signer::GrpcMsgChallenge>::Create(channel_.get(), cq, rpcmethod_join_, context, request, true);
+::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>* GruutSignerService::Stub::AsyncopenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderWriterFactory< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>::Create(channel_.get(), cq, rpcmethod_openChannel_, context, true, tag);
 }
 
-::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgChallenge>* GruutNetworkService::Stub::PrepareAsyncjoinRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgJoin& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_signer::GrpcMsgChallenge>::Create(channel_.get(), cq, rpcmethod_join_, context, request, false);
+::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>* GruutSignerService::Stub::PrepareAsyncopenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderWriterFactory< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>::Create(channel_.get(), cq, rpcmethod_openChannel_, context, false, nullptr);
 }
 
-::grpc::Status GruutNetworkService::Stub::dhKeyEx(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgResponse1& request, ::grpc_signer::GrpcMsgResponse2* response) {
-  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_dhKeyEx_, context, request, response);
+::grpc::Status GruutSignerService::Stub::signerService(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc_signer::MsgStatus* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_signerService_, context, request, response);
 }
 
-::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgResponse2>* GruutNetworkService::Stub::AsyncdhKeyExRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgResponse1& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_signer::GrpcMsgResponse2>::Create(channel_.get(), cq, rpcmethod_dhKeyEx_, context, request, true);
+::grpc::ClientAsyncResponseReader< ::grpc_signer::MsgStatus>* GruutSignerService::Stub::AsyncsignerServiceRaw(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_signer::MsgStatus>::Create(channel_.get(), cq, rpcmethod_signerService_, context, request, true);
 }
 
-::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgResponse2>* GruutNetworkService::Stub::PrepareAsyncdhKeyExRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgResponse1& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_signer::GrpcMsgResponse2>::Create(channel_.get(), cq, rpcmethod_dhKeyEx_, context, request, false);
+::grpc::ClientAsyncResponseReader< ::grpc_signer::MsgStatus>* GruutSignerService::Stub::PrepareAsyncsignerServiceRaw(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_signer::MsgStatus>::Create(channel_.get(), cq, rpcmethod_signerService_, context, request, false);
 }
 
-::grpc::Status GruutNetworkService::Stub::keyExFinished(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSuccess& request, ::grpc_signer::GrpcMsgAccept* response) {
-  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_keyExFinished_, context, request, response);
-}
-
-::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgAccept>* GruutNetworkService::Stub::AsynckeyExFinishedRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSuccess& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_signer::GrpcMsgAccept>::Create(channel_.get(), cq, rpcmethod_keyExFinished_, context, request, true);
-}
-
-::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgAccept>* GruutNetworkService::Stub::PrepareAsynckeyExFinishedRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSuccess& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_signer::GrpcMsgAccept>::Create(channel_.get(), cq, rpcmethod_keyExFinished_, context, request, false);
-}
-
-::grpc::Status GruutNetworkService::Stub::sigSend(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSsig& request, ::grpc_signer::NoReply* response) {
-  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_sigSend_, context, request, response);
-}
-
-::grpc::ClientAsyncResponseReader< ::grpc_signer::NoReply>* GruutNetworkService::Stub::AsyncsigSendRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSsig& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_signer::NoReply>::Create(channel_.get(), cq, rpcmethod_sigSend_, context, request, true);
-}
-
-::grpc::ClientAsyncResponseReader< ::grpc_signer::NoReply>* GruutNetworkService::Stub::PrepareAsyncsigSendRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSsig& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_signer::NoReply>::Create(channel_.get(), cq, rpcmethod_sigSend_, context, request, false);
-}
-
-::grpc::ClientReaderWriter< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>* GruutNetworkService::Stub::openChannelRaw(::grpc::ClientContext* context) {
-  return ::grpc::internal::ClientReaderWriterFactory< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>::Create(channel_.get(), rpcmethod_openChannel_, context);
-}
-
-::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>* GruutNetworkService::Stub::AsyncopenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {
-  return ::grpc::internal::ClientAsyncReaderWriterFactory< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>::Create(channel_.get(), cq, rpcmethod_openChannel_, context, true, tag);
-}
-
-::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>* GruutNetworkService::Stub::PrepareAsyncopenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncReaderWriterFactory< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>::Create(channel_.get(), cq, rpcmethod_openChannel_, context, false, nullptr);
-}
-
-GruutNetworkService::Service::Service() {
+GruutSignerService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      GruutNetworkService_method_names[0],
-      ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< GruutNetworkService::Service, ::grpc_signer::GrpcMsgJoin, ::grpc_signer::GrpcMsgChallenge>(
-          std::mem_fn(&GruutNetworkService::Service::join), this)));
-  AddMethod(new ::grpc::internal::RpcServiceMethod(
-      GruutNetworkService_method_names[1],
-      ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< GruutNetworkService::Service, ::grpc_signer::GrpcMsgResponse1, ::grpc_signer::GrpcMsgResponse2>(
-          std::mem_fn(&GruutNetworkService::Service::dhKeyEx), this)));
-  AddMethod(new ::grpc::internal::RpcServiceMethod(
-      GruutNetworkService_method_names[2],
-      ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< GruutNetworkService::Service, ::grpc_signer::GrpcMsgSuccess, ::grpc_signer::GrpcMsgAccept>(
-          std::mem_fn(&GruutNetworkService::Service::keyExFinished), this)));
-  AddMethod(new ::grpc::internal::RpcServiceMethod(
-      GruutNetworkService_method_names[3],
-      ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< GruutNetworkService::Service, ::grpc_signer::GrpcMsgSsig, ::grpc_signer::NoReply>(
-          std::mem_fn(&GruutNetworkService::Service::sigSend), this)));
-  AddMethod(new ::grpc::internal::RpcServiceMethod(
-      GruutNetworkService_method_names[4],
+      GruutSignerService_method_names[0],
       ::grpc::internal::RpcMethod::BIDI_STREAMING,
-      new ::grpc::internal::BidiStreamingHandler< GruutNetworkService::Service, ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>(
-          std::mem_fn(&GruutNetworkService::Service::openChannel), this)));
+      new ::grpc::internal::BidiStreamingHandler< GruutSignerService::Service, ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>(
+          std::mem_fn(&GruutSignerService::Service::openChannel), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      GruutSignerService_method_names[1],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< GruutSignerService::Service, ::grpc_signer::RequestMsg, ::grpc_signer::MsgStatus>(
+          std::mem_fn(&GruutSignerService::Service::signerService), this)));
 }
 
-GruutNetworkService::Service::~Service() {
+GruutSignerService::Service::~Service() {
 }
 
-::grpc::Status GruutNetworkService::Service::join(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgJoin* request, ::grpc_signer::GrpcMsgChallenge* response) {
-  (void) context;
-  (void) request;
-  (void) response;
-  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-}
-
-::grpc::Status GruutNetworkService::Service::dhKeyEx(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgResponse1* request, ::grpc_signer::GrpcMsgResponse2* response) {
-  (void) context;
-  (void) request;
-  (void) response;
-  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-}
-
-::grpc::Status GruutNetworkService::Service::keyExFinished(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgSuccess* request, ::grpc_signer::GrpcMsgAccept* response) {
-  (void) context;
-  (void) request;
-  (void) response;
-  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-}
-
-::grpc::Status GruutNetworkService::Service::sigSend(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgSsig* request, ::grpc_signer::NoReply* response) {
-  (void) context;
-  (void) request;
-  (void) response;
-  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-}
-
-::grpc::Status GruutNetworkService::Service::openChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::GrpcMsgReqSsig, ::grpc_signer::Identity>* stream) {
+::grpc::Status GruutSignerService::Service::openChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::ReplyMsg, ::grpc_signer::Identity>* stream) {
   (void) context;
   (void) stream;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status GruutSignerService::Service::signerService(::grpc::ServerContext* context, const ::grpc_signer::RequestMsg* request, ::grpc_signer::MsgStatus* response) {
+  (void) context;
+  (void) request;
+  (void) response;
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 

--- a/src/modules/communication/protos/protobuf_signer.grpc.pb.h
+++ b/src/modules/communication/protos/protobuf_signer.grpc.pb.h
@@ -26,126 +26,66 @@ class ServerContext;
 
 namespace grpc_signer {
 
-class GruutNetworkService final {
+class GruutSignerService final {
  public:
   static constexpr char const* service_full_name() {
-    return "grpc_signer.GruutNetworkService";
+    return "grpc_signer.GruutSignerService";
   }
   class StubInterface {
    public:
     virtual ~StubInterface() {}
-    virtual ::grpc::Status join(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgJoin& request, ::grpc_signer::GrpcMsgChallenge* response) = 0;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::GrpcMsgChallenge>> Asyncjoin(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgJoin& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::GrpcMsgChallenge>>(AsyncjoinRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>> openChannel(::grpc::ClientContext* context) {
+      return std::unique_ptr< ::grpc::ClientReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>>(openChannelRaw(context));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::GrpcMsgChallenge>> PrepareAsyncjoin(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgJoin& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::GrpcMsgChallenge>>(PrepareAsyncjoinRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>> AsyncopenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>>(AsyncopenChannelRaw(context, cq, tag));
     }
-    virtual ::grpc::Status dhKeyEx(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgResponse1& request, ::grpc_signer::GrpcMsgResponse2* response) = 0;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::GrpcMsgResponse2>> AsyncdhKeyEx(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgResponse1& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::GrpcMsgResponse2>>(AsyncdhKeyExRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>> PrepareAsyncopenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>>(PrepareAsyncopenChannelRaw(context, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::GrpcMsgResponse2>> PrepareAsyncdhKeyEx(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgResponse1& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::GrpcMsgResponse2>>(PrepareAsyncdhKeyExRaw(context, request, cq));
+    virtual ::grpc::Status signerService(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc_signer::MsgStatus* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::MsgStatus>> AsyncsignerService(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::MsgStatus>>(AsyncsignerServiceRaw(context, request, cq));
     }
-    virtual ::grpc::Status keyExFinished(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSuccess& request, ::grpc_signer::GrpcMsgAccept* response) = 0;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::GrpcMsgAccept>> AsynckeyExFinished(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSuccess& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::GrpcMsgAccept>>(AsynckeyExFinishedRaw(context, request, cq));
-    }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::GrpcMsgAccept>> PrepareAsynckeyExFinished(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSuccess& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::GrpcMsgAccept>>(PrepareAsynckeyExFinishedRaw(context, request, cq));
-    }
-    virtual ::grpc::Status sigSend(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSsig& request, ::grpc_signer::NoReply* response) = 0;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::NoReply>> AsyncsigSend(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSsig& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::NoReply>>(AsyncsigSendRaw(context, request, cq));
-    }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::NoReply>> PrepareAsyncsigSend(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSsig& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::NoReply>>(PrepareAsyncsigSendRaw(context, request, cq));
-    }
-    // 네트워크 참여가 완료 되었을 때 채널 그랜드 오픈!
-    // M: Accept Signer에게 보냄과 동시에 채널을 오픈
-    // S: Accept 수신 시 채널 오픈
-    std::unique_ptr< ::grpc::ClientReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>> openChannel(::grpc::ClientContext* context) {
-      return std::unique_ptr< ::grpc::ClientReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>>(openChannelRaw(context));
-    }
-    std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>> AsyncopenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {
-      return std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>>(AsyncopenChannelRaw(context, cq, tag));
-    }
-    std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>> PrepareAsyncopenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>>(PrepareAsyncopenChannelRaw(context, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::MsgStatus>> PrepareAsyncsignerService(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::MsgStatus>>(PrepareAsyncsignerServiceRaw(context, request, cq));
     }
   private:
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::GrpcMsgChallenge>* AsyncjoinRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgJoin& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::GrpcMsgChallenge>* PrepareAsyncjoinRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgJoin& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::GrpcMsgResponse2>* AsyncdhKeyExRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgResponse1& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::GrpcMsgResponse2>* PrepareAsyncdhKeyExRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgResponse1& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::GrpcMsgAccept>* AsynckeyExFinishedRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSuccess& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::GrpcMsgAccept>* PrepareAsynckeyExFinishedRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSuccess& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::NoReply>* AsyncsigSendRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSsig& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::NoReply>* PrepareAsyncsigSendRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSsig& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>* openChannelRaw(::grpc::ClientContext* context) = 0;
-    virtual ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>* AsyncopenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) = 0;
-    virtual ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>* PrepareAsyncopenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>* openChannelRaw(::grpc::ClientContext* context) = 0;
+    virtual ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>* AsyncopenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>* PrepareAsyncopenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::MsgStatus>* AsyncsignerServiceRaw(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::MsgStatus>* PrepareAsyncsignerServiceRaw(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
     Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel);
-    ::grpc::Status join(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgJoin& request, ::grpc_signer::GrpcMsgChallenge* response) override;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgChallenge>> Asyncjoin(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgJoin& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgChallenge>>(AsyncjoinRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>> openChannel(::grpc::ClientContext* context) {
+      return std::unique_ptr< ::grpc::ClientReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>>(openChannelRaw(context));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgChallenge>> PrepareAsyncjoin(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgJoin& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgChallenge>>(PrepareAsyncjoinRaw(context, request, cq));
+    std::unique_ptr<  ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>> AsyncopenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>>(AsyncopenChannelRaw(context, cq, tag));
     }
-    ::grpc::Status dhKeyEx(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgResponse1& request, ::grpc_signer::GrpcMsgResponse2* response) override;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgResponse2>> AsyncdhKeyEx(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgResponse1& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgResponse2>>(AsyncdhKeyExRaw(context, request, cq));
+    std::unique_ptr<  ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>> PrepareAsyncopenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>>(PrepareAsyncopenChannelRaw(context, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgResponse2>> PrepareAsyncdhKeyEx(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgResponse1& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgResponse2>>(PrepareAsyncdhKeyExRaw(context, request, cq));
+    ::grpc::Status signerService(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc_signer::MsgStatus* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::MsgStatus>> AsyncsignerService(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::MsgStatus>>(AsyncsignerServiceRaw(context, request, cq));
     }
-    ::grpc::Status keyExFinished(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSuccess& request, ::grpc_signer::GrpcMsgAccept* response) override;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgAccept>> AsynckeyExFinished(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSuccess& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgAccept>>(AsynckeyExFinishedRaw(context, request, cq));
-    }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgAccept>> PrepareAsynckeyExFinished(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSuccess& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgAccept>>(PrepareAsynckeyExFinishedRaw(context, request, cq));
-    }
-    ::grpc::Status sigSend(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSsig& request, ::grpc_signer::NoReply* response) override;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::NoReply>> AsyncsigSend(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSsig& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::NoReply>>(AsyncsigSendRaw(context, request, cq));
-    }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::NoReply>> PrepareAsyncsigSend(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSsig& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::NoReply>>(PrepareAsyncsigSendRaw(context, request, cq));
-    }
-    std::unique_ptr< ::grpc::ClientReaderWriter< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>> openChannel(::grpc::ClientContext* context) {
-      return std::unique_ptr< ::grpc::ClientReaderWriter< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>>(openChannelRaw(context));
-    }
-    std::unique_ptr<  ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>> AsyncopenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {
-      return std::unique_ptr< ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>>(AsyncopenChannelRaw(context, cq, tag));
-    }
-    std::unique_ptr<  ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>> PrepareAsyncopenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>>(PrepareAsyncopenChannelRaw(context, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::MsgStatus>> PrepareAsyncsignerService(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::MsgStatus>>(PrepareAsyncsignerServiceRaw(context, request, cq));
     }
 
    private:
     std::shared_ptr< ::grpc::ChannelInterface> channel_;
-    ::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgChallenge>* AsyncjoinRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgJoin& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgChallenge>* PrepareAsyncjoinRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgJoin& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgResponse2>* AsyncdhKeyExRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgResponse1& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgResponse2>* PrepareAsyncdhKeyExRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgResponse1& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgAccept>* AsynckeyExFinishedRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSuccess& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::grpc_signer::GrpcMsgAccept>* PrepareAsynckeyExFinishedRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSuccess& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::grpc_signer::NoReply>* AsyncsigSendRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSsig& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::grpc_signer::NoReply>* PrepareAsyncsigSendRaw(::grpc::ClientContext* context, const ::grpc_signer::GrpcMsgSsig& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientReaderWriter< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>* openChannelRaw(::grpc::ClientContext* context) override;
-    ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>* AsyncopenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) override;
-    ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::GrpcMsgReqSsig>* PrepareAsyncopenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) override;
-    const ::grpc::internal::RpcMethod rpcmethod_join_;
-    const ::grpc::internal::RpcMethod rpcmethod_dhKeyEx_;
-    const ::grpc::internal::RpcMethod rpcmethod_keyExFinished_;
-    const ::grpc::internal::RpcMethod rpcmethod_sigSend_;
+    ::grpc::ClientReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>* openChannelRaw(::grpc::ClientContext* context) override;
+    ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>* AsyncopenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>* PrepareAsyncopenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::grpc_signer::MsgStatus>* AsyncsignerServiceRaw(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::grpc_signer::MsgStatus>* PrepareAsyncsignerServiceRaw(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_openChannel_;
+    const ::grpc::internal::RpcMethod rpcmethod_signerService_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
 
@@ -153,94 +93,8 @@ class GruutNetworkService final {
    public:
     Service();
     virtual ~Service();
-    virtual ::grpc::Status join(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgJoin* request, ::grpc_signer::GrpcMsgChallenge* response);
-    virtual ::grpc::Status dhKeyEx(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgResponse1* request, ::grpc_signer::GrpcMsgResponse2* response);
-    virtual ::grpc::Status keyExFinished(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgSuccess* request, ::grpc_signer::GrpcMsgAccept* response);
-    virtual ::grpc::Status sigSend(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgSsig* request, ::grpc_signer::NoReply* response);
-    // 네트워크 참여가 완료 되었을 때 채널 그랜드 오픈!
-    // M: Accept Signer에게 보냄과 동시에 채널을 오픈
-    // S: Accept 수신 시 채널 오픈
-    virtual ::grpc::Status openChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::GrpcMsgReqSsig, ::grpc_signer::Identity>* stream);
-  };
-  template <class BaseClass>
-  class WithAsyncMethod_join : public BaseClass {
-   private:
-    void BaseClassMustBeDerivedFromService(const Service *service) {}
-   public:
-    WithAsyncMethod_join() {
-      ::grpc::Service::MarkMethodAsync(0);
-    }
-    ~WithAsyncMethod_join() override {
-      BaseClassMustBeDerivedFromService(this);
-    }
-    // disable synchronous version of this method
-    ::grpc::Status join(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgJoin* request, ::grpc_signer::GrpcMsgChallenge* response) override {
-      abort();
-      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-    }
-    void Requestjoin(::grpc::ServerContext* context, ::grpc_signer::GrpcMsgJoin* request, ::grpc::ServerAsyncResponseWriter< ::grpc_signer::GrpcMsgChallenge>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(0, context, request, response, new_call_cq, notification_cq, tag);
-    }
-  };
-  template <class BaseClass>
-  class WithAsyncMethod_dhKeyEx : public BaseClass {
-   private:
-    void BaseClassMustBeDerivedFromService(const Service *service) {}
-   public:
-    WithAsyncMethod_dhKeyEx() {
-      ::grpc::Service::MarkMethodAsync(1);
-    }
-    ~WithAsyncMethod_dhKeyEx() override {
-      BaseClassMustBeDerivedFromService(this);
-    }
-    // disable synchronous version of this method
-    ::grpc::Status dhKeyEx(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgResponse1* request, ::grpc_signer::GrpcMsgResponse2* response) override {
-      abort();
-      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-    }
-    void RequestdhKeyEx(::grpc::ServerContext* context, ::grpc_signer::GrpcMsgResponse1* request, ::grpc::ServerAsyncResponseWriter< ::grpc_signer::GrpcMsgResponse2>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
-    }
-  };
-  template <class BaseClass>
-  class WithAsyncMethod_keyExFinished : public BaseClass {
-   private:
-    void BaseClassMustBeDerivedFromService(const Service *service) {}
-   public:
-    WithAsyncMethod_keyExFinished() {
-      ::grpc::Service::MarkMethodAsync(2);
-    }
-    ~WithAsyncMethod_keyExFinished() override {
-      BaseClassMustBeDerivedFromService(this);
-    }
-    // disable synchronous version of this method
-    ::grpc::Status keyExFinished(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgSuccess* request, ::grpc_signer::GrpcMsgAccept* response) override {
-      abort();
-      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-    }
-    void RequestkeyExFinished(::grpc::ServerContext* context, ::grpc_signer::GrpcMsgSuccess* request, ::grpc::ServerAsyncResponseWriter< ::grpc_signer::GrpcMsgAccept>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
-    }
-  };
-  template <class BaseClass>
-  class WithAsyncMethod_sigSend : public BaseClass {
-   private:
-    void BaseClassMustBeDerivedFromService(const Service *service) {}
-   public:
-    WithAsyncMethod_sigSend() {
-      ::grpc::Service::MarkMethodAsync(3);
-    }
-    ~WithAsyncMethod_sigSend() override {
-      BaseClassMustBeDerivedFromService(this);
-    }
-    // disable synchronous version of this method
-    ::grpc::Status sigSend(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgSsig* request, ::grpc_signer::NoReply* response) override {
-      abort();
-      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-    }
-    void RequestsigSend(::grpc::ServerContext* context, ::grpc_signer::GrpcMsgSsig* request, ::grpc::ServerAsyncResponseWriter< ::grpc_signer::NoReply>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
-    }
+    virtual ::grpc::Status openChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::ReplyMsg, ::grpc_signer::Identity>* stream);
+    virtual ::grpc::Status signerService(::grpc::ServerContext* context, const ::grpc_signer::RequestMsg* request, ::grpc_signer::MsgStatus* response);
   };
   template <class BaseClass>
   class WithAsyncMethod_openChannel : public BaseClass {
@@ -248,184 +102,73 @@ class GruutNetworkService final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_openChannel() {
-      ::grpc::Service::MarkMethodAsync(4);
+      ::grpc::Service::MarkMethodAsync(0);
     }
     ~WithAsyncMethod_openChannel() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status openChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::GrpcMsgReqSsig, ::grpc_signer::Identity>* stream)  override {
+    ::grpc::Status openChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::ReplyMsg, ::grpc_signer::Identity>* stream)  override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestopenChannel(::grpc::ServerContext* context, ::grpc::ServerAsyncReaderWriter< ::grpc_signer::GrpcMsgReqSsig, ::grpc_signer::Identity>* stream, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncBidiStreaming(4, context, stream, new_call_cq, notification_cq, tag);
-    }
-  };
-  typedef WithAsyncMethod_join<WithAsyncMethod_dhKeyEx<WithAsyncMethod_keyExFinished<WithAsyncMethod_sigSend<WithAsyncMethod_openChannel<Service > > > > > AsyncService;
-  template <class BaseClass>
-  class WithGenericMethod_join : public BaseClass {
-   private:
-    void BaseClassMustBeDerivedFromService(const Service *service) {}
-   public:
-    WithGenericMethod_join() {
-      ::grpc::Service::MarkMethodGeneric(0);
-    }
-    ~WithGenericMethod_join() override {
-      BaseClassMustBeDerivedFromService(this);
-    }
-    // disable synchronous version of this method
-    ::grpc::Status join(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgJoin* request, ::grpc_signer::GrpcMsgChallenge* response) override {
-      abort();
-      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    void RequestopenChannel(::grpc::ServerContext* context, ::grpc::ServerAsyncReaderWriter< ::grpc_signer::ReplyMsg, ::grpc_signer::Identity>* stream, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncBidiStreaming(0, context, stream, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
-  class WithGenericMethod_dhKeyEx : public BaseClass {
+  class WithAsyncMethod_signerService : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
-    WithGenericMethod_dhKeyEx() {
-      ::grpc::Service::MarkMethodGeneric(1);
+    WithAsyncMethod_signerService() {
+      ::grpc::Service::MarkMethodAsync(1);
     }
-    ~WithGenericMethod_dhKeyEx() override {
+    ~WithAsyncMethod_signerService() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status dhKeyEx(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgResponse1* request, ::grpc_signer::GrpcMsgResponse2* response) override {
+    ::grpc::Status signerService(::grpc::ServerContext* context, const ::grpc_signer::RequestMsg* request, ::grpc_signer::MsgStatus* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-  };
-  template <class BaseClass>
-  class WithGenericMethod_keyExFinished : public BaseClass {
-   private:
-    void BaseClassMustBeDerivedFromService(const Service *service) {}
-   public:
-    WithGenericMethod_keyExFinished() {
-      ::grpc::Service::MarkMethodGeneric(2);
-    }
-    ~WithGenericMethod_keyExFinished() override {
-      BaseClassMustBeDerivedFromService(this);
-    }
-    // disable synchronous version of this method
-    ::grpc::Status keyExFinished(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgSuccess* request, ::grpc_signer::GrpcMsgAccept* response) override {
-      abort();
-      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    void RequestsignerService(::grpc::ServerContext* context, ::grpc_signer::RequestMsg* request, ::grpc::ServerAsyncResponseWriter< ::grpc_signer::MsgStatus>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  template <class BaseClass>
-  class WithGenericMethod_sigSend : public BaseClass {
-   private:
-    void BaseClassMustBeDerivedFromService(const Service *service) {}
-   public:
-    WithGenericMethod_sigSend() {
-      ::grpc::Service::MarkMethodGeneric(3);
-    }
-    ~WithGenericMethod_sigSend() override {
-      BaseClassMustBeDerivedFromService(this);
-    }
-    // disable synchronous version of this method
-    ::grpc::Status sigSend(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgSsig* request, ::grpc_signer::NoReply* response) override {
-      abort();
-      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-    }
-  };
+  typedef WithAsyncMethod_openChannel<WithAsyncMethod_signerService<Service > > AsyncService;
   template <class BaseClass>
   class WithGenericMethod_openChannel : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_openChannel() {
-      ::grpc::Service::MarkMethodGeneric(4);
+      ::grpc::Service::MarkMethodGeneric(0);
     }
     ~WithGenericMethod_openChannel() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status openChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::GrpcMsgReqSsig, ::grpc_signer::Identity>* stream)  override {
+    ::grpc::Status openChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::ReplyMsg, ::grpc_signer::Identity>* stream)  override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
   };
   template <class BaseClass>
-  class WithRawMethod_join : public BaseClass {
+  class WithGenericMethod_signerService : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
-    WithRawMethod_join() {
-      ::grpc::Service::MarkMethodRaw(0);
+    WithGenericMethod_signerService() {
+      ::grpc::Service::MarkMethodGeneric(1);
     }
-    ~WithRawMethod_join() override {
+    ~WithGenericMethod_signerService() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status join(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgJoin* request, ::grpc_signer::GrpcMsgChallenge* response) override {
+    ::grpc::Status signerService(::grpc::ServerContext* context, const ::grpc_signer::RequestMsg* request, ::grpc_signer::MsgStatus* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-    }
-    void Requestjoin(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(0, context, request, response, new_call_cq, notification_cq, tag);
-    }
-  };
-  template <class BaseClass>
-  class WithRawMethod_dhKeyEx : public BaseClass {
-   private:
-    void BaseClassMustBeDerivedFromService(const Service *service) {}
-   public:
-    WithRawMethod_dhKeyEx() {
-      ::grpc::Service::MarkMethodRaw(1);
-    }
-    ~WithRawMethod_dhKeyEx() override {
-      BaseClassMustBeDerivedFromService(this);
-    }
-    // disable synchronous version of this method
-    ::grpc::Status dhKeyEx(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgResponse1* request, ::grpc_signer::GrpcMsgResponse2* response) override {
-      abort();
-      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-    }
-    void RequestdhKeyEx(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
-    }
-  };
-  template <class BaseClass>
-  class WithRawMethod_keyExFinished : public BaseClass {
-   private:
-    void BaseClassMustBeDerivedFromService(const Service *service) {}
-   public:
-    WithRawMethod_keyExFinished() {
-      ::grpc::Service::MarkMethodRaw(2);
-    }
-    ~WithRawMethod_keyExFinished() override {
-      BaseClassMustBeDerivedFromService(this);
-    }
-    // disable synchronous version of this method
-    ::grpc::Status keyExFinished(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgSuccess* request, ::grpc_signer::GrpcMsgAccept* response) override {
-      abort();
-      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-    }
-    void RequestkeyExFinished(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
-    }
-  };
-  template <class BaseClass>
-  class WithRawMethod_sigSend : public BaseClass {
-   private:
-    void BaseClassMustBeDerivedFromService(const Service *service) {}
-   public:
-    WithRawMethod_sigSend() {
-      ::grpc::Service::MarkMethodRaw(3);
-    }
-    ~WithRawMethod_sigSend() override {
-      BaseClassMustBeDerivedFromService(this);
-    }
-    // disable synchronous version of this method
-    ::grpc::Status sigSend(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgSsig* request, ::grpc_signer::NoReply* response) override {
-      abort();
-      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-    }
-    void RequestsigSend(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -434,103 +177,63 @@ class GruutNetworkService final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_openChannel() {
-      ::grpc::Service::MarkMethodRaw(4);
+      ::grpc::Service::MarkMethodRaw(0);
     }
     ~WithRawMethod_openChannel() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status openChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::GrpcMsgReqSsig, ::grpc_signer::Identity>* stream)  override {
+    ::grpc::Status openChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::ReplyMsg, ::grpc_signer::Identity>* stream)  override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestopenChannel(::grpc::ServerContext* context, ::grpc::ServerAsyncReaderWriter< ::grpc::ByteBuffer, ::grpc::ByteBuffer>* stream, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncBidiStreaming(4, context, stream, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncBidiStreaming(0, context, stream, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
-  class WithStreamedUnaryMethod_join : public BaseClass {
+  class WithRawMethod_signerService : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
-    WithStreamedUnaryMethod_join() {
-      ::grpc::Service::MarkMethodStreamed(0,
-        new ::grpc::internal::StreamedUnaryHandler< ::grpc_signer::GrpcMsgJoin, ::grpc_signer::GrpcMsgChallenge>(std::bind(&WithStreamedUnaryMethod_join<BaseClass>::Streamedjoin, this, std::placeholders::_1, std::placeholders::_2)));
+    WithRawMethod_signerService() {
+      ::grpc::Service::MarkMethodRaw(1);
     }
-    ~WithStreamedUnaryMethod_join() override {
+    ~WithRawMethod_signerService() override {
       BaseClassMustBeDerivedFromService(this);
     }
-    // disable regular version of this method
-    ::grpc::Status join(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgJoin* request, ::grpc_signer::GrpcMsgChallenge* response) override {
+    // disable synchronous version of this method
+    ::grpc::Status signerService(::grpc::ServerContext* context, const ::grpc_signer::RequestMsg* request, ::grpc_signer::MsgStatus* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    // replace default version of method with streamed unary
-    virtual ::grpc::Status Streamedjoin(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_signer::GrpcMsgJoin,::grpc_signer::GrpcMsgChallenge>* server_unary_streamer) = 0;
+    void RequestsignerService(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
+    }
   };
   template <class BaseClass>
-  class WithStreamedUnaryMethod_dhKeyEx : public BaseClass {
+  class WithStreamedUnaryMethod_signerService : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
-    WithStreamedUnaryMethod_dhKeyEx() {
+    WithStreamedUnaryMethod_signerService() {
       ::grpc::Service::MarkMethodStreamed(1,
-        new ::grpc::internal::StreamedUnaryHandler< ::grpc_signer::GrpcMsgResponse1, ::grpc_signer::GrpcMsgResponse2>(std::bind(&WithStreamedUnaryMethod_dhKeyEx<BaseClass>::StreameddhKeyEx, this, std::placeholders::_1, std::placeholders::_2)));
+        new ::grpc::internal::StreamedUnaryHandler< ::grpc_signer::RequestMsg, ::grpc_signer::MsgStatus>(std::bind(&WithStreamedUnaryMethod_signerService<BaseClass>::StreamedsignerService, this, std::placeholders::_1, std::placeholders::_2)));
     }
-    ~WithStreamedUnaryMethod_dhKeyEx() override {
+    ~WithStreamedUnaryMethod_signerService() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable regular version of this method
-    ::grpc::Status dhKeyEx(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgResponse1* request, ::grpc_signer::GrpcMsgResponse2* response) override {
+    ::grpc::Status signerService(::grpc::ServerContext* context, const ::grpc_signer::RequestMsg* request, ::grpc_signer::MsgStatus* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     // replace default version of method with streamed unary
-    virtual ::grpc::Status StreameddhKeyEx(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_signer::GrpcMsgResponse1,::grpc_signer::GrpcMsgResponse2>* server_unary_streamer) = 0;
+    virtual ::grpc::Status StreamedsignerService(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_signer::RequestMsg,::grpc_signer::MsgStatus>* server_unary_streamer) = 0;
   };
-  template <class BaseClass>
-  class WithStreamedUnaryMethod_keyExFinished : public BaseClass {
-   private:
-    void BaseClassMustBeDerivedFromService(const Service *service) {}
-   public:
-    WithStreamedUnaryMethod_keyExFinished() {
-      ::grpc::Service::MarkMethodStreamed(2,
-        new ::grpc::internal::StreamedUnaryHandler< ::grpc_signer::GrpcMsgSuccess, ::grpc_signer::GrpcMsgAccept>(std::bind(&WithStreamedUnaryMethod_keyExFinished<BaseClass>::StreamedkeyExFinished, this, std::placeholders::_1, std::placeholders::_2)));
-    }
-    ~WithStreamedUnaryMethod_keyExFinished() override {
-      BaseClassMustBeDerivedFromService(this);
-    }
-    // disable regular version of this method
-    ::grpc::Status keyExFinished(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgSuccess* request, ::grpc_signer::GrpcMsgAccept* response) override {
-      abort();
-      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-    }
-    // replace default version of method with streamed unary
-    virtual ::grpc::Status StreamedkeyExFinished(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_signer::GrpcMsgSuccess,::grpc_signer::GrpcMsgAccept>* server_unary_streamer) = 0;
-  };
-  template <class BaseClass>
-  class WithStreamedUnaryMethod_sigSend : public BaseClass {
-   private:
-    void BaseClassMustBeDerivedFromService(const Service *service) {}
-   public:
-    WithStreamedUnaryMethod_sigSend() {
-      ::grpc::Service::MarkMethodStreamed(3,
-        new ::grpc::internal::StreamedUnaryHandler< ::grpc_signer::GrpcMsgSsig, ::grpc_signer::NoReply>(std::bind(&WithStreamedUnaryMethod_sigSend<BaseClass>::StreamedsigSend, this, std::placeholders::_1, std::placeholders::_2)));
-    }
-    ~WithStreamedUnaryMethod_sigSend() override {
-      BaseClassMustBeDerivedFromService(this);
-    }
-    // disable regular version of this method
-    ::grpc::Status sigSend(::grpc::ServerContext* context, const ::grpc_signer::GrpcMsgSsig* request, ::grpc_signer::NoReply* response) override {
-      abort();
-      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-    }
-    // replace default version of method with streamed unary
-    virtual ::grpc::Status StreamedsigSend(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_signer::GrpcMsgSsig,::grpc_signer::NoReply>* server_unary_streamer) = 0;
-  };
-  typedef WithStreamedUnaryMethod_join<WithStreamedUnaryMethod_dhKeyEx<WithStreamedUnaryMethod_keyExFinished<WithStreamedUnaryMethod_sigSend<Service > > > > StreamedUnaryService;
+  typedef WithStreamedUnaryMethod_signerService<Service > StreamedUnaryService;
   typedef Service SplitStreamedService;
-  typedef WithStreamedUnaryMethod_join<WithStreamedUnaryMethod_dhKeyEx<WithStreamedUnaryMethod_keyExFinished<WithStreamedUnaryMethod_sigSend<Service > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_signerService<Service > StreamedService;
 };
 
 }  // namespace grpc_signer

--- a/src/modules/communication/protos/protobuf_signer.pb.cc
+++ b/src/modules/communication/protos/protobuf_signer.pb.cc
@@ -20,169 +20,69 @@
 // @@protoc_insertion_point(includes)
 
 namespace grpc_signer {
-class GrpcMsgJoinDefaultTypeInternal {
+class RequestMsgDefaultTypeInternal {
  public:
-  ::google::protobuf::internal::ExplicitlyConstructed<GrpcMsgJoin>
+  ::google::protobuf::internal::ExplicitlyConstructed<RequestMsg>
       _instance;
-} _GrpcMsgJoin_default_instance_;
-class GrpcMsgChallengeDefaultTypeInternal {
+} _RequestMsg_default_instance_;
+class ReplyMsgDefaultTypeInternal {
  public:
-  ::google::protobuf::internal::ExplicitlyConstructed<GrpcMsgChallenge>
+  ::google::protobuf::internal::ExplicitlyConstructed<ReplyMsg>
       _instance;
-} _GrpcMsgChallenge_default_instance_;
-class GrpcMsgResponse1DefaultTypeInternal {
+} _ReplyMsg_default_instance_;
+class MsgStatusDefaultTypeInternal {
  public:
-  ::google::protobuf::internal::ExplicitlyConstructed<GrpcMsgResponse1>
+  ::google::protobuf::internal::ExplicitlyConstructed<MsgStatus>
       _instance;
-} _GrpcMsgResponse1_default_instance_;
-class GrpcMsgResponse2DefaultTypeInternal {
- public:
-  ::google::protobuf::internal::ExplicitlyConstructed<GrpcMsgResponse2>
-      _instance;
-} _GrpcMsgResponse2_default_instance_;
-class GrpcMsgSuccessDefaultTypeInternal {
- public:
-  ::google::protobuf::internal::ExplicitlyConstructed<GrpcMsgSuccess>
-      _instance;
-} _GrpcMsgSuccess_default_instance_;
-class GrpcMsgAcceptDefaultTypeInternal {
- public:
-  ::google::protobuf::internal::ExplicitlyConstructed<GrpcMsgAccept>
-      _instance;
-} _GrpcMsgAccept_default_instance_;
-class GrpcMsgSsigDefaultTypeInternal {
- public:
-  ::google::protobuf::internal::ExplicitlyConstructed<GrpcMsgSsig>
-      _instance;
-} _GrpcMsgSsig_default_instance_;
-class GrpcMsgReqSsigDefaultTypeInternal {
- public:
-  ::google::protobuf::internal::ExplicitlyConstructed<GrpcMsgReqSsig>
-      _instance;
-} _GrpcMsgReqSsig_default_instance_;
+} _MsgStatus_default_instance_;
 class IdentityDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<Identity>
       _instance;
 } _Identity_default_instance_;
-class NoReplyDefaultTypeInternal {
- public:
-  ::google::protobuf::internal::ExplicitlyConstructed<NoReply>
-      _instance;
-} _NoReply_default_instance_;
 }  // namespace grpc_signer
 namespace protobuf_protobuf_5fsigner_2eproto {
-static void InitDefaultsGrpcMsgJoin() {
+static void InitDefaultsRequestMsg() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   {
-    void* ptr = &::grpc_signer::_GrpcMsgJoin_default_instance_;
-    new (ptr) ::grpc_signer::GrpcMsgJoin();
+    void* ptr = &::grpc_signer::_RequestMsg_default_instance_;
+    new (ptr) ::grpc_signer::RequestMsg();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::grpc_signer::GrpcMsgJoin::InitAsDefaultInstance();
+  ::grpc_signer::RequestMsg::InitAsDefaultInstance();
 }
 
-::google::protobuf::internal::SCCInfo<0> scc_info_GrpcMsgJoin =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsGrpcMsgJoin}, {}};
+::google::protobuf::internal::SCCInfo<0> scc_info_RequestMsg =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsRequestMsg}, {}};
 
-static void InitDefaultsGrpcMsgChallenge() {
+static void InitDefaultsReplyMsg() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   {
-    void* ptr = &::grpc_signer::_GrpcMsgChallenge_default_instance_;
-    new (ptr) ::grpc_signer::GrpcMsgChallenge();
+    void* ptr = &::grpc_signer::_ReplyMsg_default_instance_;
+    new (ptr) ::grpc_signer::ReplyMsg();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::grpc_signer::GrpcMsgChallenge::InitAsDefaultInstance();
+  ::grpc_signer::ReplyMsg::InitAsDefaultInstance();
 }
 
-::google::protobuf::internal::SCCInfo<0> scc_info_GrpcMsgChallenge =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsGrpcMsgChallenge}, {}};
+::google::protobuf::internal::SCCInfo<0> scc_info_ReplyMsg =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsReplyMsg}, {}};
 
-static void InitDefaultsGrpcMsgResponse1() {
+static void InitDefaultsMsgStatus() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   {
-    void* ptr = &::grpc_signer::_GrpcMsgResponse1_default_instance_;
-    new (ptr) ::grpc_signer::GrpcMsgResponse1();
+    void* ptr = &::grpc_signer::_MsgStatus_default_instance_;
+    new (ptr) ::grpc_signer::MsgStatus();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::grpc_signer::GrpcMsgResponse1::InitAsDefaultInstance();
+  ::grpc_signer::MsgStatus::InitAsDefaultInstance();
 }
 
-::google::protobuf::internal::SCCInfo<0> scc_info_GrpcMsgResponse1 =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsGrpcMsgResponse1}, {}};
-
-static void InitDefaultsGrpcMsgResponse2() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
-
-  {
-    void* ptr = &::grpc_signer::_GrpcMsgResponse2_default_instance_;
-    new (ptr) ::grpc_signer::GrpcMsgResponse2();
-    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
-  }
-  ::grpc_signer::GrpcMsgResponse2::InitAsDefaultInstance();
-}
-
-::google::protobuf::internal::SCCInfo<0> scc_info_GrpcMsgResponse2 =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsGrpcMsgResponse2}, {}};
-
-static void InitDefaultsGrpcMsgSuccess() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
-
-  {
-    void* ptr = &::grpc_signer::_GrpcMsgSuccess_default_instance_;
-    new (ptr) ::grpc_signer::GrpcMsgSuccess();
-    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
-  }
-  ::grpc_signer::GrpcMsgSuccess::InitAsDefaultInstance();
-}
-
-::google::protobuf::internal::SCCInfo<0> scc_info_GrpcMsgSuccess =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsGrpcMsgSuccess}, {}};
-
-static void InitDefaultsGrpcMsgAccept() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
-
-  {
-    void* ptr = &::grpc_signer::_GrpcMsgAccept_default_instance_;
-    new (ptr) ::grpc_signer::GrpcMsgAccept();
-    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
-  }
-  ::grpc_signer::GrpcMsgAccept::InitAsDefaultInstance();
-}
-
-::google::protobuf::internal::SCCInfo<0> scc_info_GrpcMsgAccept =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsGrpcMsgAccept}, {}};
-
-static void InitDefaultsGrpcMsgSsig() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
-
-  {
-    void* ptr = &::grpc_signer::_GrpcMsgSsig_default_instance_;
-    new (ptr) ::grpc_signer::GrpcMsgSsig();
-    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
-  }
-  ::grpc_signer::GrpcMsgSsig::InitAsDefaultInstance();
-}
-
-::google::protobuf::internal::SCCInfo<0> scc_info_GrpcMsgSsig =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsGrpcMsgSsig}, {}};
-
-static void InitDefaultsGrpcMsgReqSsig() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
-
-  {
-    void* ptr = &::grpc_signer::_GrpcMsgReqSsig_default_instance_;
-    new (ptr) ::grpc_signer::GrpcMsgReqSsig();
-    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
-  }
-  ::grpc_signer::GrpcMsgReqSsig::InitAsDefaultInstance();
-}
-
-::google::protobuf::internal::SCCInfo<0> scc_info_GrpcMsgReqSsig =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsGrpcMsgReqSsig}, {}};
+::google::protobuf::internal::SCCInfo<0> scc_info_MsgStatus =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsMsgStatus}, {}};
 
 static void InitDefaultsIdentity() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -198,127 +98,62 @@ static void InitDefaultsIdentity() {
 ::google::protobuf::internal::SCCInfo<0> scc_info_Identity =
     {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsIdentity}, {}};
 
-static void InitDefaultsNoReply() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
-
-  {
-    void* ptr = &::grpc_signer::_NoReply_default_instance_;
-    new (ptr) ::grpc_signer::NoReply();
-    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
-  }
-  ::grpc_signer::NoReply::InitAsDefaultInstance();
-}
-
-::google::protobuf::internal::SCCInfo<0> scc_info_NoReply =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsNoReply}, {}};
-
 void InitDefaults() {
-  ::google::protobuf::internal::InitSCC(&scc_info_GrpcMsgJoin.base);
-  ::google::protobuf::internal::InitSCC(&scc_info_GrpcMsgChallenge.base);
-  ::google::protobuf::internal::InitSCC(&scc_info_GrpcMsgResponse1.base);
-  ::google::protobuf::internal::InitSCC(&scc_info_GrpcMsgResponse2.base);
-  ::google::protobuf::internal::InitSCC(&scc_info_GrpcMsgSuccess.base);
-  ::google::protobuf::internal::InitSCC(&scc_info_GrpcMsgAccept.base);
-  ::google::protobuf::internal::InitSCC(&scc_info_GrpcMsgSsig.base);
-  ::google::protobuf::internal::InitSCC(&scc_info_GrpcMsgReqSsig.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_RequestMsg.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_ReplyMsg.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_MsgStatus.base);
   ::google::protobuf::internal::InitSCC(&scc_info_Identity.base);
-  ::google::protobuf::internal::InitSCC(&scc_info_NoReply.base);
 }
 
-::google::protobuf::Metadata file_level_metadata[10];
+::google::protobuf::Metadata file_level_metadata[4];
+const ::google::protobuf::EnumDescriptor* file_level_enum_descriptors[1];
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::GrpcMsgJoin, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::RequestMsg, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::GrpcMsgJoin, message_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::RequestMsg, message_),
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::GrpcMsgChallenge, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::ReplyMsg, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::GrpcMsgChallenge, message_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::ReplyMsg, message_),
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::GrpcMsgResponse1, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::MsgStatus, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::GrpcMsgResponse1, message_),
-  ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::GrpcMsgResponse2, _internal_metadata_),
-  ~0u,  // no _extensions_
-  ~0u,  // no _oneof_case_
-  ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::GrpcMsgResponse2, message_),
-  ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::GrpcMsgSuccess, _internal_metadata_),
-  ~0u,  // no _extensions_
-  ~0u,  // no _oneof_case_
-  ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::GrpcMsgSuccess, message_),
-  ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::GrpcMsgAccept, _internal_metadata_),
-  ~0u,  // no _extensions_
-  ~0u,  // no _oneof_case_
-  ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::GrpcMsgAccept, message_),
-  ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::GrpcMsgSsig, _internal_metadata_),
-  ~0u,  // no _extensions_
-  ~0u,  // no _oneof_case_
-  ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::GrpcMsgSsig, message_),
-  ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::GrpcMsgReqSsig, _internal_metadata_),
-  ~0u,  // no _extensions_
-  ~0u,  // no _oneof_case_
-  ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::GrpcMsgReqSsig, message_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::MsgStatus, status_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::MsgStatus, message_),
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::Identity, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::Identity, sender_),
-  ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::NoReply, _internal_metadata_),
-  ~0u,  // no _extensions_
-  ~0u,  // no _oneof_case_
-  ~0u,  // no _weak_field_map_
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-  { 0, -1, sizeof(::grpc_signer::GrpcMsgJoin)},
-  { 6, -1, sizeof(::grpc_signer::GrpcMsgChallenge)},
-  { 12, -1, sizeof(::grpc_signer::GrpcMsgResponse1)},
-  { 18, -1, sizeof(::grpc_signer::GrpcMsgResponse2)},
-  { 24, -1, sizeof(::grpc_signer::GrpcMsgSuccess)},
-  { 30, -1, sizeof(::grpc_signer::GrpcMsgAccept)},
-  { 36, -1, sizeof(::grpc_signer::GrpcMsgSsig)},
-  { 42, -1, sizeof(::grpc_signer::GrpcMsgReqSsig)},
-  { 48, -1, sizeof(::grpc_signer::Identity)},
-  { 54, -1, sizeof(::grpc_signer::NoReply)},
+  { 0, -1, sizeof(::grpc_signer::RequestMsg)},
+  { 6, -1, sizeof(::grpc_signer::ReplyMsg)},
+  { 12, -1, sizeof(::grpc_signer::MsgStatus)},
+  { 19, -1, sizeof(::grpc_signer::Identity)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
-  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_signer::_GrpcMsgJoin_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_signer::_GrpcMsgChallenge_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_signer::_GrpcMsgResponse1_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_signer::_GrpcMsgResponse2_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_signer::_GrpcMsgSuccess_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_signer::_GrpcMsgAccept_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_signer::_GrpcMsgSsig_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_signer::_GrpcMsgReqSsig_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_signer::_RequestMsg_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_signer::_ReplyMsg_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_signer::_MsgStatus_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_signer::_Identity_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_signer::_NoReply_default_instance_),
 };
 
 void protobuf_AssignDescriptors() {
   AddDescriptors();
   AssignDescriptors(
       "protobuf_signer.proto", schemas, file_default_instances, TableStruct::offsets,
-      file_level_metadata, NULL, NULL);
+      file_level_metadata, file_level_enum_descriptors, NULL);
 }
 
 void protobuf_AssignDescriptorsOnce() {
@@ -329,35 +164,27 @@ void protobuf_AssignDescriptorsOnce() {
 void protobuf_RegisterTypes(const ::std::string&) GOOGLE_PROTOBUF_ATTRIBUTE_COLD;
 void protobuf_RegisterTypes(const ::std::string&) {
   protobuf_AssignDescriptorsOnce();
-  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 10);
+  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 4);
 }
 
 void AddDescriptorsImpl() {
   InitDefaults();
   static const char descriptor[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-      "\n\025protobuf_signer.proto\022\013grpc_signer\"\036\n\013"
-      "GrpcMsgJoin\022\017\n\007message\030\001 \001(\014\"#\n\020GrpcMsgC"
-      "hallenge\022\017\n\007message\030\001 \001(\014\"#\n\020GrpcMsgResp"
-      "onse1\022\017\n\007message\030\001 \001(\014\"#\n\020GrpcMsgRespons"
-      "e2\022\017\n\007message\030\001 \001(\014\"!\n\016GrpcMsgSuccess\022\017\n"
-      "\007message\030\001 \001(\014\" \n\rGrpcMsgAccept\022\017\n\007messa"
-      "ge\030\001 \001(\014\"\036\n\013GrpcMsgSsig\022\017\n\007message\030\001 \001(\014"
-      "\"!\n\016GrpcMsgReqSsig\022\017\n\007message\030\001 \001(\014\"\032\n\010I"
-      "dentity\022\016\n\006sender\030\001 \001(\014\"\t\n\007NoReply2\365\002\n\023G"
-      "ruutNetworkService\022A\n\004join\022\030.grpc_signer"
-      ".GrpcMsgJoin\032\035.grpc_signer.GrpcMsgChalle"
-      "nge\"\000\022I\n\007dhKeyEx\022\035.grpc_signer.GrpcMsgRe"
-      "sponse1\032\035.grpc_signer.GrpcMsgResponse2\"\000"
-      "\022J\n\rkeyExFinished\022\033.grpc_signer.GrpcMsgS"
-      "uccess\032\032.grpc_signer.GrpcMsgAccept\"\000\022;\n\007"
-      "sigSend\022\030.grpc_signer.GrpcMsgSsig\032\024.grpc"
-      "_signer.NoReply\"\000\022G\n\013openChannel\022\025.grpc_"
-      "signer.Identity\032\033.grpc_signer.GrpcMsgReq"
-      "Ssig\"\000(\0010\001B/\n\035com.gruutnetworks.gruutsig"
-      "nerB\014GruutNetworkP\001b\006proto3"
+      "\n\025protobuf_signer.proto\022\013grpc_signer\"\035\n\n"
+      "RequestMsg\022\017\n\007message\030\001 \001(\014\"\033\n\010ReplyMsg\022"
+      "\017\n\007message\030\001 \001(\014\"}\n\tMsgStatus\022-\n\006status\030"
+      "\001 \001(\0162\035.grpc_signer.MsgStatus.Status\022\017\n\007"
+      "message\030\002 \001(\t\"0\n\006Status\022\013\n\007SUCCESS\020\000\022\013\n\007"
+      "INVALID\020\001\022\014\n\010INTERNAL\020\002\"\032\n\010Identity\022\016\n\006s"
+      "ender\030\001 \001(\0142\233\001\n\022GruutSignerService\022A\n\013op"
+      "enChannel\022\025.grpc_signer.Identity\032\025.grpc_"
+      "signer.ReplyMsg\"\000(\0010\001\022B\n\rsignerService\022\027"
+      ".grpc_signer.RequestMsg\032\026.grpc_signer.Ms"
+      "gStatus\"\000B/\n\035com.gruutnetworks.gruutsign"
+      "erB\014GruutNetworkP\001b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 787);
+      descriptor, 466);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "protobuf_signer.proto", &protobuf_RegisterTypes);
 }
@@ -374,23 +201,46 @@ struct StaticDescriptorInitializer {
 } static_descriptor_initializer;
 }  // namespace protobuf_protobuf_5fsigner_2eproto
 namespace grpc_signer {
+const ::google::protobuf::EnumDescriptor* MsgStatus_Status_descriptor() {
+  protobuf_protobuf_5fsigner_2eproto::protobuf_AssignDescriptorsOnce();
+  return protobuf_protobuf_5fsigner_2eproto::file_level_enum_descriptors[0];
+}
+bool MsgStatus_Status_IsValid(int value) {
+  switch (value) {
+    case 0:
+    case 1:
+    case 2:
+      return true;
+    default:
+      return false;
+  }
+}
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const MsgStatus_Status MsgStatus::SUCCESS;
+const MsgStatus_Status MsgStatus::INVALID;
+const MsgStatus_Status MsgStatus::INTERNAL;
+const MsgStatus_Status MsgStatus::Status_MIN;
+const MsgStatus_Status MsgStatus::Status_MAX;
+const int MsgStatus::Status_ARRAYSIZE;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 // ===================================================================
 
-void GrpcMsgJoin::InitAsDefaultInstance() {
+void RequestMsg::InitAsDefaultInstance() {
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int GrpcMsgJoin::kMessageFieldNumber;
+const int RequestMsg::kMessageFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
-GrpcMsgJoin::GrpcMsgJoin()
+RequestMsg::RequestMsg()
   : ::google::protobuf::Message(), _internal_metadata_(NULL) {
   ::google::protobuf::internal::InitSCC(
-      &protobuf_protobuf_5fsigner_2eproto::scc_info_GrpcMsgJoin.base);
+      &protobuf_protobuf_5fsigner_2eproto::scc_info_RequestMsg.base);
   SharedCtor();
-  // @@protoc_insertion_point(constructor:grpc_signer.GrpcMsgJoin)
+  // @@protoc_insertion_point(constructor:grpc_signer.RequestMsg)
 }
-GrpcMsgJoin::GrpcMsgJoin(const GrpcMsgJoin& from)
+RequestMsg::RequestMsg(const RequestMsg& from)
   : ::google::protobuf::Message(),
       _internal_metadata_(NULL) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -398,38 +248,38 @@ GrpcMsgJoin::GrpcMsgJoin(const GrpcMsgJoin& from)
   if (from.message().size() > 0) {
     message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
   }
-  // @@protoc_insertion_point(copy_constructor:grpc_signer.GrpcMsgJoin)
+  // @@protoc_insertion_point(copy_constructor:grpc_signer.RequestMsg)
 }
 
-void GrpcMsgJoin::SharedCtor() {
+void RequestMsg::SharedCtor() {
   message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
-GrpcMsgJoin::~GrpcMsgJoin() {
-  // @@protoc_insertion_point(destructor:grpc_signer.GrpcMsgJoin)
+RequestMsg::~RequestMsg() {
+  // @@protoc_insertion_point(destructor:grpc_signer.RequestMsg)
   SharedDtor();
 }
 
-void GrpcMsgJoin::SharedDtor() {
+void RequestMsg::SharedDtor() {
   message_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
-void GrpcMsgJoin::SetCachedSize(int size) const {
+void RequestMsg::SetCachedSize(int size) const {
   _cached_size_.Set(size);
 }
-const ::google::protobuf::Descriptor* GrpcMsgJoin::descriptor() {
+const ::google::protobuf::Descriptor* RequestMsg::descriptor() {
   ::protobuf_protobuf_5fsigner_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_protobuf_5fsigner_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
 }
 
-const GrpcMsgJoin& GrpcMsgJoin::default_instance() {
-  ::google::protobuf::internal::InitSCC(&protobuf_protobuf_5fsigner_2eproto::scc_info_GrpcMsgJoin.base);
+const RequestMsg& RequestMsg::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_protobuf_5fsigner_2eproto::scc_info_RequestMsg.base);
   return *internal_default_instance();
 }
 
 
-void GrpcMsgJoin::Clear() {
-// @@protoc_insertion_point(message_clear_start:grpc_signer.GrpcMsgJoin)
+void RequestMsg::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_signer.RequestMsg)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -438,11 +288,11 @@ void GrpcMsgJoin::Clear() {
   _internal_metadata_.Clear();
 }
 
-bool GrpcMsgJoin::MergePartialFromCodedStream(
+bool RequestMsg::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:grpc_signer.GrpcMsgJoin)
+  // @@protoc_insertion_point(parse_start:grpc_signer.RequestMsg)
   for (;;) {
     ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
@@ -472,17 +322,17 @@ bool GrpcMsgJoin::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:grpc_signer.GrpcMsgJoin)
+  // @@protoc_insertion_point(parse_success:grpc_signer.RequestMsg)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:grpc_signer.GrpcMsgJoin)
+  // @@protoc_insertion_point(parse_failure:grpc_signer.RequestMsg)
   return false;
 #undef DO_
 }
 
-void GrpcMsgJoin::SerializeWithCachedSizes(
+void RequestMsg::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:grpc_signer.GrpcMsgJoin)
+  // @@protoc_insertion_point(serialize_start:grpc_signer.RequestMsg)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -496,13 +346,13 @@ void GrpcMsgJoin::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:grpc_signer.GrpcMsgJoin)
+  // @@protoc_insertion_point(serialize_end:grpc_signer.RequestMsg)
 }
 
-::google::protobuf::uint8* GrpcMsgJoin::InternalSerializeWithCachedSizesToArray(
+::google::protobuf::uint8* RequestMsg::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:grpc_signer.GrpcMsgJoin)
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_signer.RequestMsg)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -517,12 +367,12 @@ void GrpcMsgJoin::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:grpc_signer.GrpcMsgJoin)
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_signer.RequestMsg)
   return target;
 }
 
-size_t GrpcMsgJoin::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:grpc_signer.GrpcMsgJoin)
+size_t RequestMsg::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_signer.RequestMsg)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -542,23 +392,23 @@ size_t GrpcMsgJoin::ByteSizeLong() const {
   return total_size;
 }
 
-void GrpcMsgJoin::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:grpc_signer.GrpcMsgJoin)
+void RequestMsg::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_signer.RequestMsg)
   GOOGLE_DCHECK_NE(&from, this);
-  const GrpcMsgJoin* source =
-      ::google::protobuf::internal::DynamicCastToGenerated<const GrpcMsgJoin>(
+  const RequestMsg* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const RequestMsg>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_signer.GrpcMsgJoin)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_signer.RequestMsg)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_signer.GrpcMsgJoin)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_signer.RequestMsg)
     MergeFrom(*source);
   }
 }
 
-void GrpcMsgJoin::MergeFrom(const GrpcMsgJoin& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:grpc_signer.GrpcMsgJoin)
+void RequestMsg::MergeFrom(const RequestMsg& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_signer.RequestMsg)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -570,36 +420,36 @@ void GrpcMsgJoin::MergeFrom(const GrpcMsgJoin& from) {
   }
 }
 
-void GrpcMsgJoin::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:grpc_signer.GrpcMsgJoin)
+void RequestMsg::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_signer.RequestMsg)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-void GrpcMsgJoin::CopyFrom(const GrpcMsgJoin& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:grpc_signer.GrpcMsgJoin)
+void RequestMsg::CopyFrom(const RequestMsg& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_signer.RequestMsg)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool GrpcMsgJoin::IsInitialized() const {
+bool RequestMsg::IsInitialized() const {
   return true;
 }
 
-void GrpcMsgJoin::Swap(GrpcMsgJoin* other) {
+void RequestMsg::Swap(RequestMsg* other) {
   if (other == this) return;
   InternalSwap(other);
 }
-void GrpcMsgJoin::InternalSwap(GrpcMsgJoin* other) {
+void RequestMsg::InternalSwap(RequestMsg* other) {
   using std::swap;
   message_.Swap(&other->message_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
 
-::google::protobuf::Metadata GrpcMsgJoin::GetMetadata() const {
+::google::protobuf::Metadata RequestMsg::GetMetadata() const {
   protobuf_protobuf_5fsigner_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_protobuf_5fsigner_2eproto::file_level_metadata[kIndexInFileMessages];
 }
@@ -607,20 +457,20 @@ void GrpcMsgJoin::InternalSwap(GrpcMsgJoin* other) {
 
 // ===================================================================
 
-void GrpcMsgChallenge::InitAsDefaultInstance() {
+void ReplyMsg::InitAsDefaultInstance() {
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int GrpcMsgChallenge::kMessageFieldNumber;
+const int ReplyMsg::kMessageFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
-GrpcMsgChallenge::GrpcMsgChallenge()
+ReplyMsg::ReplyMsg()
   : ::google::protobuf::Message(), _internal_metadata_(NULL) {
   ::google::protobuf::internal::InitSCC(
-      &protobuf_protobuf_5fsigner_2eproto::scc_info_GrpcMsgChallenge.base);
+      &protobuf_protobuf_5fsigner_2eproto::scc_info_ReplyMsg.base);
   SharedCtor();
-  // @@protoc_insertion_point(constructor:grpc_signer.GrpcMsgChallenge)
+  // @@protoc_insertion_point(constructor:grpc_signer.ReplyMsg)
 }
-GrpcMsgChallenge::GrpcMsgChallenge(const GrpcMsgChallenge& from)
+ReplyMsg::ReplyMsg(const ReplyMsg& from)
   : ::google::protobuf::Message(),
       _internal_metadata_(NULL) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -628,38 +478,38 @@ GrpcMsgChallenge::GrpcMsgChallenge(const GrpcMsgChallenge& from)
   if (from.message().size() > 0) {
     message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
   }
-  // @@protoc_insertion_point(copy_constructor:grpc_signer.GrpcMsgChallenge)
+  // @@protoc_insertion_point(copy_constructor:grpc_signer.ReplyMsg)
 }
 
-void GrpcMsgChallenge::SharedCtor() {
+void ReplyMsg::SharedCtor() {
   message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
-GrpcMsgChallenge::~GrpcMsgChallenge() {
-  // @@protoc_insertion_point(destructor:grpc_signer.GrpcMsgChallenge)
+ReplyMsg::~ReplyMsg() {
+  // @@protoc_insertion_point(destructor:grpc_signer.ReplyMsg)
   SharedDtor();
 }
 
-void GrpcMsgChallenge::SharedDtor() {
+void ReplyMsg::SharedDtor() {
   message_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
-void GrpcMsgChallenge::SetCachedSize(int size) const {
+void ReplyMsg::SetCachedSize(int size) const {
   _cached_size_.Set(size);
 }
-const ::google::protobuf::Descriptor* GrpcMsgChallenge::descriptor() {
+const ::google::protobuf::Descriptor* ReplyMsg::descriptor() {
   ::protobuf_protobuf_5fsigner_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_protobuf_5fsigner_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
 }
 
-const GrpcMsgChallenge& GrpcMsgChallenge::default_instance() {
-  ::google::protobuf::internal::InitSCC(&protobuf_protobuf_5fsigner_2eproto::scc_info_GrpcMsgChallenge.base);
+const ReplyMsg& ReplyMsg::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_protobuf_5fsigner_2eproto::scc_info_ReplyMsg.base);
   return *internal_default_instance();
 }
 
 
-void GrpcMsgChallenge::Clear() {
-// @@protoc_insertion_point(message_clear_start:grpc_signer.GrpcMsgChallenge)
+void ReplyMsg::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_signer.ReplyMsg)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -668,11 +518,11 @@ void GrpcMsgChallenge::Clear() {
   _internal_metadata_.Clear();
 }
 
-bool GrpcMsgChallenge::MergePartialFromCodedStream(
+bool ReplyMsg::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:grpc_signer.GrpcMsgChallenge)
+  // @@protoc_insertion_point(parse_start:grpc_signer.ReplyMsg)
   for (;;) {
     ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
@@ -702,17 +552,17 @@ bool GrpcMsgChallenge::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:grpc_signer.GrpcMsgChallenge)
+  // @@protoc_insertion_point(parse_success:grpc_signer.ReplyMsg)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:grpc_signer.GrpcMsgChallenge)
+  // @@protoc_insertion_point(parse_failure:grpc_signer.ReplyMsg)
   return false;
 #undef DO_
 }
 
-void GrpcMsgChallenge::SerializeWithCachedSizes(
+void ReplyMsg::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:grpc_signer.GrpcMsgChallenge)
+  // @@protoc_insertion_point(serialize_start:grpc_signer.ReplyMsg)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -726,13 +576,13 @@ void GrpcMsgChallenge::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:grpc_signer.GrpcMsgChallenge)
+  // @@protoc_insertion_point(serialize_end:grpc_signer.ReplyMsg)
 }
 
-::google::protobuf::uint8* GrpcMsgChallenge::InternalSerializeWithCachedSizesToArray(
+::google::protobuf::uint8* ReplyMsg::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:grpc_signer.GrpcMsgChallenge)
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_signer.ReplyMsg)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -747,12 +597,12 @@ void GrpcMsgChallenge::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:grpc_signer.GrpcMsgChallenge)
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_signer.ReplyMsg)
   return target;
 }
 
-size_t GrpcMsgChallenge::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:grpc_signer.GrpcMsgChallenge)
+size_t ReplyMsg::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_signer.ReplyMsg)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -772,23 +622,23 @@ size_t GrpcMsgChallenge::ByteSizeLong() const {
   return total_size;
 }
 
-void GrpcMsgChallenge::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:grpc_signer.GrpcMsgChallenge)
+void ReplyMsg::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_signer.ReplyMsg)
   GOOGLE_DCHECK_NE(&from, this);
-  const GrpcMsgChallenge* source =
-      ::google::protobuf::internal::DynamicCastToGenerated<const GrpcMsgChallenge>(
+  const ReplyMsg* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const ReplyMsg>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_signer.GrpcMsgChallenge)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_signer.ReplyMsg)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_signer.GrpcMsgChallenge)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_signer.ReplyMsg)
     MergeFrom(*source);
   }
 }
 
-void GrpcMsgChallenge::MergeFrom(const GrpcMsgChallenge& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:grpc_signer.GrpcMsgChallenge)
+void ReplyMsg::MergeFrom(const ReplyMsg& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_signer.ReplyMsg)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -800,36 +650,36 @@ void GrpcMsgChallenge::MergeFrom(const GrpcMsgChallenge& from) {
   }
 }
 
-void GrpcMsgChallenge::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:grpc_signer.GrpcMsgChallenge)
+void ReplyMsg::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_signer.ReplyMsg)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-void GrpcMsgChallenge::CopyFrom(const GrpcMsgChallenge& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:grpc_signer.GrpcMsgChallenge)
+void ReplyMsg::CopyFrom(const ReplyMsg& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_signer.ReplyMsg)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool GrpcMsgChallenge::IsInitialized() const {
+bool ReplyMsg::IsInitialized() const {
   return true;
 }
 
-void GrpcMsgChallenge::Swap(GrpcMsgChallenge* other) {
+void ReplyMsg::Swap(ReplyMsg* other) {
   if (other == this) return;
   InternalSwap(other);
 }
-void GrpcMsgChallenge::InternalSwap(GrpcMsgChallenge* other) {
+void ReplyMsg::InternalSwap(ReplyMsg* other) {
   using std::swap;
   message_.Swap(&other->message_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
 
-::google::protobuf::Metadata GrpcMsgChallenge::GetMetadata() const {
+::google::protobuf::Metadata ReplyMsg::GetMetadata() const {
   protobuf_protobuf_5fsigner_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_protobuf_5fsigner_2eproto::file_level_metadata[kIndexInFileMessages];
 }
@@ -837,20 +687,21 @@ void GrpcMsgChallenge::InternalSwap(GrpcMsgChallenge* other) {
 
 // ===================================================================
 
-void GrpcMsgResponse1::InitAsDefaultInstance() {
+void MsgStatus::InitAsDefaultInstance() {
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int GrpcMsgResponse1::kMessageFieldNumber;
+const int MsgStatus::kStatusFieldNumber;
+const int MsgStatus::kMessageFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
-GrpcMsgResponse1::GrpcMsgResponse1()
+MsgStatus::MsgStatus()
   : ::google::protobuf::Message(), _internal_metadata_(NULL) {
   ::google::protobuf::internal::InitSCC(
-      &protobuf_protobuf_5fsigner_2eproto::scc_info_GrpcMsgResponse1.base);
+      &protobuf_protobuf_5fsigner_2eproto::scc_info_MsgStatus.base);
   SharedCtor();
-  // @@protoc_insertion_point(constructor:grpc_signer.GrpcMsgResponse1)
+  // @@protoc_insertion_point(constructor:grpc_signer.MsgStatus)
 }
-GrpcMsgResponse1::GrpcMsgResponse1(const GrpcMsgResponse1& from)
+MsgStatus::MsgStatus(const MsgStatus& from)
   : ::google::protobuf::Message(),
       _internal_metadata_(NULL) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -858,62 +709,84 @@ GrpcMsgResponse1::GrpcMsgResponse1(const GrpcMsgResponse1& from)
   if (from.message().size() > 0) {
     message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
   }
-  // @@protoc_insertion_point(copy_constructor:grpc_signer.GrpcMsgResponse1)
+  status_ = from.status_;
+  // @@protoc_insertion_point(copy_constructor:grpc_signer.MsgStatus)
 }
 
-void GrpcMsgResponse1::SharedCtor() {
+void MsgStatus::SharedCtor() {
   message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  status_ = 0;
 }
 
-GrpcMsgResponse1::~GrpcMsgResponse1() {
-  // @@protoc_insertion_point(destructor:grpc_signer.GrpcMsgResponse1)
+MsgStatus::~MsgStatus() {
+  // @@protoc_insertion_point(destructor:grpc_signer.MsgStatus)
   SharedDtor();
 }
 
-void GrpcMsgResponse1::SharedDtor() {
+void MsgStatus::SharedDtor() {
   message_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
-void GrpcMsgResponse1::SetCachedSize(int size) const {
+void MsgStatus::SetCachedSize(int size) const {
   _cached_size_.Set(size);
 }
-const ::google::protobuf::Descriptor* GrpcMsgResponse1::descriptor() {
+const ::google::protobuf::Descriptor* MsgStatus::descriptor() {
   ::protobuf_protobuf_5fsigner_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_protobuf_5fsigner_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
 }
 
-const GrpcMsgResponse1& GrpcMsgResponse1::default_instance() {
-  ::google::protobuf::internal::InitSCC(&protobuf_protobuf_5fsigner_2eproto::scc_info_GrpcMsgResponse1.base);
+const MsgStatus& MsgStatus::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_protobuf_5fsigner_2eproto::scc_info_MsgStatus.base);
   return *internal_default_instance();
 }
 
 
-void GrpcMsgResponse1::Clear() {
-// @@protoc_insertion_point(message_clear_start:grpc_signer.GrpcMsgResponse1)
+void MsgStatus::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_signer.MsgStatus)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
   message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  status_ = 0;
   _internal_metadata_.Clear();
 }
 
-bool GrpcMsgResponse1::MergePartialFromCodedStream(
+bool MsgStatus::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:grpc_signer.GrpcMsgResponse1)
+  // @@protoc_insertion_point(parse_start:grpc_signer.MsgStatus)
   for (;;) {
     ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // bytes message = 1;
+      // .grpc_signer.MsgStatus.Status status = 1;
       case 1: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
-            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
-          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
+            static_cast< ::google::protobuf::uint8>(8u /* 8 & 0xFF */)) {
+          int value;
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   int, ::google::protobuf::internal::WireFormatLite::TYPE_ENUM>(
+                 input, &value)));
+          set_status(static_cast< ::grpc_signer::MsgStatus_Status >(value));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string message = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
                 input, this->mutable_message()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->message().data(), static_cast<int>(this->message().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "grpc_signer.MsgStatus.message"));
         } else {
           goto handle_unusual;
         }
@@ -932,57 +805,77 @@ bool GrpcMsgResponse1::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:grpc_signer.GrpcMsgResponse1)
+  // @@protoc_insertion_point(parse_success:grpc_signer.MsgStatus)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:grpc_signer.GrpcMsgResponse1)
+  // @@protoc_insertion_point(parse_failure:grpc_signer.MsgStatus)
   return false;
 #undef DO_
 }
 
-void GrpcMsgResponse1::SerializeWithCachedSizes(
+void MsgStatus::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:grpc_signer.GrpcMsgResponse1)
+  // @@protoc_insertion_point(serialize_start:grpc_signer.MsgStatus)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // bytes message = 1;
+  // .grpc_signer.MsgStatus.Status status = 1;
+  if (this->status() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteEnum(
+      1, this->status(), output);
+  }
+
+  // string message = 2;
   if (this->message().size() > 0) {
-    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
-      1, this->message(), output);
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->message().data(), static_cast<int>(this->message().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_signer.MsgStatus.message");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      2, this->message(), output);
   }
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:grpc_signer.GrpcMsgResponse1)
+  // @@protoc_insertion_point(serialize_end:grpc_signer.MsgStatus)
 }
 
-::google::protobuf::uint8* GrpcMsgResponse1::InternalSerializeWithCachedSizesToArray(
+::google::protobuf::uint8* MsgStatus::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:grpc_signer.GrpcMsgResponse1)
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_signer.MsgStatus)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // bytes message = 1;
+  // .grpc_signer.MsgStatus.Status status = 1;
+  if (this->status() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
+      1, this->status(), target);
+  }
+
+  // string message = 2;
   if (this->message().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->message().data(), static_cast<int>(this->message().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_signer.MsgStatus.message");
     target =
-      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
-        1, this->message(), target);
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        2, this->message(), target);
   }
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:grpc_signer.GrpcMsgResponse1)
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_signer.MsgStatus)
   return target;
 }
 
-size_t GrpcMsgResponse1::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:grpc_signer.GrpcMsgResponse1)
+size_t MsgStatus::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_signer.MsgStatus)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -990,11 +883,17 @@ size_t GrpcMsgResponse1::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
-  // bytes message = 1;
+  // string message = 2;
   if (this->message().size() > 0) {
     total_size += 1 +
-      ::google::protobuf::internal::WireFormatLite::BytesSize(
+      ::google::protobuf::internal::WireFormatLite::StringSize(
         this->message());
+  }
+
+  // .grpc_signer.MsgStatus.Status status = 1;
+  if (this->status() != 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::EnumSize(this->status());
   }
 
   int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
@@ -1002,23 +901,23 @@ size_t GrpcMsgResponse1::ByteSizeLong() const {
   return total_size;
 }
 
-void GrpcMsgResponse1::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:grpc_signer.GrpcMsgResponse1)
+void MsgStatus::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_signer.MsgStatus)
   GOOGLE_DCHECK_NE(&from, this);
-  const GrpcMsgResponse1* source =
-      ::google::protobuf::internal::DynamicCastToGenerated<const GrpcMsgResponse1>(
+  const MsgStatus* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const MsgStatus>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_signer.GrpcMsgResponse1)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_signer.MsgStatus)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_signer.GrpcMsgResponse1)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_signer.MsgStatus)
     MergeFrom(*source);
   }
 }
 
-void GrpcMsgResponse1::MergeFrom(const GrpcMsgResponse1& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:grpc_signer.GrpcMsgResponse1)
+void MsgStatus::MergeFrom(const MsgStatus& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_signer.MsgStatus)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -1028,1188 +927,42 @@ void GrpcMsgResponse1::MergeFrom(const GrpcMsgResponse1& from) {
 
     message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
   }
+  if (from.status() != 0) {
+    set_status(from.status());
+  }
 }
 
-void GrpcMsgResponse1::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:grpc_signer.GrpcMsgResponse1)
+void MsgStatus::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_signer.MsgStatus)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-void GrpcMsgResponse1::CopyFrom(const GrpcMsgResponse1& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:grpc_signer.GrpcMsgResponse1)
+void MsgStatus::CopyFrom(const MsgStatus& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_signer.MsgStatus)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool GrpcMsgResponse1::IsInitialized() const {
+bool MsgStatus::IsInitialized() const {
   return true;
 }
 
-void GrpcMsgResponse1::Swap(GrpcMsgResponse1* other) {
+void MsgStatus::Swap(MsgStatus* other) {
   if (other == this) return;
   InternalSwap(other);
 }
-void GrpcMsgResponse1::InternalSwap(GrpcMsgResponse1* other) {
+void MsgStatus::InternalSwap(MsgStatus* other) {
   using std::swap;
   message_.Swap(&other->message_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
+  swap(status_, other->status_);
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
 
-::google::protobuf::Metadata GrpcMsgResponse1::GetMetadata() const {
-  protobuf_protobuf_5fsigner_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_protobuf_5fsigner_2eproto::file_level_metadata[kIndexInFileMessages];
-}
-
-
-// ===================================================================
-
-void GrpcMsgResponse2::InitAsDefaultInstance() {
-}
-#if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int GrpcMsgResponse2::kMessageFieldNumber;
-#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
-
-GrpcMsgResponse2::GrpcMsgResponse2()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
-  ::google::protobuf::internal::InitSCC(
-      &protobuf_protobuf_5fsigner_2eproto::scc_info_GrpcMsgResponse2.base);
-  SharedCtor();
-  // @@protoc_insertion_point(constructor:grpc_signer.GrpcMsgResponse2)
-}
-GrpcMsgResponse2::GrpcMsgResponse2(const GrpcMsgResponse2& from)
-  : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (from.message().size() > 0) {
-    message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
-  }
-  // @@protoc_insertion_point(copy_constructor:grpc_signer.GrpcMsgResponse2)
-}
-
-void GrpcMsgResponse2::SharedCtor() {
-  message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-
-GrpcMsgResponse2::~GrpcMsgResponse2() {
-  // @@protoc_insertion_point(destructor:grpc_signer.GrpcMsgResponse2)
-  SharedDtor();
-}
-
-void GrpcMsgResponse2::SharedDtor() {
-  message_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-
-void GrpcMsgResponse2::SetCachedSize(int size) const {
-  _cached_size_.Set(size);
-}
-const ::google::protobuf::Descriptor* GrpcMsgResponse2::descriptor() {
-  ::protobuf_protobuf_5fsigner_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_protobuf_5fsigner_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
-}
-
-const GrpcMsgResponse2& GrpcMsgResponse2::default_instance() {
-  ::google::protobuf::internal::InitSCC(&protobuf_protobuf_5fsigner_2eproto::scc_info_GrpcMsgResponse2.base);
-  return *internal_default_instance();
-}
-
-
-void GrpcMsgResponse2::Clear() {
-// @@protoc_insertion_point(message_clear_start:grpc_signer.GrpcMsgResponse2)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  _internal_metadata_.Clear();
-}
-
-bool GrpcMsgResponse2::MergePartialFromCodedStream(
-    ::google::protobuf::io::CodedInputStream* input) {
-#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
-  ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:grpc_signer.GrpcMsgResponse2)
-  for (;;) {
-    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
-    tag = p.first;
-    if (!p.second) goto handle_unusual;
-    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // bytes message = 1;
-      case 1: {
-        if (static_cast< ::google::protobuf::uint8>(tag) ==
-            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
-          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
-                input, this->mutable_message()));
-        } else {
-          goto handle_unusual;
-        }
-        break;
-      }
-
-      default: {
-      handle_unusual:
-        if (tag == 0) {
-          goto success;
-        }
-        DO_(::google::protobuf::internal::WireFormat::SkipField(
-              input, tag, _internal_metadata_.mutable_unknown_fields()));
-        break;
-      }
-    }
-  }
-success:
-  // @@protoc_insertion_point(parse_success:grpc_signer.GrpcMsgResponse2)
-  return true;
-failure:
-  // @@protoc_insertion_point(parse_failure:grpc_signer.GrpcMsgResponse2)
-  return false;
-#undef DO_
-}
-
-void GrpcMsgResponse2::SerializeWithCachedSizes(
-    ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:grpc_signer.GrpcMsgResponse2)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  // bytes message = 1;
-  if (this->message().size() > 0) {
-    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
-      1, this->message(), output);
-  }
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
-  }
-  // @@protoc_insertion_point(serialize_end:grpc_signer.GrpcMsgResponse2)
-}
-
-::google::protobuf::uint8* GrpcMsgResponse2::InternalSerializeWithCachedSizesToArray(
-    bool deterministic, ::google::protobuf::uint8* target) const {
-  (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:grpc_signer.GrpcMsgResponse2)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  // bytes message = 1;
-  if (this->message().size() > 0) {
-    target =
-      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
-        1, this->message(), target);
-  }
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
-  }
-  // @@protoc_insertion_point(serialize_to_array_end:grpc_signer.GrpcMsgResponse2)
-  return target;
-}
-
-size_t GrpcMsgResponse2::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:grpc_signer.GrpcMsgResponse2)
-  size_t total_size = 0;
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    total_size +=
-      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
-  }
-  // bytes message = 1;
-  if (this->message().size() > 0) {
-    total_size += 1 +
-      ::google::protobuf::internal::WireFormatLite::BytesSize(
-        this->message());
-  }
-
-  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
-  SetCachedSize(cached_size);
-  return total_size;
-}
-
-void GrpcMsgResponse2::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:grpc_signer.GrpcMsgResponse2)
-  GOOGLE_DCHECK_NE(&from, this);
-  const GrpcMsgResponse2* source =
-      ::google::protobuf::internal::DynamicCastToGenerated<const GrpcMsgResponse2>(
-          &from);
-  if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_signer.GrpcMsgResponse2)
-    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
-  } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_signer.GrpcMsgResponse2)
-    MergeFrom(*source);
-  }
-}
-
-void GrpcMsgResponse2::MergeFrom(const GrpcMsgResponse2& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:grpc_signer.GrpcMsgResponse2)
-  GOOGLE_DCHECK_NE(&from, this);
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  if (from.message().size() > 0) {
-
-    message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
-  }
-}
-
-void GrpcMsgResponse2::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:grpc_signer.GrpcMsgResponse2)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-void GrpcMsgResponse2::CopyFrom(const GrpcMsgResponse2& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:grpc_signer.GrpcMsgResponse2)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-bool GrpcMsgResponse2::IsInitialized() const {
-  return true;
-}
-
-void GrpcMsgResponse2::Swap(GrpcMsgResponse2* other) {
-  if (other == this) return;
-  InternalSwap(other);
-}
-void GrpcMsgResponse2::InternalSwap(GrpcMsgResponse2* other) {
-  using std::swap;
-  message_.Swap(&other->message_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-    GetArenaNoVirtual());
-  _internal_metadata_.Swap(&other->_internal_metadata_);
-}
-
-::google::protobuf::Metadata GrpcMsgResponse2::GetMetadata() const {
-  protobuf_protobuf_5fsigner_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_protobuf_5fsigner_2eproto::file_level_metadata[kIndexInFileMessages];
-}
-
-
-// ===================================================================
-
-void GrpcMsgSuccess::InitAsDefaultInstance() {
-}
-#if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int GrpcMsgSuccess::kMessageFieldNumber;
-#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
-
-GrpcMsgSuccess::GrpcMsgSuccess()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
-  ::google::protobuf::internal::InitSCC(
-      &protobuf_protobuf_5fsigner_2eproto::scc_info_GrpcMsgSuccess.base);
-  SharedCtor();
-  // @@protoc_insertion_point(constructor:grpc_signer.GrpcMsgSuccess)
-}
-GrpcMsgSuccess::GrpcMsgSuccess(const GrpcMsgSuccess& from)
-  : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (from.message().size() > 0) {
-    message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
-  }
-  // @@protoc_insertion_point(copy_constructor:grpc_signer.GrpcMsgSuccess)
-}
-
-void GrpcMsgSuccess::SharedCtor() {
-  message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-
-GrpcMsgSuccess::~GrpcMsgSuccess() {
-  // @@protoc_insertion_point(destructor:grpc_signer.GrpcMsgSuccess)
-  SharedDtor();
-}
-
-void GrpcMsgSuccess::SharedDtor() {
-  message_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-
-void GrpcMsgSuccess::SetCachedSize(int size) const {
-  _cached_size_.Set(size);
-}
-const ::google::protobuf::Descriptor* GrpcMsgSuccess::descriptor() {
-  ::protobuf_protobuf_5fsigner_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_protobuf_5fsigner_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
-}
-
-const GrpcMsgSuccess& GrpcMsgSuccess::default_instance() {
-  ::google::protobuf::internal::InitSCC(&protobuf_protobuf_5fsigner_2eproto::scc_info_GrpcMsgSuccess.base);
-  return *internal_default_instance();
-}
-
-
-void GrpcMsgSuccess::Clear() {
-// @@protoc_insertion_point(message_clear_start:grpc_signer.GrpcMsgSuccess)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  _internal_metadata_.Clear();
-}
-
-bool GrpcMsgSuccess::MergePartialFromCodedStream(
-    ::google::protobuf::io::CodedInputStream* input) {
-#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
-  ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:grpc_signer.GrpcMsgSuccess)
-  for (;;) {
-    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
-    tag = p.first;
-    if (!p.second) goto handle_unusual;
-    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // bytes message = 1;
-      case 1: {
-        if (static_cast< ::google::protobuf::uint8>(tag) ==
-            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
-          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
-                input, this->mutable_message()));
-        } else {
-          goto handle_unusual;
-        }
-        break;
-      }
-
-      default: {
-      handle_unusual:
-        if (tag == 0) {
-          goto success;
-        }
-        DO_(::google::protobuf::internal::WireFormat::SkipField(
-              input, tag, _internal_metadata_.mutable_unknown_fields()));
-        break;
-      }
-    }
-  }
-success:
-  // @@protoc_insertion_point(parse_success:grpc_signer.GrpcMsgSuccess)
-  return true;
-failure:
-  // @@protoc_insertion_point(parse_failure:grpc_signer.GrpcMsgSuccess)
-  return false;
-#undef DO_
-}
-
-void GrpcMsgSuccess::SerializeWithCachedSizes(
-    ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:grpc_signer.GrpcMsgSuccess)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  // bytes message = 1;
-  if (this->message().size() > 0) {
-    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
-      1, this->message(), output);
-  }
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
-  }
-  // @@protoc_insertion_point(serialize_end:grpc_signer.GrpcMsgSuccess)
-}
-
-::google::protobuf::uint8* GrpcMsgSuccess::InternalSerializeWithCachedSizesToArray(
-    bool deterministic, ::google::protobuf::uint8* target) const {
-  (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:grpc_signer.GrpcMsgSuccess)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  // bytes message = 1;
-  if (this->message().size() > 0) {
-    target =
-      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
-        1, this->message(), target);
-  }
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
-  }
-  // @@protoc_insertion_point(serialize_to_array_end:grpc_signer.GrpcMsgSuccess)
-  return target;
-}
-
-size_t GrpcMsgSuccess::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:grpc_signer.GrpcMsgSuccess)
-  size_t total_size = 0;
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    total_size +=
-      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
-  }
-  // bytes message = 1;
-  if (this->message().size() > 0) {
-    total_size += 1 +
-      ::google::protobuf::internal::WireFormatLite::BytesSize(
-        this->message());
-  }
-
-  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
-  SetCachedSize(cached_size);
-  return total_size;
-}
-
-void GrpcMsgSuccess::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:grpc_signer.GrpcMsgSuccess)
-  GOOGLE_DCHECK_NE(&from, this);
-  const GrpcMsgSuccess* source =
-      ::google::protobuf::internal::DynamicCastToGenerated<const GrpcMsgSuccess>(
-          &from);
-  if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_signer.GrpcMsgSuccess)
-    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
-  } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_signer.GrpcMsgSuccess)
-    MergeFrom(*source);
-  }
-}
-
-void GrpcMsgSuccess::MergeFrom(const GrpcMsgSuccess& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:grpc_signer.GrpcMsgSuccess)
-  GOOGLE_DCHECK_NE(&from, this);
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  if (from.message().size() > 0) {
-
-    message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
-  }
-}
-
-void GrpcMsgSuccess::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:grpc_signer.GrpcMsgSuccess)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-void GrpcMsgSuccess::CopyFrom(const GrpcMsgSuccess& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:grpc_signer.GrpcMsgSuccess)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-bool GrpcMsgSuccess::IsInitialized() const {
-  return true;
-}
-
-void GrpcMsgSuccess::Swap(GrpcMsgSuccess* other) {
-  if (other == this) return;
-  InternalSwap(other);
-}
-void GrpcMsgSuccess::InternalSwap(GrpcMsgSuccess* other) {
-  using std::swap;
-  message_.Swap(&other->message_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-    GetArenaNoVirtual());
-  _internal_metadata_.Swap(&other->_internal_metadata_);
-}
-
-::google::protobuf::Metadata GrpcMsgSuccess::GetMetadata() const {
-  protobuf_protobuf_5fsigner_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_protobuf_5fsigner_2eproto::file_level_metadata[kIndexInFileMessages];
-}
-
-
-// ===================================================================
-
-void GrpcMsgAccept::InitAsDefaultInstance() {
-}
-#if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int GrpcMsgAccept::kMessageFieldNumber;
-#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
-
-GrpcMsgAccept::GrpcMsgAccept()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
-  ::google::protobuf::internal::InitSCC(
-      &protobuf_protobuf_5fsigner_2eproto::scc_info_GrpcMsgAccept.base);
-  SharedCtor();
-  // @@protoc_insertion_point(constructor:grpc_signer.GrpcMsgAccept)
-}
-GrpcMsgAccept::GrpcMsgAccept(const GrpcMsgAccept& from)
-  : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (from.message().size() > 0) {
-    message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
-  }
-  // @@protoc_insertion_point(copy_constructor:grpc_signer.GrpcMsgAccept)
-}
-
-void GrpcMsgAccept::SharedCtor() {
-  message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-
-GrpcMsgAccept::~GrpcMsgAccept() {
-  // @@protoc_insertion_point(destructor:grpc_signer.GrpcMsgAccept)
-  SharedDtor();
-}
-
-void GrpcMsgAccept::SharedDtor() {
-  message_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-
-void GrpcMsgAccept::SetCachedSize(int size) const {
-  _cached_size_.Set(size);
-}
-const ::google::protobuf::Descriptor* GrpcMsgAccept::descriptor() {
-  ::protobuf_protobuf_5fsigner_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_protobuf_5fsigner_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
-}
-
-const GrpcMsgAccept& GrpcMsgAccept::default_instance() {
-  ::google::protobuf::internal::InitSCC(&protobuf_protobuf_5fsigner_2eproto::scc_info_GrpcMsgAccept.base);
-  return *internal_default_instance();
-}
-
-
-void GrpcMsgAccept::Clear() {
-// @@protoc_insertion_point(message_clear_start:grpc_signer.GrpcMsgAccept)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  _internal_metadata_.Clear();
-}
-
-bool GrpcMsgAccept::MergePartialFromCodedStream(
-    ::google::protobuf::io::CodedInputStream* input) {
-#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
-  ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:grpc_signer.GrpcMsgAccept)
-  for (;;) {
-    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
-    tag = p.first;
-    if (!p.second) goto handle_unusual;
-    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // bytes message = 1;
-      case 1: {
-        if (static_cast< ::google::protobuf::uint8>(tag) ==
-            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
-          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
-                input, this->mutable_message()));
-        } else {
-          goto handle_unusual;
-        }
-        break;
-      }
-
-      default: {
-      handle_unusual:
-        if (tag == 0) {
-          goto success;
-        }
-        DO_(::google::protobuf::internal::WireFormat::SkipField(
-              input, tag, _internal_metadata_.mutable_unknown_fields()));
-        break;
-      }
-    }
-  }
-success:
-  // @@protoc_insertion_point(parse_success:grpc_signer.GrpcMsgAccept)
-  return true;
-failure:
-  // @@protoc_insertion_point(parse_failure:grpc_signer.GrpcMsgAccept)
-  return false;
-#undef DO_
-}
-
-void GrpcMsgAccept::SerializeWithCachedSizes(
-    ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:grpc_signer.GrpcMsgAccept)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  // bytes message = 1;
-  if (this->message().size() > 0) {
-    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
-      1, this->message(), output);
-  }
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
-  }
-  // @@protoc_insertion_point(serialize_end:grpc_signer.GrpcMsgAccept)
-}
-
-::google::protobuf::uint8* GrpcMsgAccept::InternalSerializeWithCachedSizesToArray(
-    bool deterministic, ::google::protobuf::uint8* target) const {
-  (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:grpc_signer.GrpcMsgAccept)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  // bytes message = 1;
-  if (this->message().size() > 0) {
-    target =
-      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
-        1, this->message(), target);
-  }
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
-  }
-  // @@protoc_insertion_point(serialize_to_array_end:grpc_signer.GrpcMsgAccept)
-  return target;
-}
-
-size_t GrpcMsgAccept::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:grpc_signer.GrpcMsgAccept)
-  size_t total_size = 0;
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    total_size +=
-      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
-  }
-  // bytes message = 1;
-  if (this->message().size() > 0) {
-    total_size += 1 +
-      ::google::protobuf::internal::WireFormatLite::BytesSize(
-        this->message());
-  }
-
-  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
-  SetCachedSize(cached_size);
-  return total_size;
-}
-
-void GrpcMsgAccept::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:grpc_signer.GrpcMsgAccept)
-  GOOGLE_DCHECK_NE(&from, this);
-  const GrpcMsgAccept* source =
-      ::google::protobuf::internal::DynamicCastToGenerated<const GrpcMsgAccept>(
-          &from);
-  if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_signer.GrpcMsgAccept)
-    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
-  } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_signer.GrpcMsgAccept)
-    MergeFrom(*source);
-  }
-}
-
-void GrpcMsgAccept::MergeFrom(const GrpcMsgAccept& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:grpc_signer.GrpcMsgAccept)
-  GOOGLE_DCHECK_NE(&from, this);
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  if (from.message().size() > 0) {
-
-    message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
-  }
-}
-
-void GrpcMsgAccept::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:grpc_signer.GrpcMsgAccept)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-void GrpcMsgAccept::CopyFrom(const GrpcMsgAccept& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:grpc_signer.GrpcMsgAccept)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-bool GrpcMsgAccept::IsInitialized() const {
-  return true;
-}
-
-void GrpcMsgAccept::Swap(GrpcMsgAccept* other) {
-  if (other == this) return;
-  InternalSwap(other);
-}
-void GrpcMsgAccept::InternalSwap(GrpcMsgAccept* other) {
-  using std::swap;
-  message_.Swap(&other->message_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-    GetArenaNoVirtual());
-  _internal_metadata_.Swap(&other->_internal_metadata_);
-}
-
-::google::protobuf::Metadata GrpcMsgAccept::GetMetadata() const {
-  protobuf_protobuf_5fsigner_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_protobuf_5fsigner_2eproto::file_level_metadata[kIndexInFileMessages];
-}
-
-
-// ===================================================================
-
-void GrpcMsgSsig::InitAsDefaultInstance() {
-}
-#if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int GrpcMsgSsig::kMessageFieldNumber;
-#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
-
-GrpcMsgSsig::GrpcMsgSsig()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
-  ::google::protobuf::internal::InitSCC(
-      &protobuf_protobuf_5fsigner_2eproto::scc_info_GrpcMsgSsig.base);
-  SharedCtor();
-  // @@protoc_insertion_point(constructor:grpc_signer.GrpcMsgSsig)
-}
-GrpcMsgSsig::GrpcMsgSsig(const GrpcMsgSsig& from)
-  : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (from.message().size() > 0) {
-    message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
-  }
-  // @@protoc_insertion_point(copy_constructor:grpc_signer.GrpcMsgSsig)
-}
-
-void GrpcMsgSsig::SharedCtor() {
-  message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-
-GrpcMsgSsig::~GrpcMsgSsig() {
-  // @@protoc_insertion_point(destructor:grpc_signer.GrpcMsgSsig)
-  SharedDtor();
-}
-
-void GrpcMsgSsig::SharedDtor() {
-  message_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-
-void GrpcMsgSsig::SetCachedSize(int size) const {
-  _cached_size_.Set(size);
-}
-const ::google::protobuf::Descriptor* GrpcMsgSsig::descriptor() {
-  ::protobuf_protobuf_5fsigner_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_protobuf_5fsigner_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
-}
-
-const GrpcMsgSsig& GrpcMsgSsig::default_instance() {
-  ::google::protobuf::internal::InitSCC(&protobuf_protobuf_5fsigner_2eproto::scc_info_GrpcMsgSsig.base);
-  return *internal_default_instance();
-}
-
-
-void GrpcMsgSsig::Clear() {
-// @@protoc_insertion_point(message_clear_start:grpc_signer.GrpcMsgSsig)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  _internal_metadata_.Clear();
-}
-
-bool GrpcMsgSsig::MergePartialFromCodedStream(
-    ::google::protobuf::io::CodedInputStream* input) {
-#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
-  ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:grpc_signer.GrpcMsgSsig)
-  for (;;) {
-    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
-    tag = p.first;
-    if (!p.second) goto handle_unusual;
-    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // bytes message = 1;
-      case 1: {
-        if (static_cast< ::google::protobuf::uint8>(tag) ==
-            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
-          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
-                input, this->mutable_message()));
-        } else {
-          goto handle_unusual;
-        }
-        break;
-      }
-
-      default: {
-      handle_unusual:
-        if (tag == 0) {
-          goto success;
-        }
-        DO_(::google::protobuf::internal::WireFormat::SkipField(
-              input, tag, _internal_metadata_.mutable_unknown_fields()));
-        break;
-      }
-    }
-  }
-success:
-  // @@protoc_insertion_point(parse_success:grpc_signer.GrpcMsgSsig)
-  return true;
-failure:
-  // @@protoc_insertion_point(parse_failure:grpc_signer.GrpcMsgSsig)
-  return false;
-#undef DO_
-}
-
-void GrpcMsgSsig::SerializeWithCachedSizes(
-    ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:grpc_signer.GrpcMsgSsig)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  // bytes message = 1;
-  if (this->message().size() > 0) {
-    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
-      1, this->message(), output);
-  }
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
-  }
-  // @@protoc_insertion_point(serialize_end:grpc_signer.GrpcMsgSsig)
-}
-
-::google::protobuf::uint8* GrpcMsgSsig::InternalSerializeWithCachedSizesToArray(
-    bool deterministic, ::google::protobuf::uint8* target) const {
-  (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:grpc_signer.GrpcMsgSsig)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  // bytes message = 1;
-  if (this->message().size() > 0) {
-    target =
-      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
-        1, this->message(), target);
-  }
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
-  }
-  // @@protoc_insertion_point(serialize_to_array_end:grpc_signer.GrpcMsgSsig)
-  return target;
-}
-
-size_t GrpcMsgSsig::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:grpc_signer.GrpcMsgSsig)
-  size_t total_size = 0;
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    total_size +=
-      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
-  }
-  // bytes message = 1;
-  if (this->message().size() > 0) {
-    total_size += 1 +
-      ::google::protobuf::internal::WireFormatLite::BytesSize(
-        this->message());
-  }
-
-  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
-  SetCachedSize(cached_size);
-  return total_size;
-}
-
-void GrpcMsgSsig::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:grpc_signer.GrpcMsgSsig)
-  GOOGLE_DCHECK_NE(&from, this);
-  const GrpcMsgSsig* source =
-      ::google::protobuf::internal::DynamicCastToGenerated<const GrpcMsgSsig>(
-          &from);
-  if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_signer.GrpcMsgSsig)
-    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
-  } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_signer.GrpcMsgSsig)
-    MergeFrom(*source);
-  }
-}
-
-void GrpcMsgSsig::MergeFrom(const GrpcMsgSsig& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:grpc_signer.GrpcMsgSsig)
-  GOOGLE_DCHECK_NE(&from, this);
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  if (from.message().size() > 0) {
-
-    message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
-  }
-}
-
-void GrpcMsgSsig::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:grpc_signer.GrpcMsgSsig)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-void GrpcMsgSsig::CopyFrom(const GrpcMsgSsig& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:grpc_signer.GrpcMsgSsig)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-bool GrpcMsgSsig::IsInitialized() const {
-  return true;
-}
-
-void GrpcMsgSsig::Swap(GrpcMsgSsig* other) {
-  if (other == this) return;
-  InternalSwap(other);
-}
-void GrpcMsgSsig::InternalSwap(GrpcMsgSsig* other) {
-  using std::swap;
-  message_.Swap(&other->message_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-    GetArenaNoVirtual());
-  _internal_metadata_.Swap(&other->_internal_metadata_);
-}
-
-::google::protobuf::Metadata GrpcMsgSsig::GetMetadata() const {
-  protobuf_protobuf_5fsigner_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_protobuf_5fsigner_2eproto::file_level_metadata[kIndexInFileMessages];
-}
-
-
-// ===================================================================
-
-void GrpcMsgReqSsig::InitAsDefaultInstance() {
-}
-#if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int GrpcMsgReqSsig::kMessageFieldNumber;
-#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
-
-GrpcMsgReqSsig::GrpcMsgReqSsig()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
-  ::google::protobuf::internal::InitSCC(
-      &protobuf_protobuf_5fsigner_2eproto::scc_info_GrpcMsgReqSsig.base);
-  SharedCtor();
-  // @@protoc_insertion_point(constructor:grpc_signer.GrpcMsgReqSsig)
-}
-GrpcMsgReqSsig::GrpcMsgReqSsig(const GrpcMsgReqSsig& from)
-  : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (from.message().size() > 0) {
-    message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
-  }
-  // @@protoc_insertion_point(copy_constructor:grpc_signer.GrpcMsgReqSsig)
-}
-
-void GrpcMsgReqSsig::SharedCtor() {
-  message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-
-GrpcMsgReqSsig::~GrpcMsgReqSsig() {
-  // @@protoc_insertion_point(destructor:grpc_signer.GrpcMsgReqSsig)
-  SharedDtor();
-}
-
-void GrpcMsgReqSsig::SharedDtor() {
-  message_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-
-void GrpcMsgReqSsig::SetCachedSize(int size) const {
-  _cached_size_.Set(size);
-}
-const ::google::protobuf::Descriptor* GrpcMsgReqSsig::descriptor() {
-  ::protobuf_protobuf_5fsigner_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_protobuf_5fsigner_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
-}
-
-const GrpcMsgReqSsig& GrpcMsgReqSsig::default_instance() {
-  ::google::protobuf::internal::InitSCC(&protobuf_protobuf_5fsigner_2eproto::scc_info_GrpcMsgReqSsig.base);
-  return *internal_default_instance();
-}
-
-
-void GrpcMsgReqSsig::Clear() {
-// @@protoc_insertion_point(message_clear_start:grpc_signer.GrpcMsgReqSsig)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  _internal_metadata_.Clear();
-}
-
-bool GrpcMsgReqSsig::MergePartialFromCodedStream(
-    ::google::protobuf::io::CodedInputStream* input) {
-#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
-  ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:grpc_signer.GrpcMsgReqSsig)
-  for (;;) {
-    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
-    tag = p.first;
-    if (!p.second) goto handle_unusual;
-    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // bytes message = 1;
-      case 1: {
-        if (static_cast< ::google::protobuf::uint8>(tag) ==
-            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
-          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
-                input, this->mutable_message()));
-        } else {
-          goto handle_unusual;
-        }
-        break;
-      }
-
-      default: {
-      handle_unusual:
-        if (tag == 0) {
-          goto success;
-        }
-        DO_(::google::protobuf::internal::WireFormat::SkipField(
-              input, tag, _internal_metadata_.mutable_unknown_fields()));
-        break;
-      }
-    }
-  }
-success:
-  // @@protoc_insertion_point(parse_success:grpc_signer.GrpcMsgReqSsig)
-  return true;
-failure:
-  // @@protoc_insertion_point(parse_failure:grpc_signer.GrpcMsgReqSsig)
-  return false;
-#undef DO_
-}
-
-void GrpcMsgReqSsig::SerializeWithCachedSizes(
-    ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:grpc_signer.GrpcMsgReqSsig)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  // bytes message = 1;
-  if (this->message().size() > 0) {
-    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
-      1, this->message(), output);
-  }
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
-  }
-  // @@protoc_insertion_point(serialize_end:grpc_signer.GrpcMsgReqSsig)
-}
-
-::google::protobuf::uint8* GrpcMsgReqSsig::InternalSerializeWithCachedSizesToArray(
-    bool deterministic, ::google::protobuf::uint8* target) const {
-  (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:grpc_signer.GrpcMsgReqSsig)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  // bytes message = 1;
-  if (this->message().size() > 0) {
-    target =
-      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
-        1, this->message(), target);
-  }
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
-  }
-  // @@protoc_insertion_point(serialize_to_array_end:grpc_signer.GrpcMsgReqSsig)
-  return target;
-}
-
-size_t GrpcMsgReqSsig::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:grpc_signer.GrpcMsgReqSsig)
-  size_t total_size = 0;
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    total_size +=
-      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
-  }
-  // bytes message = 1;
-  if (this->message().size() > 0) {
-    total_size += 1 +
-      ::google::protobuf::internal::WireFormatLite::BytesSize(
-        this->message());
-  }
-
-  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
-  SetCachedSize(cached_size);
-  return total_size;
-}
-
-void GrpcMsgReqSsig::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:grpc_signer.GrpcMsgReqSsig)
-  GOOGLE_DCHECK_NE(&from, this);
-  const GrpcMsgReqSsig* source =
-      ::google::protobuf::internal::DynamicCastToGenerated<const GrpcMsgReqSsig>(
-          &from);
-  if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_signer.GrpcMsgReqSsig)
-    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
-  } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_signer.GrpcMsgReqSsig)
-    MergeFrom(*source);
-  }
-}
-
-void GrpcMsgReqSsig::MergeFrom(const GrpcMsgReqSsig& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:grpc_signer.GrpcMsgReqSsig)
-  GOOGLE_DCHECK_NE(&from, this);
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  if (from.message().size() > 0) {
-
-    message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
-  }
-}
-
-void GrpcMsgReqSsig::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:grpc_signer.GrpcMsgReqSsig)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-void GrpcMsgReqSsig::CopyFrom(const GrpcMsgReqSsig& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:grpc_signer.GrpcMsgReqSsig)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-bool GrpcMsgReqSsig::IsInitialized() const {
-  return true;
-}
-
-void GrpcMsgReqSsig::Swap(GrpcMsgReqSsig* other) {
-  if (other == this) return;
-  InternalSwap(other);
-}
-void GrpcMsgReqSsig::InternalSwap(GrpcMsgReqSsig* other) {
-  using std::swap;
-  message_.Swap(&other->message_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-    GetArenaNoVirtual());
-  _internal_metadata_.Swap(&other->_internal_metadata_);
-}
-
-::google::protobuf::Metadata GrpcMsgReqSsig::GetMetadata() const {
+::google::protobuf::Metadata MsgStatus::GetMetadata() const {
   protobuf_protobuf_5fsigner_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_protobuf_5fsigner_2eproto::file_level_metadata[kIndexInFileMessages];
 }
@@ -2445,218 +1198,21 @@ void Identity::InternalSwap(Identity* other) {
 }
 
 
-// ===================================================================
-
-void NoReply::InitAsDefaultInstance() {
-}
-#if !defined(_MSC_VER) || _MSC_VER >= 1900
-#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
-
-NoReply::NoReply()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
-  ::google::protobuf::internal::InitSCC(
-      &protobuf_protobuf_5fsigner_2eproto::scc_info_NoReply.base);
-  SharedCtor();
-  // @@protoc_insertion_point(constructor:grpc_signer.NoReply)
-}
-NoReply::NoReply(const NoReply& from)
-  : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  // @@protoc_insertion_point(copy_constructor:grpc_signer.NoReply)
-}
-
-void NoReply::SharedCtor() {
-}
-
-NoReply::~NoReply() {
-  // @@protoc_insertion_point(destructor:grpc_signer.NoReply)
-  SharedDtor();
-}
-
-void NoReply::SharedDtor() {
-}
-
-void NoReply::SetCachedSize(int size) const {
-  _cached_size_.Set(size);
-}
-const ::google::protobuf::Descriptor* NoReply::descriptor() {
-  ::protobuf_protobuf_5fsigner_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_protobuf_5fsigner_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
-}
-
-const NoReply& NoReply::default_instance() {
-  ::google::protobuf::internal::InitSCC(&protobuf_protobuf_5fsigner_2eproto::scc_info_NoReply.base);
-  return *internal_default_instance();
-}
-
-
-void NoReply::Clear() {
-// @@protoc_insertion_point(message_clear_start:grpc_signer.NoReply)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  _internal_metadata_.Clear();
-}
-
-bool NoReply::MergePartialFromCodedStream(
-    ::google::protobuf::io::CodedInputStream* input) {
-#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
-  ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:grpc_signer.NoReply)
-  for (;;) {
-    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
-    tag = p.first;
-    if (!p.second) goto handle_unusual;
-  handle_unusual:
-    if (tag == 0) {
-      goto success;
-    }
-    DO_(::google::protobuf::internal::WireFormat::SkipField(
-          input, tag, _internal_metadata_.mutable_unknown_fields()));
-  }
-success:
-  // @@protoc_insertion_point(parse_success:grpc_signer.NoReply)
-  return true;
-failure:
-  // @@protoc_insertion_point(parse_failure:grpc_signer.NoReply)
-  return false;
-#undef DO_
-}
-
-void NoReply::SerializeWithCachedSizes(
-    ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:grpc_signer.NoReply)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
-  }
-  // @@protoc_insertion_point(serialize_end:grpc_signer.NoReply)
-}
-
-::google::protobuf::uint8* NoReply::InternalSerializeWithCachedSizesToArray(
-    bool deterministic, ::google::protobuf::uint8* target) const {
-  (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:grpc_signer.NoReply)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
-  }
-  // @@protoc_insertion_point(serialize_to_array_end:grpc_signer.NoReply)
-  return target;
-}
-
-size_t NoReply::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:grpc_signer.NoReply)
-  size_t total_size = 0;
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    total_size +=
-      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
-  }
-  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
-  SetCachedSize(cached_size);
-  return total_size;
-}
-
-void NoReply::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:grpc_signer.NoReply)
-  GOOGLE_DCHECK_NE(&from, this);
-  const NoReply* source =
-      ::google::protobuf::internal::DynamicCastToGenerated<const NoReply>(
-          &from);
-  if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_signer.NoReply)
-    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
-  } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_signer.NoReply)
-    MergeFrom(*source);
-  }
-}
-
-void NoReply::MergeFrom(const NoReply& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:grpc_signer.NoReply)
-  GOOGLE_DCHECK_NE(&from, this);
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-}
-
-void NoReply::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:grpc_signer.NoReply)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-void NoReply::CopyFrom(const NoReply& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:grpc_signer.NoReply)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-bool NoReply::IsInitialized() const {
-  return true;
-}
-
-void NoReply::Swap(NoReply* other) {
-  if (other == this) return;
-  InternalSwap(other);
-}
-void NoReply::InternalSwap(NoReply* other) {
-  using std::swap;
-  _internal_metadata_.Swap(&other->_internal_metadata_);
-}
-
-::google::protobuf::Metadata NoReply::GetMetadata() const {
-  protobuf_protobuf_5fsigner_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_protobuf_5fsigner_2eproto::file_level_metadata[kIndexInFileMessages];
-}
-
-
 // @@protoc_insertion_point(namespace_scope)
 }  // namespace grpc_signer
 namespace google {
 namespace protobuf {
-template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_signer::GrpcMsgJoin* Arena::CreateMaybeMessage< ::grpc_signer::GrpcMsgJoin >(Arena* arena) {
-  return Arena::CreateInternal< ::grpc_signer::GrpcMsgJoin >(arena);
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_signer::RequestMsg* Arena::CreateMaybeMessage< ::grpc_signer::RequestMsg >(Arena* arena) {
+  return Arena::CreateInternal< ::grpc_signer::RequestMsg >(arena);
 }
-template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_signer::GrpcMsgChallenge* Arena::CreateMaybeMessage< ::grpc_signer::GrpcMsgChallenge >(Arena* arena) {
-  return Arena::CreateInternal< ::grpc_signer::GrpcMsgChallenge >(arena);
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_signer::ReplyMsg* Arena::CreateMaybeMessage< ::grpc_signer::ReplyMsg >(Arena* arena) {
+  return Arena::CreateInternal< ::grpc_signer::ReplyMsg >(arena);
 }
-template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_signer::GrpcMsgResponse1* Arena::CreateMaybeMessage< ::grpc_signer::GrpcMsgResponse1 >(Arena* arena) {
-  return Arena::CreateInternal< ::grpc_signer::GrpcMsgResponse1 >(arena);
-}
-template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_signer::GrpcMsgResponse2* Arena::CreateMaybeMessage< ::grpc_signer::GrpcMsgResponse2 >(Arena* arena) {
-  return Arena::CreateInternal< ::grpc_signer::GrpcMsgResponse2 >(arena);
-}
-template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_signer::GrpcMsgSuccess* Arena::CreateMaybeMessage< ::grpc_signer::GrpcMsgSuccess >(Arena* arena) {
-  return Arena::CreateInternal< ::grpc_signer::GrpcMsgSuccess >(arena);
-}
-template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_signer::GrpcMsgAccept* Arena::CreateMaybeMessage< ::grpc_signer::GrpcMsgAccept >(Arena* arena) {
-  return Arena::CreateInternal< ::grpc_signer::GrpcMsgAccept >(arena);
-}
-template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_signer::GrpcMsgSsig* Arena::CreateMaybeMessage< ::grpc_signer::GrpcMsgSsig >(Arena* arena) {
-  return Arena::CreateInternal< ::grpc_signer::GrpcMsgSsig >(arena);
-}
-template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_signer::GrpcMsgReqSsig* Arena::CreateMaybeMessage< ::grpc_signer::GrpcMsgReqSsig >(Arena* arena) {
-  return Arena::CreateInternal< ::grpc_signer::GrpcMsgReqSsig >(arena);
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_signer::MsgStatus* Arena::CreateMaybeMessage< ::grpc_signer::MsgStatus >(Arena* arena) {
+  return Arena::CreateInternal< ::grpc_signer::MsgStatus >(arena);
 }
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_signer::Identity* Arena::CreateMaybeMessage< ::grpc_signer::Identity >(Arena* arena) {
   return Arena::CreateInternal< ::grpc_signer::Identity >(arena);
-}
-template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_signer::NoReply* Arena::CreateMaybeMessage< ::grpc_signer::NoReply >(Arena* arena) {
-  return Arena::CreateInternal< ::grpc_signer::NoReply >(arena);
 }
 }  // namespace protobuf
 }  // namespace google

--- a/src/modules/communication/protos/protobuf_signer.pb.h
+++ b/src/modules/communication/protos/protobuf_signer.pb.h
@@ -29,6 +29,7 @@
 #include <google/protobuf/message.h>
 #include <google/protobuf/repeated_field.h>  // IWYU pragma: export
 #include <google/protobuf/extension_set.h>  // IWYU pragma: export
+#include <google/protobuf/generated_enum_reflection.h>
 #include <google/protobuf/unknown_field_set.h>
 // @@protoc_insertion_point(includes)
 #define PROTOBUF_INTERNAL_EXPORT_protobuf_protobuf_5fsigner_2eproto 
@@ -38,7 +39,7 @@ namespace protobuf_protobuf_5fsigner_2eproto {
 struct TableStruct {
   static const ::google::protobuf::internal::ParseTableField entries[];
   static const ::google::protobuf::internal::AuxillaryParseTableField aux[];
-  static const ::google::protobuf::internal::ParseTable schema[10];
+  static const ::google::protobuf::internal::ParseTable schema[4];
   static const ::google::protobuf::internal::FieldMetadata field_metadata[];
   static const ::google::protobuf::internal::SerializationTable serialization_table[];
   static const ::google::protobuf::uint32 offsets[];
@@ -46,73 +47,71 @@ struct TableStruct {
 void AddDescriptors();
 }  // namespace protobuf_protobuf_5fsigner_2eproto
 namespace grpc_signer {
-class GrpcMsgAccept;
-class GrpcMsgAcceptDefaultTypeInternal;
-extern GrpcMsgAcceptDefaultTypeInternal _GrpcMsgAccept_default_instance_;
-class GrpcMsgChallenge;
-class GrpcMsgChallengeDefaultTypeInternal;
-extern GrpcMsgChallengeDefaultTypeInternal _GrpcMsgChallenge_default_instance_;
-class GrpcMsgJoin;
-class GrpcMsgJoinDefaultTypeInternal;
-extern GrpcMsgJoinDefaultTypeInternal _GrpcMsgJoin_default_instance_;
-class GrpcMsgReqSsig;
-class GrpcMsgReqSsigDefaultTypeInternal;
-extern GrpcMsgReqSsigDefaultTypeInternal _GrpcMsgReqSsig_default_instance_;
-class GrpcMsgResponse1;
-class GrpcMsgResponse1DefaultTypeInternal;
-extern GrpcMsgResponse1DefaultTypeInternal _GrpcMsgResponse1_default_instance_;
-class GrpcMsgResponse2;
-class GrpcMsgResponse2DefaultTypeInternal;
-extern GrpcMsgResponse2DefaultTypeInternal _GrpcMsgResponse2_default_instance_;
-class GrpcMsgSsig;
-class GrpcMsgSsigDefaultTypeInternal;
-extern GrpcMsgSsigDefaultTypeInternal _GrpcMsgSsig_default_instance_;
-class GrpcMsgSuccess;
-class GrpcMsgSuccessDefaultTypeInternal;
-extern GrpcMsgSuccessDefaultTypeInternal _GrpcMsgSuccess_default_instance_;
 class Identity;
 class IdentityDefaultTypeInternal;
 extern IdentityDefaultTypeInternal _Identity_default_instance_;
-class NoReply;
-class NoReplyDefaultTypeInternal;
-extern NoReplyDefaultTypeInternal _NoReply_default_instance_;
+class MsgStatus;
+class MsgStatusDefaultTypeInternal;
+extern MsgStatusDefaultTypeInternal _MsgStatus_default_instance_;
+class ReplyMsg;
+class ReplyMsgDefaultTypeInternal;
+extern ReplyMsgDefaultTypeInternal _ReplyMsg_default_instance_;
+class RequestMsg;
+class RequestMsgDefaultTypeInternal;
+extern RequestMsgDefaultTypeInternal _RequestMsg_default_instance_;
 }  // namespace grpc_signer
 namespace google {
 namespace protobuf {
-template<> ::grpc_signer::GrpcMsgAccept* Arena::CreateMaybeMessage<::grpc_signer::GrpcMsgAccept>(Arena*);
-template<> ::grpc_signer::GrpcMsgChallenge* Arena::CreateMaybeMessage<::grpc_signer::GrpcMsgChallenge>(Arena*);
-template<> ::grpc_signer::GrpcMsgJoin* Arena::CreateMaybeMessage<::grpc_signer::GrpcMsgJoin>(Arena*);
-template<> ::grpc_signer::GrpcMsgReqSsig* Arena::CreateMaybeMessage<::grpc_signer::GrpcMsgReqSsig>(Arena*);
-template<> ::grpc_signer::GrpcMsgResponse1* Arena::CreateMaybeMessage<::grpc_signer::GrpcMsgResponse1>(Arena*);
-template<> ::grpc_signer::GrpcMsgResponse2* Arena::CreateMaybeMessage<::grpc_signer::GrpcMsgResponse2>(Arena*);
-template<> ::grpc_signer::GrpcMsgSsig* Arena::CreateMaybeMessage<::grpc_signer::GrpcMsgSsig>(Arena*);
-template<> ::grpc_signer::GrpcMsgSuccess* Arena::CreateMaybeMessage<::grpc_signer::GrpcMsgSuccess>(Arena*);
 template<> ::grpc_signer::Identity* Arena::CreateMaybeMessage<::grpc_signer::Identity>(Arena*);
-template<> ::grpc_signer::NoReply* Arena::CreateMaybeMessage<::grpc_signer::NoReply>(Arena*);
+template<> ::grpc_signer::MsgStatus* Arena::CreateMaybeMessage<::grpc_signer::MsgStatus>(Arena*);
+template<> ::grpc_signer::ReplyMsg* Arena::CreateMaybeMessage<::grpc_signer::ReplyMsg>(Arena*);
+template<> ::grpc_signer::RequestMsg* Arena::CreateMaybeMessage<::grpc_signer::RequestMsg>(Arena*);
 }  // namespace protobuf
 }  // namespace google
 namespace grpc_signer {
 
+enum MsgStatus_Status {
+  MsgStatus_Status_SUCCESS = 0,
+  MsgStatus_Status_INVALID = 1,
+  MsgStatus_Status_INTERNAL = 2,
+  MsgStatus_Status_MsgStatus_Status_INT_MIN_SENTINEL_DO_NOT_USE_ = ::google::protobuf::kint32min,
+  MsgStatus_Status_MsgStatus_Status_INT_MAX_SENTINEL_DO_NOT_USE_ = ::google::protobuf::kint32max
+};
+bool MsgStatus_Status_IsValid(int value);
+const MsgStatus_Status MsgStatus_Status_Status_MIN = MsgStatus_Status_SUCCESS;
+const MsgStatus_Status MsgStatus_Status_Status_MAX = MsgStatus_Status_INTERNAL;
+const int MsgStatus_Status_Status_ARRAYSIZE = MsgStatus_Status_Status_MAX + 1;
+
+const ::google::protobuf::EnumDescriptor* MsgStatus_Status_descriptor();
+inline const ::std::string& MsgStatus_Status_Name(MsgStatus_Status value) {
+  return ::google::protobuf::internal::NameOfEnum(
+    MsgStatus_Status_descriptor(), value);
+}
+inline bool MsgStatus_Status_Parse(
+    const ::std::string& name, MsgStatus_Status* value) {
+  return ::google::protobuf::internal::ParseNamedEnum<MsgStatus_Status>(
+    MsgStatus_Status_descriptor(), name, value);
+}
 // ===================================================================
 
-class GrpcMsgJoin : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_signer.GrpcMsgJoin) */ {
+class RequestMsg : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_signer.RequestMsg) */ {
  public:
-  GrpcMsgJoin();
-  virtual ~GrpcMsgJoin();
+  RequestMsg();
+  virtual ~RequestMsg();
 
-  GrpcMsgJoin(const GrpcMsgJoin& from);
+  RequestMsg(const RequestMsg& from);
 
-  inline GrpcMsgJoin& operator=(const GrpcMsgJoin& from) {
+  inline RequestMsg& operator=(const RequestMsg& from) {
     CopyFrom(from);
     return *this;
   }
   #if LANG_CXX11
-  GrpcMsgJoin(GrpcMsgJoin&& from) noexcept
-    : GrpcMsgJoin() {
+  RequestMsg(RequestMsg&& from) noexcept
+    : RequestMsg() {
     *this = ::std::move(from);
   }
 
-  inline GrpcMsgJoin& operator=(GrpcMsgJoin&& from) noexcept {
+  inline RequestMsg& operator=(RequestMsg&& from) noexcept {
     if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
       if (this != &from) InternalSwap(&from);
     } else {
@@ -122,34 +121,34 @@ class GrpcMsgJoin : public ::google::protobuf::Message /* @@protoc_insertion_poi
   }
   #endif
   static const ::google::protobuf::Descriptor* descriptor();
-  static const GrpcMsgJoin& default_instance();
+  static const RequestMsg& default_instance();
 
   static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const GrpcMsgJoin* internal_default_instance() {
-    return reinterpret_cast<const GrpcMsgJoin*>(
-               &_GrpcMsgJoin_default_instance_);
+  static inline const RequestMsg* internal_default_instance() {
+    return reinterpret_cast<const RequestMsg*>(
+               &_RequestMsg_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     0;
 
-  void Swap(GrpcMsgJoin* other);
-  friend void swap(GrpcMsgJoin& a, GrpcMsgJoin& b) {
+  void Swap(RequestMsg* other);
+  friend void swap(RequestMsg& a, RequestMsg& b) {
     a.Swap(&b);
   }
 
   // implements Message ----------------------------------------------
 
-  inline GrpcMsgJoin* New() const final {
-    return CreateMaybeMessage<GrpcMsgJoin>(NULL);
+  inline RequestMsg* New() const final {
+    return CreateMaybeMessage<RequestMsg>(NULL);
   }
 
-  GrpcMsgJoin* New(::google::protobuf::Arena* arena) const final {
-    return CreateMaybeMessage<GrpcMsgJoin>(arena);
+  RequestMsg* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<RequestMsg>(arena);
   }
   void CopyFrom(const ::google::protobuf::Message& from) final;
   void MergeFrom(const ::google::protobuf::Message& from) final;
-  void CopyFrom(const GrpcMsgJoin& from);
-  void MergeFrom(const GrpcMsgJoin& from);
+  void CopyFrom(const RequestMsg& from);
+  void MergeFrom(const RequestMsg& from);
   void Clear() final;
   bool IsInitialized() const final;
 
@@ -166,7 +165,7 @@ class GrpcMsgJoin : public ::google::protobuf::Message /* @@protoc_insertion_poi
   void SharedCtor();
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(GrpcMsgJoin* other);
+  void InternalSwap(RequestMsg* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
     return NULL;
@@ -196,7 +195,7 @@ class GrpcMsgJoin : public ::google::protobuf::Message /* @@protoc_insertion_poi
   ::std::string* release_message();
   void set_allocated_message(::std::string* message);
 
-  // @@protoc_insertion_point(class_scope:grpc_signer.GrpcMsgJoin)
+  // @@protoc_insertion_point(class_scope:grpc_signer.RequestMsg)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
@@ -206,24 +205,24 @@ class GrpcMsgJoin : public ::google::protobuf::Message /* @@protoc_insertion_poi
 };
 // -------------------------------------------------------------------
 
-class GrpcMsgChallenge : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_signer.GrpcMsgChallenge) */ {
+class ReplyMsg : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_signer.ReplyMsg) */ {
  public:
-  GrpcMsgChallenge();
-  virtual ~GrpcMsgChallenge();
+  ReplyMsg();
+  virtual ~ReplyMsg();
 
-  GrpcMsgChallenge(const GrpcMsgChallenge& from);
+  ReplyMsg(const ReplyMsg& from);
 
-  inline GrpcMsgChallenge& operator=(const GrpcMsgChallenge& from) {
+  inline ReplyMsg& operator=(const ReplyMsg& from) {
     CopyFrom(from);
     return *this;
   }
   #if LANG_CXX11
-  GrpcMsgChallenge(GrpcMsgChallenge&& from) noexcept
-    : GrpcMsgChallenge() {
+  ReplyMsg(ReplyMsg&& from) noexcept
+    : ReplyMsg() {
     *this = ::std::move(from);
   }
 
-  inline GrpcMsgChallenge& operator=(GrpcMsgChallenge&& from) noexcept {
+  inline ReplyMsg& operator=(ReplyMsg&& from) noexcept {
     if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
       if (this != &from) InternalSwap(&from);
     } else {
@@ -233,34 +232,34 @@ class GrpcMsgChallenge : public ::google::protobuf::Message /* @@protoc_insertio
   }
   #endif
   static const ::google::protobuf::Descriptor* descriptor();
-  static const GrpcMsgChallenge& default_instance();
+  static const ReplyMsg& default_instance();
 
   static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const GrpcMsgChallenge* internal_default_instance() {
-    return reinterpret_cast<const GrpcMsgChallenge*>(
-               &_GrpcMsgChallenge_default_instance_);
+  static inline const ReplyMsg* internal_default_instance() {
+    return reinterpret_cast<const ReplyMsg*>(
+               &_ReplyMsg_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     1;
 
-  void Swap(GrpcMsgChallenge* other);
-  friend void swap(GrpcMsgChallenge& a, GrpcMsgChallenge& b) {
+  void Swap(ReplyMsg* other);
+  friend void swap(ReplyMsg& a, ReplyMsg& b) {
     a.Swap(&b);
   }
 
   // implements Message ----------------------------------------------
 
-  inline GrpcMsgChallenge* New() const final {
-    return CreateMaybeMessage<GrpcMsgChallenge>(NULL);
+  inline ReplyMsg* New() const final {
+    return CreateMaybeMessage<ReplyMsg>(NULL);
   }
 
-  GrpcMsgChallenge* New(::google::protobuf::Arena* arena) const final {
-    return CreateMaybeMessage<GrpcMsgChallenge>(arena);
+  ReplyMsg* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<ReplyMsg>(arena);
   }
   void CopyFrom(const ::google::protobuf::Message& from) final;
   void MergeFrom(const ::google::protobuf::Message& from) final;
-  void CopyFrom(const GrpcMsgChallenge& from);
-  void MergeFrom(const GrpcMsgChallenge& from);
+  void CopyFrom(const ReplyMsg& from);
+  void MergeFrom(const ReplyMsg& from);
   void Clear() final;
   bool IsInitialized() const final;
 
@@ -277,7 +276,7 @@ class GrpcMsgChallenge : public ::google::protobuf::Message /* @@protoc_insertio
   void SharedCtor();
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(GrpcMsgChallenge* other);
+  void InternalSwap(ReplyMsg* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
     return NULL;
@@ -307,7 +306,7 @@ class GrpcMsgChallenge : public ::google::protobuf::Message /* @@protoc_insertio
   ::std::string* release_message();
   void set_allocated_message(::std::string* message);
 
-  // @@protoc_insertion_point(class_scope:grpc_signer.GrpcMsgChallenge)
+  // @@protoc_insertion_point(class_scope:grpc_signer.ReplyMsg)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
@@ -317,24 +316,24 @@ class GrpcMsgChallenge : public ::google::protobuf::Message /* @@protoc_insertio
 };
 // -------------------------------------------------------------------
 
-class GrpcMsgResponse1 : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_signer.GrpcMsgResponse1) */ {
+class MsgStatus : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_signer.MsgStatus) */ {
  public:
-  GrpcMsgResponse1();
-  virtual ~GrpcMsgResponse1();
+  MsgStatus();
+  virtual ~MsgStatus();
 
-  GrpcMsgResponse1(const GrpcMsgResponse1& from);
+  MsgStatus(const MsgStatus& from);
 
-  inline GrpcMsgResponse1& operator=(const GrpcMsgResponse1& from) {
+  inline MsgStatus& operator=(const MsgStatus& from) {
     CopyFrom(from);
     return *this;
   }
   #if LANG_CXX11
-  GrpcMsgResponse1(GrpcMsgResponse1&& from) noexcept
-    : GrpcMsgResponse1() {
+  MsgStatus(MsgStatus&& from) noexcept
+    : MsgStatus() {
     *this = ::std::move(from);
   }
 
-  inline GrpcMsgResponse1& operator=(GrpcMsgResponse1&& from) noexcept {
+  inline MsgStatus& operator=(MsgStatus&& from) noexcept {
     if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
       if (this != &from) InternalSwap(&from);
     } else {
@@ -344,34 +343,34 @@ class GrpcMsgResponse1 : public ::google::protobuf::Message /* @@protoc_insertio
   }
   #endif
   static const ::google::protobuf::Descriptor* descriptor();
-  static const GrpcMsgResponse1& default_instance();
+  static const MsgStatus& default_instance();
 
   static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const GrpcMsgResponse1* internal_default_instance() {
-    return reinterpret_cast<const GrpcMsgResponse1*>(
-               &_GrpcMsgResponse1_default_instance_);
+  static inline const MsgStatus* internal_default_instance() {
+    return reinterpret_cast<const MsgStatus*>(
+               &_MsgStatus_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     2;
 
-  void Swap(GrpcMsgResponse1* other);
-  friend void swap(GrpcMsgResponse1& a, GrpcMsgResponse1& b) {
+  void Swap(MsgStatus* other);
+  friend void swap(MsgStatus& a, MsgStatus& b) {
     a.Swap(&b);
   }
 
   // implements Message ----------------------------------------------
 
-  inline GrpcMsgResponse1* New() const final {
-    return CreateMaybeMessage<GrpcMsgResponse1>(NULL);
+  inline MsgStatus* New() const final {
+    return CreateMaybeMessage<MsgStatus>(NULL);
   }
 
-  GrpcMsgResponse1* New(::google::protobuf::Arena* arena) const final {
-    return CreateMaybeMessage<GrpcMsgResponse1>(arena);
+  MsgStatus* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<MsgStatus>(arena);
   }
   void CopyFrom(const ::google::protobuf::Message& from) final;
   void MergeFrom(const ::google::protobuf::Message& from) final;
-  void CopyFrom(const GrpcMsgResponse1& from);
-  void MergeFrom(const GrpcMsgResponse1& from);
+  void CopyFrom(const MsgStatus& from);
+  void MergeFrom(const MsgStatus& from);
   void Clear() final;
   bool IsInitialized() const final;
 
@@ -388,7 +387,7 @@ class GrpcMsgResponse1 : public ::google::protobuf::Message /* @@protoc_insertio
   void SharedCtor();
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(GrpcMsgResponse1* other);
+  void InternalSwap(MsgStatus* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
     return NULL;
@@ -402,582 +401,62 @@ class GrpcMsgResponse1 : public ::google::protobuf::Message /* @@protoc_insertio
 
   // nested types ----------------------------------------------------
 
+  typedef MsgStatus_Status Status;
+  static const Status SUCCESS =
+    MsgStatus_Status_SUCCESS;
+  static const Status INVALID =
+    MsgStatus_Status_INVALID;
+  static const Status INTERNAL =
+    MsgStatus_Status_INTERNAL;
+  static inline bool Status_IsValid(int value) {
+    return MsgStatus_Status_IsValid(value);
+  }
+  static const Status Status_MIN =
+    MsgStatus_Status_Status_MIN;
+  static const Status Status_MAX =
+    MsgStatus_Status_Status_MAX;
+  static const int Status_ARRAYSIZE =
+    MsgStatus_Status_Status_ARRAYSIZE;
+  static inline const ::google::protobuf::EnumDescriptor*
+  Status_descriptor() {
+    return MsgStatus_Status_descriptor();
+  }
+  static inline const ::std::string& Status_Name(Status value) {
+    return MsgStatus_Status_Name(value);
+  }
+  static inline bool Status_Parse(const ::std::string& name,
+      Status* value) {
+    return MsgStatus_Status_Parse(name, value);
+  }
+
   // accessors -------------------------------------------------------
 
-  // bytes message = 1;
+  // string message = 2;
   void clear_message();
-  static const int kMessageFieldNumber = 1;
+  static const int kMessageFieldNumber = 2;
   const ::std::string& message() const;
   void set_message(const ::std::string& value);
   #if LANG_CXX11
   void set_message(::std::string&& value);
   #endif
   void set_message(const char* value);
-  void set_message(const void* value, size_t size);
+  void set_message(const char* value, size_t size);
   ::std::string* mutable_message();
   ::std::string* release_message();
   void set_allocated_message(::std::string* message);
 
-  // @@protoc_insertion_point(class_scope:grpc_signer.GrpcMsgResponse1)
+  // .grpc_signer.MsgStatus.Status status = 1;
+  void clear_status();
+  static const int kStatusFieldNumber = 1;
+  ::grpc_signer::MsgStatus_Status status() const;
+  void set_status(::grpc_signer::MsgStatus_Status value);
+
+  // @@protoc_insertion_point(class_scope:grpc_signer.MsgStatus)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::internal::ArenaStringPtr message_;
-  mutable ::google::protobuf::internal::CachedSize _cached_size_;
-  friend struct ::protobuf_protobuf_5fsigner_2eproto::TableStruct;
-};
-// -------------------------------------------------------------------
-
-class GrpcMsgResponse2 : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_signer.GrpcMsgResponse2) */ {
- public:
-  GrpcMsgResponse2();
-  virtual ~GrpcMsgResponse2();
-
-  GrpcMsgResponse2(const GrpcMsgResponse2& from);
-
-  inline GrpcMsgResponse2& operator=(const GrpcMsgResponse2& from) {
-    CopyFrom(from);
-    return *this;
-  }
-  #if LANG_CXX11
-  GrpcMsgResponse2(GrpcMsgResponse2&& from) noexcept
-    : GrpcMsgResponse2() {
-    *this = ::std::move(from);
-  }
-
-  inline GrpcMsgResponse2& operator=(GrpcMsgResponse2&& from) noexcept {
-    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
-      if (this != &from) InternalSwap(&from);
-    } else {
-      CopyFrom(from);
-    }
-    return *this;
-  }
-  #endif
-  static const ::google::protobuf::Descriptor* descriptor();
-  static const GrpcMsgResponse2& default_instance();
-
-  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const GrpcMsgResponse2* internal_default_instance() {
-    return reinterpret_cast<const GrpcMsgResponse2*>(
-               &_GrpcMsgResponse2_default_instance_);
-  }
-  static constexpr int kIndexInFileMessages =
-    3;
-
-  void Swap(GrpcMsgResponse2* other);
-  friend void swap(GrpcMsgResponse2& a, GrpcMsgResponse2& b) {
-    a.Swap(&b);
-  }
-
-  // implements Message ----------------------------------------------
-
-  inline GrpcMsgResponse2* New() const final {
-    return CreateMaybeMessage<GrpcMsgResponse2>(NULL);
-  }
-
-  GrpcMsgResponse2* New(::google::protobuf::Arena* arena) const final {
-    return CreateMaybeMessage<GrpcMsgResponse2>(arena);
-  }
-  void CopyFrom(const ::google::protobuf::Message& from) final;
-  void MergeFrom(const ::google::protobuf::Message& from) final;
-  void CopyFrom(const GrpcMsgResponse2& from);
-  void MergeFrom(const GrpcMsgResponse2& from);
-  void Clear() final;
-  bool IsInitialized() const final;
-
-  size_t ByteSizeLong() const final;
-  bool MergePartialFromCodedStream(
-      ::google::protobuf::io::CodedInputStream* input) final;
-  void SerializeWithCachedSizes(
-      ::google::protobuf::io::CodedOutputStream* output) const final;
-  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
-      bool deterministic, ::google::protobuf::uint8* target) const final;
-  int GetCachedSize() const final { return _cached_size_.Get(); }
-
-  private:
-  void SharedCtor();
-  void SharedDtor();
-  void SetCachedSize(int size) const final;
-  void InternalSwap(GrpcMsgResponse2* other);
-  private:
-  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return NULL;
-  }
-  inline void* MaybeArenaPtr() const {
-    return NULL;
-  }
-  public:
-
-  ::google::protobuf::Metadata GetMetadata() const final;
-
-  // nested types ----------------------------------------------------
-
-  // accessors -------------------------------------------------------
-
-  // bytes message = 1;
-  void clear_message();
-  static const int kMessageFieldNumber = 1;
-  const ::std::string& message() const;
-  void set_message(const ::std::string& value);
-  #if LANG_CXX11
-  void set_message(::std::string&& value);
-  #endif
-  void set_message(const char* value);
-  void set_message(const void* value, size_t size);
-  ::std::string* mutable_message();
-  ::std::string* release_message();
-  void set_allocated_message(::std::string* message);
-
-  // @@protoc_insertion_point(class_scope:grpc_signer.GrpcMsgResponse2)
- private:
-
-  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
-  ::google::protobuf::internal::ArenaStringPtr message_;
-  mutable ::google::protobuf::internal::CachedSize _cached_size_;
-  friend struct ::protobuf_protobuf_5fsigner_2eproto::TableStruct;
-};
-// -------------------------------------------------------------------
-
-class GrpcMsgSuccess : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_signer.GrpcMsgSuccess) */ {
- public:
-  GrpcMsgSuccess();
-  virtual ~GrpcMsgSuccess();
-
-  GrpcMsgSuccess(const GrpcMsgSuccess& from);
-
-  inline GrpcMsgSuccess& operator=(const GrpcMsgSuccess& from) {
-    CopyFrom(from);
-    return *this;
-  }
-  #if LANG_CXX11
-  GrpcMsgSuccess(GrpcMsgSuccess&& from) noexcept
-    : GrpcMsgSuccess() {
-    *this = ::std::move(from);
-  }
-
-  inline GrpcMsgSuccess& operator=(GrpcMsgSuccess&& from) noexcept {
-    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
-      if (this != &from) InternalSwap(&from);
-    } else {
-      CopyFrom(from);
-    }
-    return *this;
-  }
-  #endif
-  static const ::google::protobuf::Descriptor* descriptor();
-  static const GrpcMsgSuccess& default_instance();
-
-  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const GrpcMsgSuccess* internal_default_instance() {
-    return reinterpret_cast<const GrpcMsgSuccess*>(
-               &_GrpcMsgSuccess_default_instance_);
-  }
-  static constexpr int kIndexInFileMessages =
-    4;
-
-  void Swap(GrpcMsgSuccess* other);
-  friend void swap(GrpcMsgSuccess& a, GrpcMsgSuccess& b) {
-    a.Swap(&b);
-  }
-
-  // implements Message ----------------------------------------------
-
-  inline GrpcMsgSuccess* New() const final {
-    return CreateMaybeMessage<GrpcMsgSuccess>(NULL);
-  }
-
-  GrpcMsgSuccess* New(::google::protobuf::Arena* arena) const final {
-    return CreateMaybeMessage<GrpcMsgSuccess>(arena);
-  }
-  void CopyFrom(const ::google::protobuf::Message& from) final;
-  void MergeFrom(const ::google::protobuf::Message& from) final;
-  void CopyFrom(const GrpcMsgSuccess& from);
-  void MergeFrom(const GrpcMsgSuccess& from);
-  void Clear() final;
-  bool IsInitialized() const final;
-
-  size_t ByteSizeLong() const final;
-  bool MergePartialFromCodedStream(
-      ::google::protobuf::io::CodedInputStream* input) final;
-  void SerializeWithCachedSizes(
-      ::google::protobuf::io::CodedOutputStream* output) const final;
-  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
-      bool deterministic, ::google::protobuf::uint8* target) const final;
-  int GetCachedSize() const final { return _cached_size_.Get(); }
-
-  private:
-  void SharedCtor();
-  void SharedDtor();
-  void SetCachedSize(int size) const final;
-  void InternalSwap(GrpcMsgSuccess* other);
-  private:
-  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return NULL;
-  }
-  inline void* MaybeArenaPtr() const {
-    return NULL;
-  }
-  public:
-
-  ::google::protobuf::Metadata GetMetadata() const final;
-
-  // nested types ----------------------------------------------------
-
-  // accessors -------------------------------------------------------
-
-  // bytes message = 1;
-  void clear_message();
-  static const int kMessageFieldNumber = 1;
-  const ::std::string& message() const;
-  void set_message(const ::std::string& value);
-  #if LANG_CXX11
-  void set_message(::std::string&& value);
-  #endif
-  void set_message(const char* value);
-  void set_message(const void* value, size_t size);
-  ::std::string* mutable_message();
-  ::std::string* release_message();
-  void set_allocated_message(::std::string* message);
-
-  // @@protoc_insertion_point(class_scope:grpc_signer.GrpcMsgSuccess)
- private:
-
-  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
-  ::google::protobuf::internal::ArenaStringPtr message_;
-  mutable ::google::protobuf::internal::CachedSize _cached_size_;
-  friend struct ::protobuf_protobuf_5fsigner_2eproto::TableStruct;
-};
-// -------------------------------------------------------------------
-
-class GrpcMsgAccept : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_signer.GrpcMsgAccept) */ {
- public:
-  GrpcMsgAccept();
-  virtual ~GrpcMsgAccept();
-
-  GrpcMsgAccept(const GrpcMsgAccept& from);
-
-  inline GrpcMsgAccept& operator=(const GrpcMsgAccept& from) {
-    CopyFrom(from);
-    return *this;
-  }
-  #if LANG_CXX11
-  GrpcMsgAccept(GrpcMsgAccept&& from) noexcept
-    : GrpcMsgAccept() {
-    *this = ::std::move(from);
-  }
-
-  inline GrpcMsgAccept& operator=(GrpcMsgAccept&& from) noexcept {
-    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
-      if (this != &from) InternalSwap(&from);
-    } else {
-      CopyFrom(from);
-    }
-    return *this;
-  }
-  #endif
-  static const ::google::protobuf::Descriptor* descriptor();
-  static const GrpcMsgAccept& default_instance();
-
-  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const GrpcMsgAccept* internal_default_instance() {
-    return reinterpret_cast<const GrpcMsgAccept*>(
-               &_GrpcMsgAccept_default_instance_);
-  }
-  static constexpr int kIndexInFileMessages =
-    5;
-
-  void Swap(GrpcMsgAccept* other);
-  friend void swap(GrpcMsgAccept& a, GrpcMsgAccept& b) {
-    a.Swap(&b);
-  }
-
-  // implements Message ----------------------------------------------
-
-  inline GrpcMsgAccept* New() const final {
-    return CreateMaybeMessage<GrpcMsgAccept>(NULL);
-  }
-
-  GrpcMsgAccept* New(::google::protobuf::Arena* arena) const final {
-    return CreateMaybeMessage<GrpcMsgAccept>(arena);
-  }
-  void CopyFrom(const ::google::protobuf::Message& from) final;
-  void MergeFrom(const ::google::protobuf::Message& from) final;
-  void CopyFrom(const GrpcMsgAccept& from);
-  void MergeFrom(const GrpcMsgAccept& from);
-  void Clear() final;
-  bool IsInitialized() const final;
-
-  size_t ByteSizeLong() const final;
-  bool MergePartialFromCodedStream(
-      ::google::protobuf::io::CodedInputStream* input) final;
-  void SerializeWithCachedSizes(
-      ::google::protobuf::io::CodedOutputStream* output) const final;
-  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
-      bool deterministic, ::google::protobuf::uint8* target) const final;
-  int GetCachedSize() const final { return _cached_size_.Get(); }
-
-  private:
-  void SharedCtor();
-  void SharedDtor();
-  void SetCachedSize(int size) const final;
-  void InternalSwap(GrpcMsgAccept* other);
-  private:
-  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return NULL;
-  }
-  inline void* MaybeArenaPtr() const {
-    return NULL;
-  }
-  public:
-
-  ::google::protobuf::Metadata GetMetadata() const final;
-
-  // nested types ----------------------------------------------------
-
-  // accessors -------------------------------------------------------
-
-  // bytes message = 1;
-  void clear_message();
-  static const int kMessageFieldNumber = 1;
-  const ::std::string& message() const;
-  void set_message(const ::std::string& value);
-  #if LANG_CXX11
-  void set_message(::std::string&& value);
-  #endif
-  void set_message(const char* value);
-  void set_message(const void* value, size_t size);
-  ::std::string* mutable_message();
-  ::std::string* release_message();
-  void set_allocated_message(::std::string* message);
-
-  // @@protoc_insertion_point(class_scope:grpc_signer.GrpcMsgAccept)
- private:
-
-  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
-  ::google::protobuf::internal::ArenaStringPtr message_;
-  mutable ::google::protobuf::internal::CachedSize _cached_size_;
-  friend struct ::protobuf_protobuf_5fsigner_2eproto::TableStruct;
-};
-// -------------------------------------------------------------------
-
-class GrpcMsgSsig : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_signer.GrpcMsgSsig) */ {
- public:
-  GrpcMsgSsig();
-  virtual ~GrpcMsgSsig();
-
-  GrpcMsgSsig(const GrpcMsgSsig& from);
-
-  inline GrpcMsgSsig& operator=(const GrpcMsgSsig& from) {
-    CopyFrom(from);
-    return *this;
-  }
-  #if LANG_CXX11
-  GrpcMsgSsig(GrpcMsgSsig&& from) noexcept
-    : GrpcMsgSsig() {
-    *this = ::std::move(from);
-  }
-
-  inline GrpcMsgSsig& operator=(GrpcMsgSsig&& from) noexcept {
-    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
-      if (this != &from) InternalSwap(&from);
-    } else {
-      CopyFrom(from);
-    }
-    return *this;
-  }
-  #endif
-  static const ::google::protobuf::Descriptor* descriptor();
-  static const GrpcMsgSsig& default_instance();
-
-  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const GrpcMsgSsig* internal_default_instance() {
-    return reinterpret_cast<const GrpcMsgSsig*>(
-               &_GrpcMsgSsig_default_instance_);
-  }
-  static constexpr int kIndexInFileMessages =
-    6;
-
-  void Swap(GrpcMsgSsig* other);
-  friend void swap(GrpcMsgSsig& a, GrpcMsgSsig& b) {
-    a.Swap(&b);
-  }
-
-  // implements Message ----------------------------------------------
-
-  inline GrpcMsgSsig* New() const final {
-    return CreateMaybeMessage<GrpcMsgSsig>(NULL);
-  }
-
-  GrpcMsgSsig* New(::google::protobuf::Arena* arena) const final {
-    return CreateMaybeMessage<GrpcMsgSsig>(arena);
-  }
-  void CopyFrom(const ::google::protobuf::Message& from) final;
-  void MergeFrom(const ::google::protobuf::Message& from) final;
-  void CopyFrom(const GrpcMsgSsig& from);
-  void MergeFrom(const GrpcMsgSsig& from);
-  void Clear() final;
-  bool IsInitialized() const final;
-
-  size_t ByteSizeLong() const final;
-  bool MergePartialFromCodedStream(
-      ::google::protobuf::io::CodedInputStream* input) final;
-  void SerializeWithCachedSizes(
-      ::google::protobuf::io::CodedOutputStream* output) const final;
-  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
-      bool deterministic, ::google::protobuf::uint8* target) const final;
-  int GetCachedSize() const final { return _cached_size_.Get(); }
-
-  private:
-  void SharedCtor();
-  void SharedDtor();
-  void SetCachedSize(int size) const final;
-  void InternalSwap(GrpcMsgSsig* other);
-  private:
-  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return NULL;
-  }
-  inline void* MaybeArenaPtr() const {
-    return NULL;
-  }
-  public:
-
-  ::google::protobuf::Metadata GetMetadata() const final;
-
-  // nested types ----------------------------------------------------
-
-  // accessors -------------------------------------------------------
-
-  // bytes message = 1;
-  void clear_message();
-  static const int kMessageFieldNumber = 1;
-  const ::std::string& message() const;
-  void set_message(const ::std::string& value);
-  #if LANG_CXX11
-  void set_message(::std::string&& value);
-  #endif
-  void set_message(const char* value);
-  void set_message(const void* value, size_t size);
-  ::std::string* mutable_message();
-  ::std::string* release_message();
-  void set_allocated_message(::std::string* message);
-
-  // @@protoc_insertion_point(class_scope:grpc_signer.GrpcMsgSsig)
- private:
-
-  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
-  ::google::protobuf::internal::ArenaStringPtr message_;
-  mutable ::google::protobuf::internal::CachedSize _cached_size_;
-  friend struct ::protobuf_protobuf_5fsigner_2eproto::TableStruct;
-};
-// -------------------------------------------------------------------
-
-class GrpcMsgReqSsig : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_signer.GrpcMsgReqSsig) */ {
- public:
-  GrpcMsgReqSsig();
-  virtual ~GrpcMsgReqSsig();
-
-  GrpcMsgReqSsig(const GrpcMsgReqSsig& from);
-
-  inline GrpcMsgReqSsig& operator=(const GrpcMsgReqSsig& from) {
-    CopyFrom(from);
-    return *this;
-  }
-  #if LANG_CXX11
-  GrpcMsgReqSsig(GrpcMsgReqSsig&& from) noexcept
-    : GrpcMsgReqSsig() {
-    *this = ::std::move(from);
-  }
-
-  inline GrpcMsgReqSsig& operator=(GrpcMsgReqSsig&& from) noexcept {
-    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
-      if (this != &from) InternalSwap(&from);
-    } else {
-      CopyFrom(from);
-    }
-    return *this;
-  }
-  #endif
-  static const ::google::protobuf::Descriptor* descriptor();
-  static const GrpcMsgReqSsig& default_instance();
-
-  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const GrpcMsgReqSsig* internal_default_instance() {
-    return reinterpret_cast<const GrpcMsgReqSsig*>(
-               &_GrpcMsgReqSsig_default_instance_);
-  }
-  static constexpr int kIndexInFileMessages =
-    7;
-
-  void Swap(GrpcMsgReqSsig* other);
-  friend void swap(GrpcMsgReqSsig& a, GrpcMsgReqSsig& b) {
-    a.Swap(&b);
-  }
-
-  // implements Message ----------------------------------------------
-
-  inline GrpcMsgReqSsig* New() const final {
-    return CreateMaybeMessage<GrpcMsgReqSsig>(NULL);
-  }
-
-  GrpcMsgReqSsig* New(::google::protobuf::Arena* arena) const final {
-    return CreateMaybeMessage<GrpcMsgReqSsig>(arena);
-  }
-  void CopyFrom(const ::google::protobuf::Message& from) final;
-  void MergeFrom(const ::google::protobuf::Message& from) final;
-  void CopyFrom(const GrpcMsgReqSsig& from);
-  void MergeFrom(const GrpcMsgReqSsig& from);
-  void Clear() final;
-  bool IsInitialized() const final;
-
-  size_t ByteSizeLong() const final;
-  bool MergePartialFromCodedStream(
-      ::google::protobuf::io::CodedInputStream* input) final;
-  void SerializeWithCachedSizes(
-      ::google::protobuf::io::CodedOutputStream* output) const final;
-  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
-      bool deterministic, ::google::protobuf::uint8* target) const final;
-  int GetCachedSize() const final { return _cached_size_.Get(); }
-
-  private:
-  void SharedCtor();
-  void SharedDtor();
-  void SetCachedSize(int size) const final;
-  void InternalSwap(GrpcMsgReqSsig* other);
-  private:
-  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return NULL;
-  }
-  inline void* MaybeArenaPtr() const {
-    return NULL;
-  }
-  public:
-
-  ::google::protobuf::Metadata GetMetadata() const final;
-
-  // nested types ----------------------------------------------------
-
-  // accessors -------------------------------------------------------
-
-  // bytes message = 1;
-  void clear_message();
-  static const int kMessageFieldNumber = 1;
-  const ::std::string& message() const;
-  void set_message(const ::std::string& value);
-  #if LANG_CXX11
-  void set_message(::std::string&& value);
-  #endif
-  void set_message(const char* value);
-  void set_message(const void* value, size_t size);
-  ::std::string* mutable_message();
-  ::std::string* release_message();
-  void set_allocated_message(::std::string* message);
-
-  // @@protoc_insertion_point(class_scope:grpc_signer.GrpcMsgReqSsig)
- private:
-
-  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
-  ::google::protobuf::internal::ArenaStringPtr message_;
+  int status_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_protobuf_5fsigner_2eproto::TableStruct;
 };
@@ -1018,7 +497,7 @@ class Identity : public ::google::protobuf::Message /* @@protoc_insertion_point(
                &_Identity_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    8;
+    3;
 
   void Swap(Identity* other);
   friend void swap(Identity& a, Identity& b) {
@@ -1092,102 +571,6 @@ class Identity : public ::google::protobuf::Message /* @@protoc_insertion_point(
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_protobuf_5fsigner_2eproto::TableStruct;
 };
-// -------------------------------------------------------------------
-
-class NoReply : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_signer.NoReply) */ {
- public:
-  NoReply();
-  virtual ~NoReply();
-
-  NoReply(const NoReply& from);
-
-  inline NoReply& operator=(const NoReply& from) {
-    CopyFrom(from);
-    return *this;
-  }
-  #if LANG_CXX11
-  NoReply(NoReply&& from) noexcept
-    : NoReply() {
-    *this = ::std::move(from);
-  }
-
-  inline NoReply& operator=(NoReply&& from) noexcept {
-    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
-      if (this != &from) InternalSwap(&from);
-    } else {
-      CopyFrom(from);
-    }
-    return *this;
-  }
-  #endif
-  static const ::google::protobuf::Descriptor* descriptor();
-  static const NoReply& default_instance();
-
-  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const NoReply* internal_default_instance() {
-    return reinterpret_cast<const NoReply*>(
-               &_NoReply_default_instance_);
-  }
-  static constexpr int kIndexInFileMessages =
-    9;
-
-  void Swap(NoReply* other);
-  friend void swap(NoReply& a, NoReply& b) {
-    a.Swap(&b);
-  }
-
-  // implements Message ----------------------------------------------
-
-  inline NoReply* New() const final {
-    return CreateMaybeMessage<NoReply>(NULL);
-  }
-
-  NoReply* New(::google::protobuf::Arena* arena) const final {
-    return CreateMaybeMessage<NoReply>(arena);
-  }
-  void CopyFrom(const ::google::protobuf::Message& from) final;
-  void MergeFrom(const ::google::protobuf::Message& from) final;
-  void CopyFrom(const NoReply& from);
-  void MergeFrom(const NoReply& from);
-  void Clear() final;
-  bool IsInitialized() const final;
-
-  size_t ByteSizeLong() const final;
-  bool MergePartialFromCodedStream(
-      ::google::protobuf::io::CodedInputStream* input) final;
-  void SerializeWithCachedSizes(
-      ::google::protobuf::io::CodedOutputStream* output) const final;
-  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
-      bool deterministic, ::google::protobuf::uint8* target) const final;
-  int GetCachedSize() const final { return _cached_size_.Get(); }
-
-  private:
-  void SharedCtor();
-  void SharedDtor();
-  void SetCachedSize(int size) const final;
-  void InternalSwap(NoReply* other);
-  private:
-  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return NULL;
-  }
-  inline void* MaybeArenaPtr() const {
-    return NULL;
-  }
-  public:
-
-  ::google::protobuf::Metadata GetMetadata() const final;
-
-  // nested types ----------------------------------------------------
-
-  // accessors -------------------------------------------------------
-
-  // @@protoc_insertion_point(class_scope:grpc_signer.NoReply)
- private:
-
-  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
-  mutable ::google::protobuf::internal::CachedSize _cached_size_;
-  friend struct ::protobuf_protobuf_5fsigner_2eproto::TableStruct;
-};
 // ===================================================================
 
 
@@ -1197,458 +580,187 @@ class NoReply : public ::google::protobuf::Message /* @@protoc_insertion_point(c
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif  // __GNUC__
-// GrpcMsgJoin
+// RequestMsg
 
 // bytes message = 1;
-inline void GrpcMsgJoin::clear_message() {
+inline void RequestMsg::clear_message() {
   message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-inline const ::std::string& GrpcMsgJoin::message() const {
-  // @@protoc_insertion_point(field_get:grpc_signer.GrpcMsgJoin.message)
+inline const ::std::string& RequestMsg::message() const {
+  // @@protoc_insertion_point(field_get:grpc_signer.RequestMsg.message)
   return message_.GetNoArena();
 }
-inline void GrpcMsgJoin::set_message(const ::std::string& value) {
+inline void RequestMsg::set_message(const ::std::string& value) {
   
   message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:grpc_signer.GrpcMsgJoin.message)
+  // @@protoc_insertion_point(field_set:grpc_signer.RequestMsg.message)
 }
 #if LANG_CXX11
-inline void GrpcMsgJoin::set_message(::std::string&& value) {
+inline void RequestMsg::set_message(::std::string&& value) {
   
   message_.SetNoArena(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
-  // @@protoc_insertion_point(field_set_rvalue:grpc_signer.GrpcMsgJoin.message)
+  // @@protoc_insertion_point(field_set_rvalue:grpc_signer.RequestMsg.message)
 }
 #endif
-inline void GrpcMsgJoin::set_message(const char* value) {
+inline void RequestMsg::set_message(const char* value) {
   GOOGLE_DCHECK(value != NULL);
   
   message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:grpc_signer.GrpcMsgJoin.message)
+  // @@protoc_insertion_point(field_set_char:grpc_signer.RequestMsg.message)
 }
-inline void GrpcMsgJoin::set_message(const void* value, size_t size) {
+inline void RequestMsg::set_message(const void* value, size_t size) {
   
   message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:grpc_signer.GrpcMsgJoin.message)
+  // @@protoc_insertion_point(field_set_pointer:grpc_signer.RequestMsg.message)
 }
-inline ::std::string* GrpcMsgJoin::mutable_message() {
+inline ::std::string* RequestMsg::mutable_message() {
   
-  // @@protoc_insertion_point(field_mutable:grpc_signer.GrpcMsgJoin.message)
+  // @@protoc_insertion_point(field_mutable:grpc_signer.RequestMsg.message)
   return message_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-inline ::std::string* GrpcMsgJoin::release_message() {
-  // @@protoc_insertion_point(field_release:grpc_signer.GrpcMsgJoin.message)
+inline ::std::string* RequestMsg::release_message() {
+  // @@protoc_insertion_point(field_release:grpc_signer.RequestMsg.message)
   
   return message_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-inline void GrpcMsgJoin::set_allocated_message(::std::string* message) {
+inline void RequestMsg::set_allocated_message(::std::string* message) {
   if (message != NULL) {
     
   } else {
     
   }
   message_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), message);
-  // @@protoc_insertion_point(field_set_allocated:grpc_signer.GrpcMsgJoin.message)
+  // @@protoc_insertion_point(field_set_allocated:grpc_signer.RequestMsg.message)
 }
 
 // -------------------------------------------------------------------
 
-// GrpcMsgChallenge
+// ReplyMsg
 
 // bytes message = 1;
-inline void GrpcMsgChallenge::clear_message() {
+inline void ReplyMsg::clear_message() {
   message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-inline const ::std::string& GrpcMsgChallenge::message() const {
-  // @@protoc_insertion_point(field_get:grpc_signer.GrpcMsgChallenge.message)
+inline const ::std::string& ReplyMsg::message() const {
+  // @@protoc_insertion_point(field_get:grpc_signer.ReplyMsg.message)
   return message_.GetNoArena();
 }
-inline void GrpcMsgChallenge::set_message(const ::std::string& value) {
+inline void ReplyMsg::set_message(const ::std::string& value) {
   
   message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:grpc_signer.GrpcMsgChallenge.message)
+  // @@protoc_insertion_point(field_set:grpc_signer.ReplyMsg.message)
 }
 #if LANG_CXX11
-inline void GrpcMsgChallenge::set_message(::std::string&& value) {
+inline void ReplyMsg::set_message(::std::string&& value) {
   
   message_.SetNoArena(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
-  // @@protoc_insertion_point(field_set_rvalue:grpc_signer.GrpcMsgChallenge.message)
+  // @@protoc_insertion_point(field_set_rvalue:grpc_signer.ReplyMsg.message)
 }
 #endif
-inline void GrpcMsgChallenge::set_message(const char* value) {
+inline void ReplyMsg::set_message(const char* value) {
   GOOGLE_DCHECK(value != NULL);
   
   message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:grpc_signer.GrpcMsgChallenge.message)
+  // @@protoc_insertion_point(field_set_char:grpc_signer.ReplyMsg.message)
 }
-inline void GrpcMsgChallenge::set_message(const void* value, size_t size) {
+inline void ReplyMsg::set_message(const void* value, size_t size) {
   
   message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:grpc_signer.GrpcMsgChallenge.message)
+  // @@protoc_insertion_point(field_set_pointer:grpc_signer.ReplyMsg.message)
 }
-inline ::std::string* GrpcMsgChallenge::mutable_message() {
+inline ::std::string* ReplyMsg::mutable_message() {
   
-  // @@protoc_insertion_point(field_mutable:grpc_signer.GrpcMsgChallenge.message)
+  // @@protoc_insertion_point(field_mutable:grpc_signer.ReplyMsg.message)
   return message_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-inline ::std::string* GrpcMsgChallenge::release_message() {
-  // @@protoc_insertion_point(field_release:grpc_signer.GrpcMsgChallenge.message)
+inline ::std::string* ReplyMsg::release_message() {
+  // @@protoc_insertion_point(field_release:grpc_signer.ReplyMsg.message)
   
   return message_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-inline void GrpcMsgChallenge::set_allocated_message(::std::string* message) {
+inline void ReplyMsg::set_allocated_message(::std::string* message) {
   if (message != NULL) {
     
   } else {
     
   }
   message_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), message);
-  // @@protoc_insertion_point(field_set_allocated:grpc_signer.GrpcMsgChallenge.message)
+  // @@protoc_insertion_point(field_set_allocated:grpc_signer.ReplyMsg.message)
 }
 
 // -------------------------------------------------------------------
 
-// GrpcMsgResponse1
+// MsgStatus
 
-// bytes message = 1;
-inline void GrpcMsgResponse1::clear_message() {
+// .grpc_signer.MsgStatus.Status status = 1;
+inline void MsgStatus::clear_status() {
+  status_ = 0;
+}
+inline ::grpc_signer::MsgStatus_Status MsgStatus::status() const {
+  // @@protoc_insertion_point(field_get:grpc_signer.MsgStatus.status)
+  return static_cast< ::grpc_signer::MsgStatus_Status >(status_);
+}
+inline void MsgStatus::set_status(::grpc_signer::MsgStatus_Status value) {
+  
+  status_ = value;
+  // @@protoc_insertion_point(field_set:grpc_signer.MsgStatus.status)
+}
+
+// string message = 2;
+inline void MsgStatus::clear_message() {
   message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-inline const ::std::string& GrpcMsgResponse1::message() const {
-  // @@protoc_insertion_point(field_get:grpc_signer.GrpcMsgResponse1.message)
+inline const ::std::string& MsgStatus::message() const {
+  // @@protoc_insertion_point(field_get:grpc_signer.MsgStatus.message)
   return message_.GetNoArena();
 }
-inline void GrpcMsgResponse1::set_message(const ::std::string& value) {
+inline void MsgStatus::set_message(const ::std::string& value) {
   
   message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:grpc_signer.GrpcMsgResponse1.message)
+  // @@protoc_insertion_point(field_set:grpc_signer.MsgStatus.message)
 }
 #if LANG_CXX11
-inline void GrpcMsgResponse1::set_message(::std::string&& value) {
+inline void MsgStatus::set_message(::std::string&& value) {
   
   message_.SetNoArena(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
-  // @@protoc_insertion_point(field_set_rvalue:grpc_signer.GrpcMsgResponse1.message)
+  // @@protoc_insertion_point(field_set_rvalue:grpc_signer.MsgStatus.message)
 }
 #endif
-inline void GrpcMsgResponse1::set_message(const char* value) {
+inline void MsgStatus::set_message(const char* value) {
   GOOGLE_DCHECK(value != NULL);
   
   message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:grpc_signer.GrpcMsgResponse1.message)
+  // @@protoc_insertion_point(field_set_char:grpc_signer.MsgStatus.message)
 }
-inline void GrpcMsgResponse1::set_message(const void* value, size_t size) {
+inline void MsgStatus::set_message(const char* value, size_t size) {
   
   message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:grpc_signer.GrpcMsgResponse1.message)
+  // @@protoc_insertion_point(field_set_pointer:grpc_signer.MsgStatus.message)
 }
-inline ::std::string* GrpcMsgResponse1::mutable_message() {
+inline ::std::string* MsgStatus::mutable_message() {
   
-  // @@protoc_insertion_point(field_mutable:grpc_signer.GrpcMsgResponse1.message)
+  // @@protoc_insertion_point(field_mutable:grpc_signer.MsgStatus.message)
   return message_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-inline ::std::string* GrpcMsgResponse1::release_message() {
-  // @@protoc_insertion_point(field_release:grpc_signer.GrpcMsgResponse1.message)
+inline ::std::string* MsgStatus::release_message() {
+  // @@protoc_insertion_point(field_release:grpc_signer.MsgStatus.message)
   
   return message_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-inline void GrpcMsgResponse1::set_allocated_message(::std::string* message) {
+inline void MsgStatus::set_allocated_message(::std::string* message) {
   if (message != NULL) {
     
   } else {
     
   }
   message_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), message);
-  // @@protoc_insertion_point(field_set_allocated:grpc_signer.GrpcMsgResponse1.message)
-}
-
-// -------------------------------------------------------------------
-
-// GrpcMsgResponse2
-
-// bytes message = 1;
-inline void GrpcMsgResponse2::clear_message() {
-  message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline const ::std::string& GrpcMsgResponse2::message() const {
-  // @@protoc_insertion_point(field_get:grpc_signer.GrpcMsgResponse2.message)
-  return message_.GetNoArena();
-}
-inline void GrpcMsgResponse2::set_message(const ::std::string& value) {
-  
-  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:grpc_signer.GrpcMsgResponse2.message)
-}
-#if LANG_CXX11
-inline void GrpcMsgResponse2::set_message(::std::string&& value) {
-  
-  message_.SetNoArena(
-    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
-  // @@protoc_insertion_point(field_set_rvalue:grpc_signer.GrpcMsgResponse2.message)
-}
-#endif
-inline void GrpcMsgResponse2::set_message(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
-  
-  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:grpc_signer.GrpcMsgResponse2.message)
-}
-inline void GrpcMsgResponse2::set_message(const void* value, size_t size) {
-  
-  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:grpc_signer.GrpcMsgResponse2.message)
-}
-inline ::std::string* GrpcMsgResponse2::mutable_message() {
-  
-  // @@protoc_insertion_point(field_mutable:grpc_signer.GrpcMsgResponse2.message)
-  return message_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline ::std::string* GrpcMsgResponse2::release_message() {
-  // @@protoc_insertion_point(field_release:grpc_signer.GrpcMsgResponse2.message)
-  
-  return message_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline void GrpcMsgResponse2::set_allocated_message(::std::string* message) {
-  if (message != NULL) {
-    
-  } else {
-    
-  }
-  message_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), message);
-  // @@protoc_insertion_point(field_set_allocated:grpc_signer.GrpcMsgResponse2.message)
-}
-
-// -------------------------------------------------------------------
-
-// GrpcMsgSuccess
-
-// bytes message = 1;
-inline void GrpcMsgSuccess::clear_message() {
-  message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline const ::std::string& GrpcMsgSuccess::message() const {
-  // @@protoc_insertion_point(field_get:grpc_signer.GrpcMsgSuccess.message)
-  return message_.GetNoArena();
-}
-inline void GrpcMsgSuccess::set_message(const ::std::string& value) {
-  
-  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:grpc_signer.GrpcMsgSuccess.message)
-}
-#if LANG_CXX11
-inline void GrpcMsgSuccess::set_message(::std::string&& value) {
-  
-  message_.SetNoArena(
-    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
-  // @@protoc_insertion_point(field_set_rvalue:grpc_signer.GrpcMsgSuccess.message)
-}
-#endif
-inline void GrpcMsgSuccess::set_message(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
-  
-  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:grpc_signer.GrpcMsgSuccess.message)
-}
-inline void GrpcMsgSuccess::set_message(const void* value, size_t size) {
-  
-  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:grpc_signer.GrpcMsgSuccess.message)
-}
-inline ::std::string* GrpcMsgSuccess::mutable_message() {
-  
-  // @@protoc_insertion_point(field_mutable:grpc_signer.GrpcMsgSuccess.message)
-  return message_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline ::std::string* GrpcMsgSuccess::release_message() {
-  // @@protoc_insertion_point(field_release:grpc_signer.GrpcMsgSuccess.message)
-  
-  return message_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline void GrpcMsgSuccess::set_allocated_message(::std::string* message) {
-  if (message != NULL) {
-    
-  } else {
-    
-  }
-  message_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), message);
-  // @@protoc_insertion_point(field_set_allocated:grpc_signer.GrpcMsgSuccess.message)
-}
-
-// -------------------------------------------------------------------
-
-// GrpcMsgAccept
-
-// bytes message = 1;
-inline void GrpcMsgAccept::clear_message() {
-  message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline const ::std::string& GrpcMsgAccept::message() const {
-  // @@protoc_insertion_point(field_get:grpc_signer.GrpcMsgAccept.message)
-  return message_.GetNoArena();
-}
-inline void GrpcMsgAccept::set_message(const ::std::string& value) {
-  
-  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:grpc_signer.GrpcMsgAccept.message)
-}
-#if LANG_CXX11
-inline void GrpcMsgAccept::set_message(::std::string&& value) {
-  
-  message_.SetNoArena(
-    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
-  // @@protoc_insertion_point(field_set_rvalue:grpc_signer.GrpcMsgAccept.message)
-}
-#endif
-inline void GrpcMsgAccept::set_message(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
-  
-  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:grpc_signer.GrpcMsgAccept.message)
-}
-inline void GrpcMsgAccept::set_message(const void* value, size_t size) {
-  
-  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:grpc_signer.GrpcMsgAccept.message)
-}
-inline ::std::string* GrpcMsgAccept::mutable_message() {
-  
-  // @@protoc_insertion_point(field_mutable:grpc_signer.GrpcMsgAccept.message)
-  return message_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline ::std::string* GrpcMsgAccept::release_message() {
-  // @@protoc_insertion_point(field_release:grpc_signer.GrpcMsgAccept.message)
-  
-  return message_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline void GrpcMsgAccept::set_allocated_message(::std::string* message) {
-  if (message != NULL) {
-    
-  } else {
-    
-  }
-  message_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), message);
-  // @@protoc_insertion_point(field_set_allocated:grpc_signer.GrpcMsgAccept.message)
-}
-
-// -------------------------------------------------------------------
-
-// GrpcMsgSsig
-
-// bytes message = 1;
-inline void GrpcMsgSsig::clear_message() {
-  message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline const ::std::string& GrpcMsgSsig::message() const {
-  // @@protoc_insertion_point(field_get:grpc_signer.GrpcMsgSsig.message)
-  return message_.GetNoArena();
-}
-inline void GrpcMsgSsig::set_message(const ::std::string& value) {
-  
-  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:grpc_signer.GrpcMsgSsig.message)
-}
-#if LANG_CXX11
-inline void GrpcMsgSsig::set_message(::std::string&& value) {
-  
-  message_.SetNoArena(
-    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
-  // @@protoc_insertion_point(field_set_rvalue:grpc_signer.GrpcMsgSsig.message)
-}
-#endif
-inline void GrpcMsgSsig::set_message(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
-  
-  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:grpc_signer.GrpcMsgSsig.message)
-}
-inline void GrpcMsgSsig::set_message(const void* value, size_t size) {
-  
-  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:grpc_signer.GrpcMsgSsig.message)
-}
-inline ::std::string* GrpcMsgSsig::mutable_message() {
-  
-  // @@protoc_insertion_point(field_mutable:grpc_signer.GrpcMsgSsig.message)
-  return message_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline ::std::string* GrpcMsgSsig::release_message() {
-  // @@protoc_insertion_point(field_release:grpc_signer.GrpcMsgSsig.message)
-  
-  return message_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline void GrpcMsgSsig::set_allocated_message(::std::string* message) {
-  if (message != NULL) {
-    
-  } else {
-    
-  }
-  message_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), message);
-  // @@protoc_insertion_point(field_set_allocated:grpc_signer.GrpcMsgSsig.message)
-}
-
-// -------------------------------------------------------------------
-
-// GrpcMsgReqSsig
-
-// bytes message = 1;
-inline void GrpcMsgReqSsig::clear_message() {
-  message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline const ::std::string& GrpcMsgReqSsig::message() const {
-  // @@protoc_insertion_point(field_get:grpc_signer.GrpcMsgReqSsig.message)
-  return message_.GetNoArena();
-}
-inline void GrpcMsgReqSsig::set_message(const ::std::string& value) {
-  
-  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:grpc_signer.GrpcMsgReqSsig.message)
-}
-#if LANG_CXX11
-inline void GrpcMsgReqSsig::set_message(::std::string&& value) {
-  
-  message_.SetNoArena(
-    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
-  // @@protoc_insertion_point(field_set_rvalue:grpc_signer.GrpcMsgReqSsig.message)
-}
-#endif
-inline void GrpcMsgReqSsig::set_message(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
-  
-  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:grpc_signer.GrpcMsgReqSsig.message)
-}
-inline void GrpcMsgReqSsig::set_message(const void* value, size_t size) {
-  
-  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:grpc_signer.GrpcMsgReqSsig.message)
-}
-inline ::std::string* GrpcMsgReqSsig::mutable_message() {
-  
-  // @@protoc_insertion_point(field_mutable:grpc_signer.GrpcMsgReqSsig.message)
-  return message_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline ::std::string* GrpcMsgReqSsig::release_message() {
-  // @@protoc_insertion_point(field_release:grpc_signer.GrpcMsgReqSsig.message)
-  
-  return message_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline void GrpcMsgReqSsig::set_allocated_message(::std::string* message) {
-  if (message != NULL) {
-    
-  } else {
-    
-  }
-  message_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), message);
-  // @@protoc_insertion_point(field_set_allocated:grpc_signer.GrpcMsgReqSsig.message)
+  // @@protoc_insertion_point(field_set_allocated:grpc_signer.MsgStatus.message)
 }
 
 // -------------------------------------------------------------------
@@ -1708,25 +820,9 @@ inline void Identity::set_allocated_sender(::std::string* sender) {
   // @@protoc_insertion_point(field_set_allocated:grpc_signer.Identity.sender)
 }
 
-// -------------------------------------------------------------------
-
-// NoReply
-
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
-// -------------------------------------------------------------------
-
-// -------------------------------------------------------------------
-
-// -------------------------------------------------------------------
-
-// -------------------------------------------------------------------
-
-// -------------------------------------------------------------------
-
-// -------------------------------------------------------------------
-
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------
@@ -1737,6 +833,18 @@ inline void Identity::set_allocated_sender(::std::string* sender) {
 // @@protoc_insertion_point(namespace_scope)
 
 }  // namespace grpc_signer
+
+namespace google {
+namespace protobuf {
+
+template <> struct is_proto_enum< ::grpc_signer::MsgStatus_Status> : ::std::true_type {};
+template <>
+inline const EnumDescriptor* GetEnumDescriptor< ::grpc_signer::MsgStatus_Status>() {
+  return ::grpc_signer::MsgStatus_Status_descriptor();
+}
+
+}  // namespace protobuf
+}  // namespace google
 
 // @@protoc_insertion_point(global_scope)
 

--- a/src/modules/communication/protos/protobuf_signer.proto
+++ b/src/modules/communication/protos/protobuf_signer.proto
@@ -6,44 +6,26 @@ option java_outer_classname = "GruutNetwork";
 
 package grpc_signer;
 
-service  GruutNetworkService {
-    rpc join(GrpcMsgJoin) returns (GrpcMsgChallenge) {}
-    rpc dhKeyEx(GrpcMsgResponse1) returns (GrpcMsgResponse2) {}
-    rpc keyExFinished(GrpcMsgSuccess) returns (GrpcMsgAccept) {}
-    rpc sigSend(GrpcMsgSsig) returns (NoReply) {}
-
-    // 네트워크 참여가 완료 되었을 때 채널 그랜드 오픈!
-    // M: Accept Signer에게 보냄과 동시에 채널을 오픈
-    // S: Accept 수신 시 채널 오픈
-    rpc openChannel(stream Identity) returns (stream GrpcMsgReqSsig) {}
+service GruutSignerService {
+    rpc openChannel(stream Identity) returns (stream ReplyMsg) {}
+    rpc signerService (RequestMsg) returns (MsgStatus) {}
 }
 
-message GrpcMsgJoin {
+message RequestMsg {
     bytes message = 1;
 }
-message GrpcMsgChallenge {
+message ReplyMsg {
     bytes message = 1;
 }
-message GrpcMsgResponse1 {
-    bytes message = 1;
+message MsgStatus {
+    enum Status{
+        SUCCESS = 0;
+        INVALID = 1;
+        INTERNAL = 2;
+    }
+    Status status = 1;
+    string message = 2;
 }
-message GrpcMsgResponse2 {
-    bytes message = 1;
-}
-message GrpcMsgSuccess {
-    bytes message = 1;
-}
-message GrpcMsgAccept {
-    bytes message = 1;
-}
-message GrpcMsgSsig {
-    bytes message = 1;
-}
-message GrpcMsgReqSsig {
-    bytes message = 1;
-}
-
 message Identity {
     bytes sender = 1;
 }
-message NoReply {}

--- a/src/modules/communication/rpc_receiver_list.hpp
+++ b/src/modules/communication/rpc_receiver_list.hpp
@@ -18,16 +18,7 @@ enum class RpcCallStatus { CREATE, PROCESS, READ, WAIT, FINISH };
 
 struct SignerRpcInfo {
   void *tag_identity;
-  void *tag_join;
-  void *tag_dhkeyex;
-  void *tag_keyexfinished;
-  ServerAsyncReaderWriter<GrpcMsgReqSsig, Identity> *send_req_ssig;
-  ServerAsyncResponseWriter<GrpcMsgChallenge> *send_challenge;
-  ServerAsyncResponseWriter<GrpcMsgResponse2> *send_response2;
-  ServerAsyncResponseWriter<GrpcMsgAccept> *send_accept;
-  RpcCallStatus *join_status;
-  RpcCallStatus *dhkeyex_status;
-  RpcCallStatus *keyexfinished_status;
+  ServerAsyncReaderWriter<ReplyMsg, Identity> *send_msg;
 };
 
 class RpcReceiverList : public TemplateSingleton<RpcReceiverList> {
@@ -36,47 +27,13 @@ private:
   std::mutex m_mutex;
 
 public:
-  void
-  setReqSsig(id_type &recv_id,
-             ServerAsyncReaderWriter<GrpcMsgReqSsig, Identity> *req_sig_rpc,
-             void *tag) {
+  void setReplyMsg(id_type &recv_id,
+                   ServerAsyncReaderWriter<ReplyMsg, Identity> *reply_rpc,
+                   void *tag) {
     string recv_id_b64 = TypeConverter::encodeBase64(recv_id);
     std::lock_guard<std::mutex> lock(m_mutex);
-    m_receiver_list[recv_id_b64].send_req_ssig = req_sig_rpc;
+    m_receiver_list[recv_id_b64].send_msg = reply_rpc;
     m_receiver_list[recv_id_b64].tag_identity = tag;
-    m_mutex.unlock();
-  }
-
-  void setChanllenge(id_type &recv_id,
-                     ServerAsyncResponseWriter<GrpcMsgChallenge> *challenge,
-                     void *tag, RpcCallStatus *status) {
-    string recv_id_b64 = TypeConverter::encodeBase64(recv_id);
-    std::lock_guard<std::mutex> lock(m_mutex);
-    m_receiver_list[recv_id_b64].send_challenge = challenge;
-    m_receiver_list[recv_id_b64].tag_join = tag;
-    m_receiver_list[recv_id_b64].join_status = status;
-    m_mutex.unlock();
-  }
-
-  void setResponse2(id_type &recv_id,
-                    ServerAsyncResponseWriter<GrpcMsgResponse2> *response2,
-                    void *tag, RpcCallStatus *status) {
-    string recv_id_b64 = TypeConverter::encodeBase64(recv_id);
-    std::lock_guard<std::mutex> lock(m_mutex);
-    m_receiver_list[recv_id_b64].send_response2 = response2;
-    m_receiver_list[recv_id_b64].tag_dhkeyex = tag;
-    m_receiver_list[recv_id_b64].dhkeyex_status = status;
-    m_mutex.unlock();
-  }
-
-  void setAccept(id_type &recv_id,
-                 ServerAsyncResponseWriter<GrpcMsgAccept> *accept, void *tag,
-                 RpcCallStatus *status) {
-    string recv_id_b64 = TypeConverter::encodeBase64(recv_id);
-    std::lock_guard<std::mutex> lock(m_mutex);
-    m_receiver_list[recv_id_b64].send_accept = accept;
-    m_receiver_list[recv_id_b64].tag_keyexfinished = tag;
-    m_receiver_list[recv_id_b64].keyexfinished_status = status;
     m_mutex.unlock();
   }
 


### PR DESCRIPTION
### 수정 사항
- Signer - Merger 간 Protobuf 수정
- Protobuf 수정에 따라 @rpc_receiver_list.hpp 에서 관리하는 signer rpc가 stream rpc 하나로 줄음
- Protobuf 수정에 따라서 MergerClient에서 Signer로 메시지 보내는 부분 수정

- Signer - Merger 간 통신하는 방법 수정. 기존에는  일반 Rpc로 key 교환 완료후 stream channel을 열었었다. 수정후에는 Channel을 먼저 열고.  Join, key교환 메시지 등에 대한 답을 Stream Rpc로 답하는 형태로 수정.

### 수정 후 해결 될 현상
- 현재 Signer가 channel이 열리기 전에 끊어지면, signer pool에는  signer가  'Temporary' 상태로  남는다. 이 때문에 Bp Scheduler에서는 Signer가 있다고 인지함. 
- 수정 후에는 channel을 먼저 열기 때문에 중간에 signer와의 연결이 끊어지면 internal msg로 MSG_LEAVE가 발생하므로 signer pool에서 해당 signer을 지울 것 으로 생각됨. 