### PR TITLE
 # FIX - bp scheduler 및 storage 수정

### DIFF
--- a/src/chain/block.hpp
+++ b/src/chain/block.hpp
@@ -258,6 +258,8 @@ public:
 
   size_t getNumTransactions() { return m_transactions.size(); }
 
+  size_t getNumSSigs() { return m_ssigs.size(); }
+
   block_id_type getBlockId() { return m_block_id; }
 
   sha256 getHash() { return m_block_hash; }

--- a/src/modules/bootstraper/block_synchronizer.cpp
+++ b/src/modules/bootstraper/block_synchronizer.cpp
@@ -37,7 +37,7 @@ bool BlockSynchronizer::pushMsgToBlockList(InputMsgEntry &msg_block) {
 
   size_t block_height = new_block.getHeight();
 
-  if(m_my_last_height >= block_height) {
+  if (m_my_last_height >= block_height) {
     CLOG(INFO, "BSYN") << "Block dropped (old block)";
     return false;
   }

--- a/src/modules/bp_scheduler/bp_scheduler.cpp
+++ b/src/modules/bp_scheduler/bp_scheduler.cpp
@@ -231,7 +231,7 @@ void BpScheduler::postSendPingJob() {
 
     auto signer_pool = SignerPool::getInstance();
 
-    size_t num_signers = signer_pool->size();
+    size_t num_signers = signer_pool->getNumSignerBy();
     if (m_current_status != BpStatus::IN_BOOT_WAIT &&
         num_signers < config::MIN_SIGNATURE_COLLECT_SIZE) {
       m_current_status = BpStatus::ERROR_ON_SIGNERS;

--- a/src/services/argv_parser.hpp
+++ b/src/services/argv_parser.hpp
@@ -28,8 +28,7 @@ public:
         cxxopts::value<string>()->default_value("./setting.json"))(
         "pass", "Password to decrypt secret key",
         cxxopts::value<string>()->default_value(""))(
-        "port", "Port number",
-        cxxopts::value<string>()->default_value(""))(
+        "port", "Port number", cxxopts::value<string>()->default_value(""))(
         "dbpath", "DB path",
         cxxopts::value<string>()->default_value(config::DEFAULT_DB_PATH));
 

--- a/src/services/block_generator.hpp
+++ b/src/services/block_generator.hpp
@@ -48,7 +48,8 @@ public:
     storage->saveBlock(block_raw, block_header, block_body);
 
     CLOG(INFO, "BGEN") << "BLOCK GENERATED (height=" << new_block.getHeight()
-                       << ",#tx=" << new_block.getNumTransactions() << ")";
+                       << ",#tx=" << new_block.getNumTransactions()
+                       << ",#ssig=" << new_block.getNumSSigs() << ")";
 
     // setp-3) send blocks to others
 

--- a/src/services/setting.hpp
+++ b/src/services/setting.hpp
@@ -169,7 +169,7 @@ public:
     m_address = Safe::getString(setting_json["Self"], "address");
     m_port = Safe::getString(setting_json["Self"], "port");
 
-    if(m_port.empty()){
+    if (m_port.empty()) {
       m_port = config::DEFAULT_PORT_NUM;
     }
 

--- a/src/services/storage.cpp
+++ b/src/services/storage.cpp
@@ -468,7 +468,7 @@ read_block_type Storage::readBlock(size_t height) {
     result.height = 0;
   else {
     if (height == 0)
-      height =
+      result.height =
           static_cast<size_t>(stoll(getDataByKey(DBType::BLOCK_LATEST, "hgt")));
 
     result.block_raw = TypeConverter::stringToBytes(


### PR DESCRIPTION
- Bp scheduler에서 signer pool에서 'GOOD' status signer숫자만 보도록함
- Storage에서 readBlock()에서 값을 제대로 못 읽는 문제 해결
- 생성된 블록을 보낼 때, ssig 숫자 log 찍도록 함.