### PR TITLE
# FIX - added missing code to remove duplicated TX in block prorcessor

### DIFF
--- a/src/modules/block_processor/block_processor.cpp
+++ b/src/modules/block_processor/block_processor.cpp
@@ -186,6 +186,9 @@ bool BlockProcessor::handleMsgBlock(InputMsgEntry &entry) {
     CLOG(ERROR, "BPRO") << "Block dropped (unlinkable)";
   }
 
+  Application::app().getTransactionPool().removeDuplicatedTransactions(
+      recv_block.getTxIds());
+
   return true;
 }
 


### PR DESCRIPTION
### 수정
- unresolved block pool을 작업하면서 빠졌던 중복 TX 삭제 기능 추가

### 왜 발견하지 못했나.
- 시뮬레이터에서는 사실상 중복 TX를 생성하지 않으며, 2개 이상의 머저에서 테스트해야 되서...