### PR TITLE
# FIX - POST의 필드를 escape하지 않을때 발생하는 문제

### DIFF
--- a/src/modules/communication/http_client.cpp
+++ b/src/modules/communication/http_client.cpp
@@ -9,10 +9,11 @@ HttpClient::HttpClient(const string &m_address) : m_address(m_address) {}
 CURLcode HttpClient::post(const string &packed_msg) {
   CLOG(INFO, "HTTP") << "POST (" << m_address << ")";
   try {
-    const string post_field = getPostField("message", packed_msg);
-
     m_curl.setOpt(CURLOPT_URL, m_address.data());
     m_curl.setOpt(CURLOPT_POST, 1L);
+
+    const auto escaped_field_data = m_curl.escape(packed_msg);
+    const string post_field = getPostField("message", escaped_field_data);
     m_curl.setOpt(CURLOPT_POSTFIELDS, post_field.data());
     m_curl.setOpt(CURLOPT_POSTFIELDSIZE, post_field.size());
 


### PR DESCRIPTION
## 원인
- post로 데이터를 전송할때 escape하지 않고 전송하게 되면
`i6A0XxDmwYKfYoudEu/pZ5tu2+mChFu/+75OpWsrCfk=` -> `i6A0XxDmwYKfYoudEu/pZ5tu2 mChFu/ 75OpWsrCfk=`  '+' character가 blank space로 치환되는 문제가 생김

## 수정사항
- 전송할때 데이터필드 escape하도록 수정

참조: https://stackoverflow.com/questions/5628738/strange-base64-encode-decode-problem