### PR TITLE
# EDIT - 올바른 경로로 MSG_PING 을 보내도록 수정

### DIFF
--- a/src/modules/communication/merger_client.hpp
+++ b/src/modules/communication/merger_client.hpp
@@ -14,6 +14,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <iostream>
 #include <memory>
+#include <string>
 
 using namespace grpc;
 using namespace grpc_merger;
@@ -44,8 +45,8 @@ private:
   std::unique_ptr<boost::asio::deadline_timer> m_http_check_timer;
   std::unique_ptr<boost::asio::io_service::strand> m_http_check_strand;
 
-  void sendToSE(std::vector<id_type> &receiver_list,
-                OutputMsgEntry &output_msg);
+  void sendToSE(std::vector<id_type> &receiver_list, OutputMsgEntry &output_msg,
+                std::string api_path);
 
   void sendToMerger(std::vector<id_type> &receiver_list,
                     std::string &packed_msg);
@@ -57,6 +58,7 @@ private:
   bool checkMergerMsgType(MessageType msg_tpye);
   bool checkSignerMsgType(MessageType msg_tpye);
   bool checkSEMsgType(MessageType msg_type);
+  std::string getApiPath(MessageType msg_type);
 };
 } // namespace gruut
 


### PR DESCRIPTION
## 수정사항
- 종전의 코드에서는 무조건 `/api/blocks/` 로 PING을 보내고 있었다.
- SE에서는 PING을 처리하는 경로가 `/api/ping`이다.
- "api/blocks" 하드코딩 되어있던 것을 제거하고, MessageType에 따라 다른 path를 리턴하도록 함(`getApiPath`)