### PR TITLE
#EDIT - MSG_REQ_STATUS / MSG_RES_STATUS

### DIFF
--- a/src/chain/mem_ledger.hpp
+++ b/src/chain/mem_ledger.hpp
@@ -9,8 +9,8 @@ struct LedgerRecord {
   std::string key;
   std::string value;
   std::string block_id_b64;
-  LedgerRecord(std::string &key_, std::string &value_, std::string &block_id_b64_) :
-  key(key_), value(value_), block_id_b64(block_id_b64_) {
+  LedgerRecord(std::string key_, std::string value_, std::string block_id_b64_) :
+  key(std::move(key_)), value(std::move(value_)), block_id_b64(std::move(block_id_b64_)) {
 
   }
 };

--- a/src/chain/types.hpp
+++ b/src/chain/types.hpp
@@ -142,12 +142,12 @@ using proof_type = struct _proof_type {
 };
 
 using storage_block_type = struct _storage_block_type {
-  std::string id_b64;
-  std::string hash_b64;
-  std::string prev_id_b64;
-  std::string prev_hash_b64;
+  block_id_type id;
+  hash_t hash;
+  block_id_type prev_id;
+  hash_t prev_hash;
   timestamp_t time;
-  size_t height;
+  block_height_type height;
   bytes block_raw;
   json txs;
 };
@@ -157,8 +157,13 @@ using nth_link_type = struct _nth_link_type {
   block_id_type prev_id;
   hash_t hash;
   hash_t prev_hash;
-  size_t height;
+  block_height_type height;
   timestamp_t time;
+};
+
+using unblk_push_result_type = struct _unblk_push_result_type {
+  block_height_type height;
+  bool linked;
 };
 
 // All of the blows are the same type. Use them according to the context.

--- a/src/ledger/certificate_ledger.hpp
+++ b/src/ledger/certificate_ledger.hpp
@@ -98,12 +98,9 @@ public:
 
 private:
 
-  template <typename S = json, typename T = std::string, typename V = std::vector<std::string>>
-  mem_ledger_t blockToLedger(S&& txs_json, T&& block_id_b64_,  V&& block_layer = {}){
+  mem_ledger_t blockToLedger(const json& txs_json, const std::string& block_id_b64, const std::vector<std::string>& block_layer = {}){
 
     mem_ledger_t ret_mem_ledger;
-
-    std::string block_id_b64 = block_id_b64_; // !!
 
     if(txs_json.is_array()) {
 

--- a/src/modules/block_processor/block_processor.cpp
+++ b/src/modules/block_processor/block_processor.cpp
@@ -9,7 +9,7 @@ BlockProcessor::BlockProcessor() {
   m_layered_storage = LayeredStorage::getInstance();
 
   auto setting = Setting::getInstance();
-  m_my_id = setting->getMyId();
+  m_my_id_b64 = TypeConverter::encodeBase64(setting->getMyId());
 
   auto last_block_info = m_storage->getNthBlockLinkInfo();
 
@@ -31,7 +31,7 @@ void BlockProcessor::start() { periodicTask(); }
 void BlockProcessor::periodicTask() {
   auto &io_service = Application::app().getIoService();
   io_service.post(m_task_strand->wrap([this]() {
-    std::vector<Block> resolved_blocks;
+    std::vector<std::pair<Block,bool>> resolved_blocks;
     std::vector<std::string> drop_blocks;
 
     m_unresolved_block_pool.getResolvedBlocks(resolved_blocks,drop_blocks);
@@ -44,22 +44,25 @@ void BlockProcessor::periodicTask() {
 
       for (auto &each_block : resolved_blocks) {
 
-        if (!each_block.isValidLate()) {
+        if (!each_block.first.isValidLate()) {
           CLOG(ERROR, "BPRO")
               << "Block dropped (invalid - late stage validation)";
           continue;
         }
 
-        json block_header = each_block.getBlockHeaderJson();
-        bytes block_raw = each_block.getBlockRaw();
-        json block_body = each_block.getBlockBodyJson();
+        json block_header = each_block.first.getBlockHeaderJson();
+        bytes block_raw = each_block.first.getBlockRaw();
+        json block_body = each_block.first.getBlockBodyJson();
+
+        if(!each_block.second) // this block was not interpreted into the ledger because of link failure
+          Application::app().getCustomLedgerManager().procLedgerBlock(block_body["tx"], each_block.first.getBlockIdB64());
 
         m_storage->saveBlock(block_raw, block_header, block_body);
-        m_layered_storage->moveToDiskLedger(each_block.getBlockIdB64());
+        m_layered_storage->moveToDiskLedger(each_block.first.getBlockIdB64());
 
-        CLOG(INFO, "BPRO") << "BLOCK SAVED (height=" << each_block.getHeight()
-                           << ",#tx=" << each_block.getNumTransactions()
-                           << ",#ssig=" << each_block.getNumSSigs() << ")";
+        CLOG(INFO, "BPRO") << "BLOCK SAVED (height=" << each_block.first.getHeight()
+                           << ",#tx=" << each_block.first.getNumTransactions()
+                           << ",#ssig=" << each_block.first.getNumSSigs() << ")";
       }
     }
 
@@ -69,7 +72,7 @@ void BlockProcessor::periodicTask() {
       OutputMsgEntry msg_req_block;
 
       msg_req_block.type = MessageType::MSG_REQ_BLOCK;
-      msg_req_block.body["mID"] = TypeConverter::encodeBase64(m_my_id); // my_id
+      msg_req_block.body["mID"] = m_my_id_b64; // my_id
       msg_req_block.body["time"] = Time::now();
       msg_req_block.body["mCert"] = "";
       msg_req_block.body["hgt"] = std::to_string(unresolved_block.height);
@@ -117,17 +120,48 @@ void BlockProcessor::handleMessage(InputMsgEntry &entry) {
   case MessageType::MSG_REQ_CHECK:
     handleMsgReqCheck(entry);
     break;
+  case MessageType::MSG_REQ_STATUS:
+    handleMsgReqStatus(entry);
+    break;
   default:
     break;
   }
 }
 
+void BlockProcessor::handleMsgReqStatus(InputMsgEntry &entry){
+
+  id_type sender_id = Safe::getBytesFromB64<id_type>(entry.body,"mID");
+
+  if(m_unresolved_block_pool.empty() && m_storage->empty()) {
+    sendErrorMessage(ErrorMsgType::BSYNC_NO_BLOCK,sender_id);
+    return;
+  }
+
+  auto possible_link = getMostPossibleLink();
+
+  OutputMsgEntry msg_res_status;
+  msg_res_status.type = MessageType::MSG_RES_STATUS;
+  msg_res_status.body["mID"] = m_my_id_b64;
+  msg_res_status.body["time"] = Time::now();
+  msg_res_status.body["mCert"] = "";
+  msg_res_status.body["hgt"] = to_string(possible_link.height);
+  msg_res_status.body["hash"] = TypeConverter::encodeBase64(possible_link.hash);
+  msg_res_status.body["mSig"] = "";
+  msg_res_status.receivers = {sender_id};
+
+  CLOG(INFO, "BPRO") << "Send MSG_RES_STATUS (height=" << possible_link.height << ")";
+
+  m_msg_proxy.deliverOutputMessage(msg_res_status);
+
+}
+
 void BlockProcessor::handleMsgReqBlock(InputMsgEntry &entry) {
 
   block_height_type req_block_height = Safe::getInt(entry.body, "hgt");
-  std::string req_prev_hash = Safe::getString(entry.body, "prevHash");
-  std::string req_hash = Safe::getString(entry.body, "hash");
+  hash_t req_prev_hash = Safe::getBytesFromB64<hash_t>(entry.body, "prevHash");
+  hash_t req_hash = Safe::getBytesFromB64<hash_t>(entry.body, "hash");
 
+/*
   if (Safe::getString(entry.body, "mCert").empty() ||
       Safe::getString(entry.body, "mSig").empty()) {
 
@@ -150,10 +184,12 @@ void BlockProcessor::handleMsgReqBlock(InputMsgEntry &entry) {
     }
   }
 
-  id_type recv_id = Safe::getBytesFromB64<id_type>(entry.body, "mID");
+*/
+
+  id_type sender_id = Safe::getBytesFromB64<id_type>(entry.body, "mID");
 
   if(m_unresolved_block_pool.empty() && m_storage->empty()) {
-    sendErrorMessage(ErrorMsgType::BSYNC_NO_BLOCK,recv_id);
+    sendErrorMessage(ErrorMsgType::BSYNC_NO_BLOCK,sender_id);
     return;
   }
 
@@ -165,24 +201,26 @@ void BlockProcessor::handleMsgReqBlock(InputMsgEntry &entry) {
 
   if(!found_block) { // no block in unresolved block pool, then try storage
     storage_block_type saved_block = m_storage->readBlock(req_block_height);
-    if ((req_prev_hash.empty() || saved_block.prev_hash_b64 == req_prev_hash) &&
-        (req_hash.empty() || saved_block.hash_b64 == req_hash)) {
+    if(saved_block.height > 0 &&
+        (req_prev_hash.empty() || saved_block.prev_hash == req_prev_hash) &&
+        (req_hash.empty() || saved_block.hash == req_hash)) {
       found_block = true;
       ret_block.initialize(saved_block);
     }
-  }
 
-  if (!found_block) {
-    sendErrorMessage(ErrorMsgType::NO_SUCH_BLOCK,recv_id);
-    return;
+    if(!found_block) {
+      CLOG(ERROR, "BPRO") << "No such block (height=" << req_block_height << ",hash=" << TypeConverter::encodeBase64(saved_block.hash) << ",prevhash=" <<  TypeConverter::encodeBase64(saved_block.prev_hash) <<  ")";
+      sendErrorMessage(ErrorMsgType::NO_SUCH_BLOCK,sender_id);
+      return;
+    }
   }
 
   OutputMsgEntry msg_block;
   msg_block.type = MessageType::MSG_BLOCK;
-  msg_block.body["mID"] = TypeConverter::encodeBase64(m_my_id);
+  msg_block.body["mID"] = m_my_id_b64;
   msg_block.body["blockraw"] = TypeConverter::encodeBase64(ret_block.getBlockRaw());
   msg_block.body["tx"] = ret_block.getBlockBodyJson()["tx"];
-  msg_block.receivers = {recv_id};
+  msg_block.receivers = {sender_id};
 
   CLOG(INFO, "BPRO") << "Send MSG_BLOCK (height=" << ret_block.getHeight() << ",#tx=" << ret_block.getNumTransactions() << ")";
 
@@ -202,24 +240,24 @@ block_height_type BlockProcessor::handleMsgBlock(InputMsgEntry &entry) {
     return 0;
   }
 
-  auto pushed_block_height = m_unresolved_block_pool.push(recv_block);
+  auto block_push_result = m_unresolved_block_pool.push(recv_block);
 
-  if (pushed_block_height == 0) {
+  if (block_push_result.height == 0) {
     CLOG(ERROR, "BPRO") << "Block dropped (unlinkable)";
     return 0;
   }
 
-  Application::app().getCustomLedgerManager().procLedgerBlock(entry.body["tx"], recv_block.getBlockIdB64());
+  // if not linked initially, we cannot interpret this block because of previous missing blocks!
+  if(block_push_result.linked)
+    Application::app().getCustomLedgerManager().procLedgerBlock(entry.body["tx"], recv_block.getBlockIdB64());
 
-  Application::app().getTransactionPool().removeDuplicatedTransactions(
-      recv_block.getTxIds());
 
-  return pushed_block_height;
+  Application::app().getTransactionPool().removeDuplicatedTransactions(recv_block.getTxIds());
+
+  return block_push_result.height;
 }
 
 void BlockProcessor::handleMsgReqCheck(InputMsgEntry &entry) {
-
-  auto setting = Setting::getInstance();
 
   proof_type proof = m_storage->getProof(Safe::getString(entry.body, "txid"));
 
@@ -231,7 +269,7 @@ void BlockProcessor::handleMsgReqCheck(InputMsgEntry &entry) {
 
   OutputMsgEntry msg_res_check;
   msg_res_check.type = MessageType::MSG_RES_CHECK;
-  msg_res_check.body["mID"] = TypeConverter::encodeBase64(setting->getMyId());
+  msg_res_check.body["mID"] = m_my_id_b64;
   msg_res_check.body["time"] = to_string(Time::now_int());
   msg_res_check.body["blockID"] = proof.block_id_b64;
   msg_res_check.body["proof"] = proof_json;
@@ -245,7 +283,7 @@ void BlockProcessor::sendErrorMessage(ErrorMsgType t_error_type, id_type &recv_i
 
   OutputMsgEntry output_message;
   output_message.type = MessageType::MSG_ERROR;
-  output_message.body["sender"] = TypeConverter::encodeBase64(m_my_id); // my_id
+  output_message.body["sender"] = m_my_id_b64; // my_id
   output_message.body["time"] = Time::now();
   output_message.body["type"] = std::to_string(static_cast<int>(t_error_type));
   output_message.body["info"] = "no block!";

--- a/src/modules/block_processor/block_processor.cpp
+++ b/src/modules/block_processor/block_processor.cpp
@@ -66,7 +66,6 @@ void BlockProcessor::periodicTask() {
       }
     }
 
-
     nth_link_type unresolved_block = m_unresolved_block_pool.getUnresolvedLowestLink();
     if (unresolved_block.height > 0) {
       OutputMsgEntry msg_req_block;
@@ -80,7 +79,7 @@ void BlockProcessor::periodicTask() {
       msg_req_block.body["mSig"] = "";
       msg_req_block.receivers = {};
 
-      CLOG(INFO, "BPRO") << "send MSG_REQ_BLOCK (" << unresolved_block.height << ")";
+      CLOG(INFO, "BPRO") << "send MSG_REQ_BLOCK (height=" << unresolved_block.height << ",prevHash=" << msg_req_block.body["prevHash"] << ")";
 
       m_msg_proxy.deliverOutputMessage(msg_req_block);
     }
@@ -243,14 +242,13 @@ block_height_type BlockProcessor::handleMsgBlock(InputMsgEntry &entry) {
   auto block_push_result = m_unresolved_block_pool.push(recv_block);
 
   if (block_push_result.height == 0) {
-    CLOG(ERROR, "BPRO") << "Block dropped (unlinkable)";
+    CLOG(ERROR, "BPRO") << "Block dropped (unlinkable or duplicated)";
     return 0;
   }
 
   // if not linked initially, we cannot interpret this block because of previous missing blocks!
   if(block_push_result.linked)
     Application::app().getCustomLedgerManager().procLedgerBlock(entry.body["tx"], recv_block.getBlockIdB64());
-
 
   Application::app().getTransactionPool().removeDuplicatedTransactions(recv_block.getTxIds());
 

--- a/src/modules/block_processor/block_processor.hpp
+++ b/src/modules/block_processor/block_processor.hpp
@@ -35,7 +35,7 @@ private:
   MessageProxy m_msg_proxy;
   Storage *m_storage;
   LayeredStorage *m_layered_storage;
-  merger_id_type m_my_id;
+  std::string m_my_id_b64;
   UnresolvedBlockPool m_unresolved_block_pool;
   std::unique_ptr<boost::asio::deadline_timer> m_timer;
   std::unique_ptr<boost::asio::io_service::strand> m_task_strand;
@@ -57,6 +57,7 @@ private:
   void periodicTask();
   void handleMsgReqBlock(InputMsgEntry &entry);
   void handleMsgReqCheck(InputMsgEntry &entry);
+  void handleMsgReqStatus(InputMsgEntry &entry);
   void sendErrorMessage(ErrorMsgType t_error_typem, id_type &recv_id);
 };
 } // namespace gruut

--- a/src/modules/bootstraper/block_synchronizer.cpp
+++ b/src/modules/bootstraper/block_synchronizer.cpp
@@ -254,7 +254,7 @@ void BlockSynchronizer::sendRequestBlock(size_t height, const std::string &block
   msg_req_block.body["mSig"] = "";
   msg_req_block.receivers = {t_merger};
 
-  CLOG(INFO, "BSYN") << "send MSG_REQ_BLOCK (" << height << ")";
+  CLOG(INFO, "BSYN") << "send MSG_REQ_BLOCK (height=" << height << ",hash=" << block_hash_b64 << ")";
 
   m_msg_proxy.deliverOutputMessage(msg_req_block);
 }

--- a/src/modules/communication/merger_client.cpp
+++ b/src/modules/communication/merger_client.cpp
@@ -225,25 +225,40 @@ void MergerClient::sendToSigner(MessageType msg_type,
 }
 
 bool MergerClient::checkMergerMsgType(MessageType msg_type) {
+  // clang-format off
   return (
-      msg_type == MessageType::MSG_UP || msg_type == MessageType::MSG_PING ||
+      msg_type == MessageType::MSG_UP ||
+      msg_type == MessageType::MSG_PING ||
       msg_type == MessageType::MSG_REQ_BLOCK ||
-      msg_type == MessageType::MSG_BLOCK || msg_type == MessageType::MSG_ERROR);
+      msg_type == MessageType::MSG_REQ_STATUS ||
+      msg_type == MessageType::MSG_RES_STATUS ||
+      msg_type == MessageType::MSG_BLOCK ||
+      msg_type == MessageType::MSG_ERROR
+      );
+  // clang-format on
 }
 
 bool MergerClient::checkSignerMsgType(MessageType msg_type) {
-  return (msg_type == MessageType::MSG_CHALLENGE ||
-          msg_type == MessageType::MSG_RESPONSE_2 ||
-          msg_type == MessageType::MSG_ACCEPT ||
-          msg_type == MessageType::MSG_REQ_SSIG ||
-          msg_type == MessageType::MSG_ERROR);
+  // clang-format off
+  return (
+      msg_type == MessageType::MSG_CHALLENGE ||
+      msg_type == MessageType::MSG_RESPONSE_2 ||
+      msg_type == MessageType::MSG_ACCEPT ||
+      msg_type == MessageType::MSG_REQ_SSIG ||
+      msg_type == MessageType::MSG_ERROR
+      );
+  // clang-format on
 }
 
 bool MergerClient::checkSEMsgType(MessageType msg_type) {
-  return (msg_type == MessageType::MSG_UP ||
-          msg_type == MessageType::MSG_PING ||
-          msg_type == MessageType::MSG_HEADER ||
-          msg_type == MessageType::MSG_RES_CHECK ||
-          msg_type == MessageType::MSG_ERROR);
+  // clang-format off
+  return (
+      msg_type == MessageType::MSG_UP ||
+      msg_type == MessageType::MSG_PING ||
+      msg_type == MessageType::MSG_HEADER ||
+      msg_type == MessageType::MSG_RES_CHECK ||
+      msg_type == MessageType::MSG_ERROR
+      );
+  // clang-format on
 }
 }; // namespace gruut

--- a/src/services/message_proxy.cpp
+++ b/src/services/message_proxy.cpp
@@ -41,7 +41,8 @@ void MessageProxy::deliverInputMessage(InputMsgEntry &input_message) {
     } break;
     case MessageType::MSG_REQ_CHECK:
     case MessageType::MSG_BLOCK:
-    case MessageType::MSG_REQ_BLOCK: {
+    case MessageType::MSG_REQ_BLOCK:
+    case MessageType::MSG_REQ_STATUS:{
       Application::app().getBlockProcessor().handleMessage(input_message);
     } break;
     default:

--- a/src/services/storage.cpp
+++ b/src/services/storage.cpp
@@ -346,7 +346,7 @@ nth_link_type Storage::getNthBlockLinkInfo(block_height_type t_height) {
     ret_link_info.id = TypeConverter::decodeBase64(t_block_id_b64);
     ret_link_info.hash = TypeConverter::stringToBytes(getValueByKey(DBType::BLOCK_RAW, t_block_id_b64 + "_hash"));
     ret_link_info.prev_id = TypeConverter::decodeBase64(getValueByKey(DBType::BLOCK_HEADER, t_block_id_b64 + "_prevbID"));
-    ret_link_info.prev_hash = TypeConverter::stringToBytes(getValueByKey(DBType::BLOCK_HEADER, t_block_id_b64 + "_prevH"));
+    ret_link_info.prev_hash = TypeConverter::decodeBase64(getValueByKey(DBType::BLOCK_HEADER, t_block_id_b64 + "_prevH"));
     ret_link_info.height = Safe::getSize(getValueByKey(DBType::BLOCK_HEADER, t_block_id_b64 + "_hgt"));
     ret_link_info.time = Safe::getTime(getValueByKey(DBType::BLOCK_HEADER, t_block_id_b64 + "_time"));
   } else {

--- a/src/services/storage.cpp
+++ b/src/services/storage.cpp
@@ -333,7 +333,7 @@ nth_link_type Storage::getLatestHashAndHeight() {
   return ret_link_info;
 }
 
-nth_link_type Storage::getNthBlockLinkInfo(size_t t_height) {
+nth_link_type Storage::getNthBlockLinkInfo(block_height_type t_height) {
   nth_link_type ret_link_info;
   ret_link_info.height = t_height;
 
@@ -359,13 +359,10 @@ nth_link_type Storage::getNthBlockLinkInfo(size_t t_height) {
   return ret_link_info;
 }
 
-std::vector<std::string> Storage::getNthTxIdList(size_t t_height) {
+std::vector<std::string> Storage::getNthTxIdList(block_height_type t_height) {
   std::vector<std::string> tx_ids_list;
 
-  std::string t_block_id_b64 =
-      (t_height == 0)
-          ? getValueByKey(DBType::BLOCK_LATEST, "bID")
-          : getValueByKey(DBType::BLOCK_HEIGHT, to_string(t_height));
+  std::string t_block_id_b64 = getNthBlockIdB64(t_height);
 
   if (!t_block_id_b64.empty()) {
     auto tx_ids_json_str =
@@ -393,17 +390,24 @@ void Storage::destroyDB() {
   boost::filesystem::remove_all(m_db_path + "/" + config::DB_SUB_DIR_LEDGER);
 }
 
-storage_block_type Storage::readBlock(size_t height) {
-  storage_block_type result;
+std::string Storage::getNthBlockIdB64(block_height_type height){
   std::string block_id_b64 =
       (height == 0) ? getValueByKey(DBType::BLOCK_LATEST, "bID")
                     : getValueByKey(DBType::BLOCK_HEIGHT, to_string(height));
+
+  return block_id_b64;
+}
+
+storage_block_type Storage::readBlock(block_height_type height) {
+  storage_block_type result;
+  std::string block_id_b64 = getNthBlockIdB64(height);
   if (block_id_b64.empty())
     result.height = 0;
   else {
     if (height == 0) {
-      result.height = static_cast<size_t>(
-          stoll(getValueByKey(DBType::BLOCK_LATEST, "hgt")));
+      std::string height_str = getValueByKey(DBType::BLOCK_LATEST, "hgt");
+      if(!height_str.empty())
+        result.height = static_cast<block_height_type>(stoll(height_str));
     }
 
     result.block_raw = TypeConverter::stringToBytes(
@@ -425,11 +429,12 @@ storage_block_type Storage::readBlock(size_t height) {
       }
     }
 
-    nth_link_type link_info = getNthBlockLinkInfo(result.height);
-    result.prev_id_b64 = TypeConverter::encodeBase64(link_info.prev_id);
-    result.prev_hash_b64 = TypeConverter::encodeBase64(link_info.prev_hash);
-    result.hash_b64 = TypeConverter::encodeBase64(link_info.hash);
-    result.id_b64 = TypeConverter::encodeBase64(link_info.id);
+    nth_link_type link_info = getNthBlockLinkInfo(height);
+    result.height = height;
+    result.prev_id = link_info.prev_id;
+    result.prev_hash = link_info.prev_hash;
+    result.hash = link_info.hash;
+    result.id = link_info.id;
     result.time = link_info.time;
     result.txs = txs_json;
   }

--- a/src/services/storage.hpp
+++ b/src/services/storage.hpp
@@ -56,10 +56,10 @@ public:
   bool saveBlock(const std::string &block_raw_b64, json &block_header,
                  json &block_transaction);
   nth_link_type getLatestHashAndHeight();
-  nth_link_type getNthBlockLinkInfo(size_t t_height = 0);
-  std::vector<std::string> getNthTxIdList(size_t t_height = 0);
+  nth_link_type getNthBlockLinkInfo(block_height_type t_height = 0);
+  std::vector<std::string> getNthTxIdList(block_height_type t_height = 0);
   void destroyDB();
-  storage_block_type readBlock(size_t height);
+  storage_block_type readBlock(block_height_type height);
   proof_type getProof(const std::string &txid_b64);
   bool isDuplicatedTx(const std::string &txid_b64);
   bool saveLedger(std::string &key, std::string &ledger);
@@ -69,6 +69,7 @@ public:
   bool empty();
 
 private:
+  std::string getNthBlockIdB64(block_height_type height = 0);
   bool errorOnCritical(const leveldb::Status &status);
   bool errorOn(const leveldb::Status &status);
   bool addBatch(DBType what, const std::string &key, const std::string &value);


### PR DESCRIPTION
### 수정
- MSG_REQ_STATUS / MSG_RES_STATUS 구현
- 순서에 맞지 않게 도착한 블록에서 파생된 ledger 정보 처리
- 블록 싱크가 block processor를 이용하도록 수정

### 테스트
- 블록 생성, 블록 싱크 동작
- 현재) A 머저가 7개 블록이 있을 때, B 머저는 5개까지만 저장하고, 2개는 unresolved block pool에 존재 (정상! A가 계속 블록을 생성하면 최종적으로 A와 B의 상태가 동일해짐.)

### TODO
- getUnresolvedLowestLink를 캐시를 이용하도록 수정할 것. (코스트가 크지만 지속적으로 호출됨, 블록이 push 되었을때만 결과가 변동이 있음)
- MSG_REQ_BLOCK을 일정 시간 내에서는 한 번만 보내도록