### PR TITLE
# FIX - bug of clearing tx pool simultaniously (for develop)

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -117,7 +117,6 @@ void Application::setup() {
   registerModule(m_message_fetcher, 2);
   registerModule(m_bp_scheduler, 2);
 
-
   // setp 3 - link services
 
   m_bootstraper->setCommunication(m_communication);

--- a/src/chain/block.hpp
+++ b/src/chain/block.hpp
@@ -1,11 +1,11 @@
 #ifndef GRUUT_ENTERPRISE_MERGER_TEMPORARY_BLOCK_HPP
 #define GRUUT_ENTERPRISE_MERGER_TEMPORARY_BLOCK_HPP
 
+#include "mem_ledger.hpp"
 #include "merkle_tree.hpp"
 #include "signature.hpp"
 #include "transaction.hpp"
 #include "types.hpp"
-#include "mem_ledger.hpp"
 
 #include "../services/certificate_pool.hpp"
 #include "../services/storage.hpp"
@@ -52,7 +52,6 @@ private:
   std::vector<Signature> m_ssigs;
   std::map<std::string, std::string> m_user_certs;
   bytes m_block_raw;
-
 
 public:
   Block() { el::Loggers::getLogger("BLOC"); };
@@ -103,7 +102,8 @@ public:
     m_tx_root =
         Safe::getBytesFromB64<transaction_root_type>(block_header_json, "txrt");
     m_prev_block_hash = Safe::getBytesFromB64(block_header_json, "prevH");
-    m_prev_block_id = Safe::getBytesFromB64<block_id_type>(block_header_json, "prevbID");
+    m_prev_block_id =
+        Safe::getBytesFromB64<block_id_type>(block_header_json, "prevbID");
     m_block_id = Safe::getBytesFromB64<block_id_type>(block_header_json, "bID");
 
     if (!setSupportSignaturesFromJson(block_header_json["SSig"]))
@@ -166,7 +166,9 @@ public:
   }
 
   template <typename T = std::string>
-  void linkPreviousBlock(T&& last_id_b64 = config::GENESIS_BLOCK_PREV_ID_B64, T&& last_hash_b64 = config::GENESIS_BLOCK_PREV_HASH_B64) {
+  void
+  linkPreviousBlock(T &&last_id_b64 = config::GENESIS_BLOCK_PREV_ID_B64,
+                    T &&last_hash_b64 = config::GENESIS_BLOCK_PREV_HASH_B64) {
 
     m_version = config::DEFAULT_VERSION;
     m_prev_block_id = TypeConverter::decodeBase64(last_id_b64);
@@ -267,19 +269,23 @@ public:
 
   size_t getNumSSigs() { return m_ssigs.size(); }
 
-
-
   timestamp_t getTime() { return m_time; }
 
   hash_t getHash() { return m_block_hash; }
-  hash_t getPrevHash(){ return m_prev_block_hash; }
+  hash_t getPrevHash() { return m_prev_block_hash; }
   block_id_type getBlockId() { return m_block_id; }
-  block_id_type getPrevBlockId(){ return m_prev_block_id; }
+  block_id_type getPrevBlockId() { return m_prev_block_id; }
 
   std::string getHashB64() { return TypeConverter::encodeBase64(m_block_hash); }
-  std::string getPrevHashB64() { return TypeConverter::encodeBase64(m_prev_block_hash); }
-  std::string getBlockIdB64() { return TypeConverter::encodeBase64(m_block_id); }
-  std::string getPrevBlockIdB64() { return TypeConverter::encodeBase64(m_prev_block_id); }
+  std::string getPrevHashB64() {
+    return TypeConverter::encodeBase64(m_prev_block_hash);
+  }
+  std::string getBlockIdB64() {
+    return TypeConverter::encodeBase64(m_block_id);
+  }
+  std::string getPrevBlockIdB64() {
+    return TypeConverter::encodeBase64(m_prev_block_id);
+  }
 
   bool isValid() { return (isValidEarly() && isValidLate()); }
 
@@ -304,7 +310,8 @@ public:
       if (it_map != m_user_certs.end()) {
         user_pk_pem = it_map->second;
       } else {
-        user_pk_pem = cert_ledger.getCertificate(user_id_b64, m_time); // this is from storage
+        user_pk_pem = cert_ledger.getCertificate(
+            user_id_b64, m_time); // this is from storage
       }
 
       if (user_pk_pem.empty()) {

--- a/src/chain/mem_ledger.hpp
+++ b/src/chain/mem_ledger.hpp
@@ -9,14 +9,13 @@ struct LedgerRecord {
   std::string key;
   std::string value;
   std::string block_id_b64;
-  LedgerRecord(std::string key_, std::string value_, std::string block_id_b64_) :
-  key(std::move(key_)), value(std::move(value_)), block_id_b64(std::move(block_id_b64_)) {
-
-  }
+  LedgerRecord(std::string key_, std::string value_, std::string block_id_b64_)
+      : key(std::move(key_)), value(std::move(value_)),
+        block_id_b64(std::move(block_id_b64_)) {}
 };
 
 using mem_ledger_t = std::list<LedgerRecord>;
 
-}
+} // namespace gruut
 
-#endif //GRUUT_ENTERPRISE_MERGER_MEM_LEDGER_HPP
+#endif // GRUUT_ENTERPRISE_MERGER_MEM_LEDGER_HPP

--- a/src/ledger/digest_ledger.hpp
+++ b/src/ledger/digest_ledger.hpp
@@ -11,7 +11,10 @@ public:
 
   bool isValidTx(const Transaction &tx) override { return true; }
 
-  bool procBlock(const json &txs_json, const std::string &block_id_b64) override { return true; }
+  bool procBlock(const json &txs_json,
+                 const std::string &block_id_b64) override {
+    return true;
+  }
 };
 } // namespace gruut
 

--- a/src/ledger/ledger.hpp
+++ b/src/ledger/ledger.hpp
@@ -24,7 +24,8 @@ public:
   };
 
   virtual bool isValidTx(const Transaction &tx) = 0;
-  virtual bool procBlock(const json &txs_json, const std::string &block_id_b64) = 0;
+  virtual bool procBlock(const json &txs_json,
+                         const std::string &block_id_b64) = 0;
 
 protected:
   template <typename T = std::string> void setPrefix(T &&prefix) {
@@ -33,29 +34,28 @@ protected:
 
   template <typename T = std::string> bool saveLedger(T &&key, T &&value) {
     std::string wrap_key = m_prefix + key;
-    //CLOG(INFO, "LEDG") << "Save ledger (key=" << wrap_key << ")";
+    // CLOG(INFO, "LEDG") << "Save ledger (key=" << wrap_key << ")";
     m_layered_storage->saveLedger(wrap_key, value);
     return true;
   }
 
   bool saveLedger(mem_ledger_t &ledger) {
-    for(auto &record : ledger) {
+    for (auto &record : ledger) {
       record.key = m_prefix + record.key; // key to wrap key
     }
 
     bool ret_val = m_layered_storage->saveLedger(ledger);
-    if(ret_val)
+    if (ret_val)
       m_layered_storage->flushLedger();
     return ret_val;
   }
 
   template <typename T = std::string, typename V = std::vector<std::string>>
-  std::string readLedgerByKey(T &&key, V&& block_layer = {}) {
+  std::string readLedgerByKey(T &&key, V &&block_layer = {}) {
     std::string wrap_key = m_prefix + key;
-    //CLOG(INFO, "LEDG") << "Search ledger (key=" << wrap_key << ")";
+    // CLOG(INFO, "LEDG") << "Search ledger (key=" << wrap_key << ")";
     return m_layered_storage->readLedgerByKey(wrap_key, block_layer);
   }
-
 };
 } // namespace gruut
 

--- a/src/ledger/sms_ledger.hpp
+++ b/src/ledger/sms_ledger.hpp
@@ -11,7 +11,10 @@ public:
 
   bool isValidTx(const Transaction &tx) override { return true; }
 
-  bool procBlock(const json &txs_json, const std::string &block_id_b64) override { return true; }
+  bool procBlock(const json &txs_json,
+                 const std::string &block_id_b64) override {
+    return true;
+  }
 };
 } // namespace gruut
 

--- a/src/modules/block_processor/block_processor.cpp
+++ b/src/modules/block_processor/block_processor.cpp
@@ -13,8 +13,7 @@ BlockProcessor::BlockProcessor() {
 
   auto last_block_info = m_storage->getNthBlockLinkInfo();
 
-  m_unresolved_block_pool.setPool(last_block_info.id,
-                                  last_block_info.hash,
+  m_unresolved_block_pool.setPool(last_block_info.id, last_block_info.hash,
                                   last_block_info.height, last_block_info.time);
 
   // TODO : resotre m_unresolved_block_pool from backup
@@ -31,16 +30,17 @@ void BlockProcessor::start() { periodicTask(); }
 void BlockProcessor::periodicTask() {
   auto &io_service = Application::app().getIoService();
   io_service.post(m_task_strand->wrap([this]() {
-    std::vector<std::pair<Block,bool>> resolved_blocks;
+    std::vector<std::pair<Block, bool>> resolved_blocks;
     std::vector<std::string> drop_blocks;
 
-    m_unresolved_block_pool.getResolvedBlocks(resolved_blocks,drop_blocks);
+    m_unresolved_block_pool.getResolvedBlocks(resolved_blocks, drop_blocks);
 
-    for(auto &block_id_b64 : drop_blocks)
+    for (auto &block_id_b64 : drop_blocks)
       m_layered_storage->dropLedger(block_id_b64);
 
     if (!resolved_blocks.empty()) {
-      CLOG(INFO, "BPRO") << "Resolved block(s) received (" << resolved_blocks.size() << ")";
+      CLOG(INFO, "BPRO") << "Resolved block(s) received ("
+                         << resolved_blocks.size() << ")";
 
       for (auto &each_block : resolved_blocks) {
 
@@ -54,19 +54,24 @@ void BlockProcessor::periodicTask() {
         bytes block_raw = each_block.first.getBlockRaw();
         json block_body = each_block.first.getBlockBodyJson();
 
-        if(!each_block.second) // this block was not interpreted into the ledger because of link failure
-          Application::app().getCustomLedgerManager().procLedgerBlock(block_body["tx"], each_block.first.getBlockIdB64());
+        if (!each_block.second) // this block was not interpreted into the
+                                // ledger because of link failure
+          Application::app().getCustomLedgerManager().procLedgerBlock(
+              block_body["tx"], each_block.first.getBlockIdB64());
 
         m_storage->saveBlock(block_raw, block_header, block_body);
         m_layered_storage->moveToDiskLedger(each_block.first.getBlockIdB64());
 
-        CLOG(INFO, "BPRO") << "BLOCK SAVED (height=" << each_block.first.getHeight()
+        CLOG(INFO, "BPRO") << "BLOCK SAVED (height="
+                           << each_block.first.getHeight()
                            << ",#tx=" << each_block.first.getNumTransactions()
-                           << ",#ssig=" << each_block.first.getNumSSigs() << ")";
+                           << ",#ssig=" << each_block.first.getNumSSigs()
+                           << ")";
       }
     }
 
-    nth_link_type unresolved_block = m_unresolved_block_pool.getUnresolvedLowestLink();
+    nth_link_type unresolved_block =
+        m_unresolved_block_pool.getUnresolvedLowestLink();
     if (unresolved_block.height > 0) {
       OutputMsgEntry msg_req_block;
 
@@ -75,11 +80,15 @@ void BlockProcessor::periodicTask() {
       msg_req_block.body["time"] = Time::now();
       msg_req_block.body["mCert"] = "";
       msg_req_block.body["hgt"] = std::to_string(unresolved_block.height);
-      msg_req_block.body["prevHash"] = TypeConverter::encodeBase64(unresolved_block.prev_hash);
+      msg_req_block.body["prevHash"] =
+          TypeConverter::encodeBase64(unresolved_block.prev_hash);
       msg_req_block.body["mSig"] = "";
       msg_req_block.receivers = {};
 
-      CLOG(INFO, "BPRO") << "send MSG_REQ_BLOCK (height=" << unresolved_block.height << ",prevHash=" << msg_req_block.body["prevHash"] << ")";
+      CLOG(INFO, "BPRO") << "send MSG_REQ_BLOCK (height="
+                         << unresolved_block.height
+                         << ",prevHash=" << msg_req_block.body["prevHash"]
+                         << ")";
 
       m_msg_proxy.deliverOutputMessage(msg_req_block);
     }
@@ -100,7 +109,7 @@ nth_link_type BlockProcessor::getMostPossibleLink() {
   return m_unresolved_block_pool.getMostPossibleLink();
 }
 
-std::vector<std::string> BlockProcessor::getMostPossibleBlockLayer(){
+std::vector<std::string> BlockProcessor::getMostPossibleBlockLayer() {
   return m_unresolved_block_pool.getMostPossibleBlockLayer();
 }
 
@@ -127,12 +136,12 @@ void BlockProcessor::handleMessage(InputMsgEntry &entry) {
   }
 }
 
-void BlockProcessor::handleMsgReqStatus(InputMsgEntry &entry){
+void BlockProcessor::handleMsgReqStatus(InputMsgEntry &entry) {
 
-  id_type sender_id = Safe::getBytesFromB64<id_type>(entry.body,"mID");
+  id_type sender_id = Safe::getBytesFromB64<id_type>(entry.body, "mID");
 
-  if(m_unresolved_block_pool.empty() && m_storage->empty()) {
-    sendErrorMessage(ErrorMsgType::BSYNC_NO_BLOCK,sender_id);
+  if (m_unresolved_block_pool.empty() && m_storage->empty()) {
+    sendErrorMessage(ErrorMsgType::BSYNC_NO_BLOCK, sender_id);
     return;
   }
 
@@ -148,10 +157,10 @@ void BlockProcessor::handleMsgReqStatus(InputMsgEntry &entry){
   msg_res_status.body["mSig"] = "";
   msg_res_status.receivers = {sender_id};
 
-  CLOG(INFO, "BPRO") << "Send MSG_RES_STATUS (height=" << possible_link.height << ")";
+  CLOG(INFO, "BPRO") << "Send MSG_RES_STATUS (height=" << possible_link.height
+                     << ")";
 
   m_msg_proxy.deliverOutputMessage(msg_res_status);
-
 }
 
 void BlockProcessor::handleMsgReqBlock(InputMsgEntry &entry) {
@@ -160,56 +169,62 @@ void BlockProcessor::handleMsgReqBlock(InputMsgEntry &entry) {
   hash_t req_prev_hash = Safe::getBytesFromB64<hash_t>(entry.body, "prevHash");
   hash_t req_hash = Safe::getBytesFromB64<hash_t>(entry.body, "hash");
 
-/*
-  if (Safe::getString(entry.body, "mCert").empty() ||
-      Safe::getString(entry.body, "mSig").empty()) {
+  /*
+    if (Safe::getString(entry.body, "mCert").empty() ||
+        Safe::getString(entry.body, "mSig").empty()) {
 
-    // TODO : check whether the requester is trustworthy or not
+      // TODO : check whether the requester is trustworthy or not
 
-  } else {
-    BytesBuilder msg_builder;
-    msg_builder.appendB64(Safe::getString(entry.body, "mID"));
-    msg_builder.appendDec(Safe::getString(entry.body, "time"));
-    msg_builder.append(Safe::getString(entry.body, "mCert"));
-    msg_builder.append(req_block_height);
-    msg_builder.appendB64(req_prev_hash);
+    } else {
+      BytesBuilder msg_builder;
+      msg_builder.appendB64(Safe::getString(entry.body, "mID"));
+      msg_builder.appendDec(Safe::getString(entry.body, "time"));
+      msg_builder.append(Safe::getString(entry.body, "mCert"));
+      msg_builder.append(req_block_height);
+      msg_builder.appendB64(req_prev_hash);
 
-    if (!ECDSA::doVerify(Safe::getString(entry.body, "mCert"),
-                         msg_builder.getBytes(),
-                         Safe::getBytesFromB64(entry.body, "mSig"))) {
+      if (!ECDSA::doVerify(Safe::getString(entry.body, "mCert"),
+                           msg_builder.getBytes(),
+                           Safe::getBytesFromB64(entry.body, "mSig"))) {
 
-      CLOG(ERROR, "BPRO") << "Invalid mSig on MSG_REQ_BLOCK";
-      return;
+        CLOG(ERROR, "BPRO") << "Invalid mSig on MSG_REQ_BLOCK";
+        return;
+      }
     }
-  }
 
-*/
+  */
 
   id_type sender_id = Safe::getBytesFromB64<id_type>(entry.body, "mID");
 
-  if(m_unresolved_block_pool.empty() && m_storage->empty()) {
-    sendErrorMessage(ErrorMsgType::BSYNC_NO_BLOCK,sender_id);
+  if (m_unresolved_block_pool.empty() && m_storage->empty()) {
+    sendErrorMessage(ErrorMsgType::BSYNC_NO_BLOCK, sender_id);
     return;
   }
 
   bool found_block = false;
   Block ret_block;
-  if(m_unresolved_block_pool.getBlock(req_block_height,req_prev_hash,req_hash,ret_block)){
+  if (m_unresolved_block_pool.getBlock(req_block_height, req_prev_hash,
+                                       req_hash, ret_block)) {
     found_block = true;
   }
 
-  if(!found_block) { // no block in unresolved block pool, then try storage
+  if (!found_block) { // no block in unresolved block pool, then try storage
     storage_block_type saved_block = m_storage->readBlock(req_block_height);
-    if(saved_block.height > 0 &&
+    if (saved_block.height > 0 &&
         (req_prev_hash.empty() || saved_block.prev_hash == req_prev_hash) &&
         (req_hash.empty() || saved_block.hash == req_hash)) {
       found_block = true;
       ret_block.initialize(saved_block);
     }
 
-    if(!found_block) {
-      CLOG(ERROR, "BPRO") << "No such block (height=" << req_block_height << ",hash=" << TypeConverter::encodeBase64(saved_block.hash) << ",prevhash=" <<  TypeConverter::encodeBase64(saved_block.prev_hash) <<  ")";
-      sendErrorMessage(ErrorMsgType::NO_SUCH_BLOCK,sender_id);
+    if (!found_block) {
+      CLOG(ERROR, "BPRO") << "No such block (height=" << req_block_height
+                          << ",hash="
+                          << TypeConverter::encodeBase64(saved_block.hash)
+                          << ",prevhash="
+                          << TypeConverter::encodeBase64(saved_block.prev_hash)
+                          << ")";
+      sendErrorMessage(ErrorMsgType::NO_SUCH_BLOCK, sender_id);
       return;
     }
   }
@@ -217,11 +232,13 @@ void BlockProcessor::handleMsgReqBlock(InputMsgEntry &entry) {
   OutputMsgEntry msg_block;
   msg_block.type = MessageType::MSG_BLOCK;
   msg_block.body["mID"] = m_my_id_b64;
-  msg_block.body["blockraw"] = TypeConverter::encodeBase64(ret_block.getBlockRaw());
+  msg_block.body["blockraw"] =
+      TypeConverter::encodeBase64(ret_block.getBlockRaw());
   msg_block.body["tx"] = ret_block.getBlockBodyJson()["tx"];
   msg_block.receivers = {sender_id};
 
-  CLOG(INFO, "BPRO") << "Send MSG_BLOCK (height=" << ret_block.getHeight() << ",#tx=" << ret_block.getNumTransactions() << ")";
+  CLOG(INFO, "BPRO") << "Send MSG_BLOCK (height=" << ret_block.getHeight()
+                     << ",#tx=" << ret_block.getNumTransactions() << ")";
 
   m_msg_proxy.deliverOutputMessage(msg_block);
 }
@@ -246,11 +263,14 @@ block_height_type BlockProcessor::handleMsgBlock(InputMsgEntry &entry) {
     return 0;
   }
 
-  // if not linked initially, we cannot interpret this block because of previous missing blocks!
-  if(block_push_result.linked)
-    Application::app().getCustomLedgerManager().procLedgerBlock(entry.body["tx"], recv_block.getBlockIdB64());
+  // if not linked initially, we cannot interpret this block because of previous
+  // missing blocks!
+  if (block_push_result.linked)
+    Application::app().getCustomLedgerManager().procLedgerBlock(
+        entry.body["tx"], recv_block.getBlockIdB64());
 
-  Application::app().getTransactionPool().removeDuplicatedTransactions(recv_block.getTxIds());
+  Application::app().getTransactionPool().removeDuplicatedTransactions(
+      recv_block.getTxIds());
 
   return block_push_result.height;
 }
@@ -277,7 +297,8 @@ void BlockProcessor::handleMsgReqCheck(InputMsgEntry &entry) {
   m_msg_proxy.deliverOutputMessage(msg_res_check);
 }
 
-void BlockProcessor::sendErrorMessage(ErrorMsgType t_error_type, id_type &recv_id) {
+void BlockProcessor::sendErrorMessage(ErrorMsgType t_error_type,
+                                      id_type &recv_id) {
 
   OutputMsgEntry output_message;
   output_message.type = MessageType::MSG_ERROR;
@@ -287,7 +308,7 @@ void BlockProcessor::sendErrorMessage(ErrorMsgType t_error_type, id_type &recv_i
   output_message.body["info"] = "no block!";
   output_message.receivers = {recv_id};
 
-  CLOG(INFO, "BPRO") << "Send MSG_ERROR (" << (int) t_error_type << ")";
+  CLOG(INFO, "BPRO") << "Send MSG_ERROR (" << (int)t_error_type << ")";
 
   m_msg_proxy.deliverOutputMessage(output_message);
 }

--- a/src/modules/block_processor/block_processor.hpp
+++ b/src/modules/block_processor/block_processor.hpp
@@ -10,11 +10,11 @@
 #include "../../utils/sha256.hpp"
 
 #include "../../services/input_queue.hpp"
+#include "../../services/layered_storage.hpp"
 #include "../../services/message_proxy.hpp"
 #include "../../services/output_queue.hpp"
 #include "../../services/setting.hpp"
 #include "../../services/storage.hpp"
-#include "../../services/layered_storage.hpp"
 
 #include "../module.hpp"
 #include "unresolved_block_pool.hpp"

--- a/src/modules/bootstraper/block_synchronizer.cpp
+++ b/src/modules/bootstraper/block_synchronizer.cpp
@@ -26,7 +26,7 @@ void BlockSynchronizer::syncFinish(ExitCode exit_code) {
 
   m_is_sync_done = true;
 
-  std::call_once(m_sync_finish_call_flag, [this,&exit_code]() {
+  std::call_once(m_sync_finish_call_flag, [this, &exit_code]() {
     m_msg_fetching_loop_timer->cancel();
     m_sync_ctrl_loop_timer->cancel();
 
@@ -35,7 +35,6 @@ void BlockSynchronizer::syncFinish(ExitCode exit_code) {
 
     CLOG(INFO, "BSYN") << "BLOCK SYNCHRONIZATION ---- END";
   });
-
 }
 
 void BlockSynchronizer::blockSyncControl() {
@@ -46,34 +45,33 @@ void BlockSynchronizer::blockSyncControl() {
 
   auto &io_service = Application::app().getIoService();
   io_service.post([this]() {
-    if(!m_is_sync_begin) {
+    if (!m_is_sync_begin) {
       return;
     }
 
     bool is_done = true;
 
-    for(auto each_flag : m_sync_flags){
-      if(each_flag == false){
+    for (auto each_flag : m_sync_flags) {
+      if (each_flag == false) {
         is_done = false;
         break;
       }
     }
 
-    if(is_done)
+    if (is_done)
       syncFinish(ExitCode::NORMAL);
-
   });
 
   m_sync_ctrl_loop_timer->expires_from_now(
       boost::posix_time::milliseconds(config::SYNC_CONTROL_INTERVAL));
-  m_sync_ctrl_loop_timer->async_wait([this](const boost::system::error_code &error) {
-    if (!error) {
-      blockSyncControl();
-    }
-    else {
-      CLOG(INFO, "BSYN") << error.message();
-    }
-  });
+  m_sync_ctrl_loop_timer->async_wait(
+      [this](const boost::system::error_code &error) {
+        if (!error) {
+          blockSyncControl();
+        } else {
+          CLOG(INFO, "BSYN") << error.message();
+        }
+      });
 }
 
 void BlockSynchronizer::sendErrorToSigner(InputMsgEntry &input_msg_entry) {
@@ -111,24 +109,26 @@ void BlockSynchronizer::messageFetch() {
     if (input_msg_entry.type == MessageType::MSG_NULL)
       return;
 
-    CLOG(INFO, "BSYN") << "MSG IN: 0x" << std::hex << (int) input_msg_entry.type;
+    CLOG(INFO, "BSYN") << "MSG IN: 0x" << std::hex << (int)input_msg_entry.type;
 
     if (checkMsgFromSigner(input_msg_entry.type)) {
       sendErrorToSigner(input_msg_entry);
     }
 
     switch (input_msg_entry.type) {
-    case MessageType::MSG_ERROR : {
-      if (Safe::getString(input_msg_entry.body, "type")
-        == std::to_string(static_cast<int>(ErrorMsgType::BSYNC_NO_BLOCK))) { // Oh! No block!
+    case MessageType::MSG_ERROR: {
+      if (Safe::getString(input_msg_entry.body, "type") ==
+          std::to_string(static_cast<int>(
+              ErrorMsgType::BSYNC_NO_BLOCK))) { // Oh! No block!
         syncFinish(ExitCode::NORMAL);
       }
-    }
-      break;
+    } break;
 
-    case MessageType::MSG_BLOCK : {
-      auto pushed_block_height = Application::app().getBlockProcessor().handleMsgBlock(input_msg_entry);
-      if(pushed_block_height > 0) {
+    case MessageType::MSG_BLOCK: {
+      auto pushed_block_height =
+          Application::app().getBlockProcessor().handleMsgBlock(
+              input_msg_entry);
+      if (pushed_block_height > 0) {
 
         if (pushed_block_height > m_link_from.height) {
           size_t req_map_size = pushed_block_height - m_link_from.height;
@@ -138,48 +138,45 @@ void BlockSynchronizer::messageFetch() {
           m_sync_flags[req_map_size - 1] = true; // last or this
         }
       }
-    }
-      break;
+    } break;
 
-    case MessageType::MSG_RES_STATUS : {
+    case MessageType::MSG_RES_STATUS: {
       collectingStatus(input_msg_entry);
-    }
-      break;
+    } break;
 
-    case MessageType::MSG_REQ_STATUS : {
+    case MessageType::MSG_REQ_STATUS: {
       Application::app().getBlockProcessor().handleMessage(input_msg_entry);
-    }
-      break;
+    } break;
 
-    default:break;
+    default:
+      break;
     }
   });
 
   m_msg_fetching_loop_timer->expires_from_now(
       boost::posix_time::milliseconds(config::INQUEUE_MSG_FETCHER_INTERVAL));
-  m_msg_fetching_loop_timer->async_wait([this](const boost::system::error_code &error) {
-    if (!error) {
-      messageFetch();
-    }
-    else {
-      CLOG(INFO, "BSYN") << error.message();
-    }
-  });
+  m_msg_fetching_loop_timer->async_wait(
+      [this](const boost::system::error_code &error) {
+        if (!error) {
+          messageFetch();
+        } else {
+          CLOG(INFO, "BSYN") << error.message();
+        }
+      });
 }
 
-void BlockSynchronizer::collectingStatus(InputMsgEntry &entry){
-  if(m_is_sync_begin)
+void BlockSynchronizer::collectingStatus(InputMsgEntry &entry) {
+  if (m_is_sync_begin)
     return;
 
   std::lock_guard<std::mutex> guard(m_chain_mutex);
 
-  m_chain_status.insert(std::make_pair(
-    Safe::getString(entry.body,"mID"),
-    OtherStatusData(Safe::getString(entry.body,"hash"),Safe::getSize(entry.body,"hgt"))
-  ));
+  m_chain_status.insert(
+      std::make_pair(Safe::getString(entry.body, "mID"),
+                     OtherStatusData(Safe::getString(entry.body, "hash"),
+                                     Safe::getSize(entry.body, "hgt"))));
 
   m_chain_mutex.unlock();
-
 }
 
 void BlockSynchronizer::startBlockSync(std::function<void(ExitCode)> callback) {
@@ -194,43 +191,47 @@ void BlockSynchronizer::startBlockSync(std::function<void(ExitCode)> callback) {
   messageFetch();
   blockSyncControl();
 
-  m_sync_begin_timer->expires_from_now(boost::posix_time::seconds(config::STATUS_COLLECTING_TIMEOUT_SEC));
-  m_sync_begin_timer->async_wait([this](const boost::system::error_code &error) {
-    if (!error) {
-      sendRequestLastBlock();
-    }
-    else {
-      CLOG(INFO, "BSYN") << error.message();
-    }
-  });
+  m_sync_begin_timer->expires_from_now(
+      boost::posix_time::seconds(config::STATUS_COLLECTING_TIMEOUT_SEC));
+  m_sync_begin_timer->async_wait(
+      [this](const boost::system::error_code &error) {
+        if (!error) {
+          sendRequestLastBlock();
+        } else {
+          CLOG(INFO, "BSYN") << error.message();
+        }
+      });
 }
 
-void BlockSynchronizer::sendRequestLastBlock(){
+void BlockSynchronizer::sendRequestLastBlock() {
 
   block_height_type last_block_height = 0;
   std::string last_block_hash_b64;
   std::string t_merger_id_b64;
 
-  for(auto& status_dat : m_chain_status) {
-    if(status_dat.second.height > last_block_height) {
+  for (auto &status_dat : m_chain_status) {
+    if (status_dat.second.height > last_block_height) {
       last_block_height = status_dat.second.height;
       last_block_hash_b64 = status_dat.second.hash_b64;
       t_merger_id_b64 = status_dat.first;
     }
 
-    if(status_dat.second.height == last_block_height) {
-      if(last_block_hash_b64 != status_dat.second.hash_b64) {
-        CLOG(INFO, "ERROR") << "Chain fork was detected! [" << t_merger_id_b64 << "] and [" << status_dat.first << "] have different blocks.";
+    if (status_dat.second.height == last_block_height) {
+      if (last_block_hash_b64 != status_dat.second.hash_b64) {
+        CLOG(INFO, "ERROR")
+            << "Chain fork was detected! [" << t_merger_id_b64 << "] and ["
+            << status_dat.first << "] have different blocks.";
       }
     }
   }
 
-  if(last_block_height == 0) { // no response at all
+  if (last_block_height == 0) { // no response at all
     syncFinish(ExitCode::ERROR_SYNC_ALONE);
     return;
   }
 
-  sendRequestBlock(last_block_height, last_block_hash_b64, TypeConverter::decodeBase64(t_merger_id_b64));
+  sendRequestBlock(last_block_height, last_block_hash_b64,
+                   TypeConverter::decodeBase64(t_merger_id_b64));
 
   if (last_block_height > m_link_from.height) {
     size_t req_map_size = last_block_height - m_link_from.height;
@@ -241,7 +242,9 @@ void BlockSynchronizer::sendRequestLastBlock(){
   m_is_sync_begin = true;
 }
 
-void BlockSynchronizer::sendRequestBlock(size_t height, const std::string &block_hash_b64, const merger_id_type &t_merger){
+void BlockSynchronizer::sendRequestBlock(size_t height,
+                                         const std::string &block_hash_b64,
+                                         const merger_id_type &t_merger) {
 
   OutputMsgEntry msg_req_block;
   msg_req_block.type = MessageType::MSG_REQ_BLOCK;
@@ -254,15 +257,16 @@ void BlockSynchronizer::sendRequestBlock(size_t height, const std::string &block
   msg_req_block.body["mSig"] = "";
   msg_req_block.receivers = {t_merger};
 
-  CLOG(INFO, "BSYN") << "send MSG_REQ_BLOCK (height=" << height << ",hash=" << block_hash_b64 << ")";
+  CLOG(INFO, "BSYN") << "send MSG_REQ_BLOCK (height=" << height
+                     << ",hash=" << block_hash_b64 << ")";
 
   m_msg_proxy.deliverOutputMessage(msg_req_block);
 }
 
-void BlockSynchronizer::sendRequestStatus(){
+void BlockSynchronizer::sendRequestStatus() {
 
   OutputMsgEntry msg_req_status;
-  msg_req_status.type = MessageType::MSG_REQ_STATUS ;
+  msg_req_status.type = MessageType::MSG_REQ_STATUS;
   msg_req_status.body["mID"] = TypeConverter::encodeBase64(m_my_id); // my_id
   msg_req_status.body["time"] = Time::now();
   msg_req_status.body["mCert"] = "";

--- a/src/modules/bootstraper/block_synchronizer.hpp
+++ b/src/modules/bootstraper/block_synchronizer.hpp
@@ -32,7 +32,8 @@ namespace gruut {
 struct OtherStatusData {
   std::string hash_b64;
   block_height_type height;
-  OtherStatusData(std::string hash_b64_, block_height_type height_) : hash_b64(hash_b64_), height(height_) {}
+  OtherStatusData(std::string hash_b64_, block_height_type height_)
+      : hash_b64(hash_b64_), height(height_) {}
 };
 
 class BlockSynchronizer {
@@ -49,8 +50,8 @@ private:
   std::once_flag m_sync_finish_call_flag;
   ExitCode m_sync_finish_code;
 
-  std::atomic<bool> m_is_sync_begin {false};
-  std::atomic<bool> m_is_sync_done {false};
+  std::atomic<bool> m_is_sync_begin{false};
+  std::atomic<bool> m_is_sync_done{false};
 
   nth_link_type m_link_from;
   std::vector<bool> m_sync_flags;
@@ -67,7 +68,8 @@ public:
 private:
   void collectingStatus(InputMsgEntry &entry);
   void sendRequestLastBlock();
-  void sendRequestBlock(size_t height, const std::string &block_hash_b64, const merger_id_type &t_merger);
+  void sendRequestBlock(size_t height, const std::string &block_hash_b64,
+                        const merger_id_type &t_merger);
   void sendRequestStatus();
   void sendErrorToSigner(InputMsgEntry &input_msg_entry);
   void syncFinish(ExitCode exit_code);

--- a/src/modules/bp_scheduler/bp_scheduler.cpp
+++ b/src/modules/bp_scheduler/bp_scheduler.cpp
@@ -17,6 +17,7 @@ BpScheduler::BpScheduler() {
   auto &io_service = Application::app().getIoService();
   m_timer.reset(new boost::asio::deadline_timer(io_service));
   m_lock_timer.reset(new boost::asio::deadline_timer(io_service));
+  m_set_strand.reset(new boost::asio::strand(io_service));
 
   el::Loggers::getLogger("BPSC");
 }
@@ -193,11 +194,11 @@ void BpScheduler::lockStatusloop() {
 
 void BpScheduler::postLockJob() {
   auto &io_service = Application::app().getIoService();
-  io_service.post([this]() {
+  io_service.post(m_set_strand->wrap([this]() {
+    m_is_lock = true; // lock to update status
     Application::app().getTransactionCollector().setTxCollectStatus(
         m_current_status);
-    m_is_lock = true; // lock to update status
-  });
+  }));
 }
 
 void BpScheduler::sendPingloop() {
@@ -205,19 +206,16 @@ void BpScheduler::sendPingloop() {
   time_t next_slot_begin = (current_slot + 1) * config::BP_INTERVAL;
 
   boost::posix_time::ptime ping_time = boost::posix_time::from_time_t(
-      PRNG::getRange(0, config::BP_PING_PERIOD) + next_slot_begin);
+      PRNG::getRange(1, config::BP_PING_PERIOD + 1) + next_slot_begin);
   ping_time += boost::posix_time::milliseconds(PRNG::getRange(0, 999));
 
   m_timer->expires_at(ping_time);
-  m_timer->async_wait([this](const boost::system::error_code &ec) {
-    if (ec == boost::asio::error::operation_aborted) {
-      CLOG(INFO, "BPSC") << "PingTimer ABORTED";
-    } else if (ec.value() == 0) {
+  m_timer->async_wait([this](const boost::system::error_code &error) {
+    if (!error) {
       postSendPingJob();
       sendPingloop();
     } else {
-      CLOG(ERROR, "BPSC") << ec.message();
-      // throw;
+      CLOG(ERROR, "BPSC") << error.message();
     }
   });
 }

--- a/src/modules/bp_scheduler/bp_scheduler.hpp
+++ b/src/modules/bp_scheduler/bp_scheduler.hpp
@@ -56,13 +56,14 @@ private:
 
   size_t m_up_slot{0};
   BpStatus m_current_status{BpStatus::IN_BOOT_WAIT};
-  bool m_is_lock{true};
+  std::atomic<bool> m_is_lock{true};
   std::vector<BpRecvStatusInfo> m_recv_status;
 
   std::mutex m_recv_status_mutex;
 
   std::unique_ptr<boost::asio::deadline_timer> m_timer;
   std::unique_ptr<boost::asio::deadline_timer> m_lock_timer;
+  std::unique_ptr<boost::asio::strand> m_set_strand;
 
   MessageProxy m_msg_proxy;
   Setting *m_setting;

--- a/src/modules/communication/merger_client.cpp
+++ b/src/modules/communication/merger_client.cpp
@@ -140,8 +140,8 @@ void MergerClient::sendToSE(std::vector<id_type> &receiver_list,
       for (auto &service_endpoint : service_endpoints_list) {
         bool status = m_connection_list->getSeStatus(service_endpoint.id);
         if (status && service_endpoint.id == receiver_id) {
-          std::string address = service_endpoint.address + ":" +
-                                service_endpoint.port + api_path;
+          std::string address =
+              service_endpoint.address + ":" + service_endpoint.port + api_path;
           HttpClient http_client(address);
           http_client.post(send_msg);
           break;
@@ -266,14 +266,13 @@ bool MergerClient::checkSEMsgType(MessageType msg_type) {
 std::string MergerClient::getApiPath(MessageType msg_type) {
   std::string path;
 
-  switch (msg_type)
-  {
-    case MessageType::MSG_PING:
-      path = "/api/ping";
-      break;
-    case MessageType::MSG_HEADER:
-      path = "/api/blocks";
-      break;
+  switch (msg_type) {
+  case MessageType::MSG_PING:
+    path = "/api/ping";
+    break;
+  case MessageType::MSG_HEADER:
+    path = "/api/blocks";
+    break;
   }
 
   return path;

--- a/src/modules/communication/msg_schema.hpp
+++ b/src/modules/communication/msg_schema.hpp
@@ -414,8 +414,7 @@ const std::map<MessageType, json> MSG_SCHEMA_MAP = {
     {MessageType::MSG_TX, SCHEMA_TX},
     {MessageType::MSG_REQ_CHECK, SCHEMA_REQ_CHECK},
     {MessageType::MSG_REQ_STATUS, SCHEMA_REQ_STATUS},
-    {MessageType::MSG_RES_STATUS, SCHEMA_RES_STATUS}
-};
+    {MessageType::MSG_RES_STATUS, SCHEMA_RES_STATUS}};
 
 class MessageSchema {
 public:

--- a/src/services/custom_ledger_manager.hpp
+++ b/src/services/custom_ledger_manager.hpp
@@ -6,7 +6,6 @@
 
 #include "../ledger/digest_ledger.hpp"
 #include "../ledger/sms_ledger.hpp"
-#include "../ledger/digest_ledger.hpp"
 
 #include "../chain/mem_ledger.hpp"
 #include "../chain/types.hpp"

--- a/src/services/layered_storage.hpp
+++ b/src/services/layered_storage.hpp
@@ -1,81 +1,78 @@
 #ifndef GRUUT_ENTERPRISE_MERGER_LAYERED_STORAGE_HPP
 #define GRUUT_ENTERPRISE_MERGER_LAYERED_STORAGE_HPP
 
-#include "../utils/template_singleton.hpp"
 #include "../chain/mem_ledger.hpp"
+#include "../utils/template_singleton.hpp"
 
 #include "storage.hpp"
 
 namespace gruut {
 
-class LayeredStorage : public TemplateSingleton<LayeredStorage>{
+class LayeredStorage : public TemplateSingleton<LayeredStorage> {
 private:
-  Storage* m_storage;
+  Storage *m_storage;
   mem_ledger_t m_mem_ledger;
   std::recursive_mutex m_push_mutex;
+
 public:
-  LayeredStorage(){
-    m_storage = Storage::getInstance();
-  }
+  LayeredStorage() { m_storage = Storage::getInstance(); }
 
   bool saveLedger(mem_ledger_t &mem_ledger) {
     std::lock_guard<std::recursive_mutex> lock_guard(m_push_mutex);
-    m_mem_ledger.insert(m_mem_ledger.end(), mem_ledger.begin(), mem_ledger.end());
+    m_mem_ledger.insert(m_mem_ledger.end(), mem_ledger.begin(),
+                        mem_ledger.end());
     return true;
   }
 
   template <typename T = std::string>
-  bool saveLedger(T&& key, T&& value, T&& block_id_b64 = ""){
+  bool saveLedger(T &&key, T &&value, T &&block_id_b64 = "") {
 
-    if(block_id_b64.empty())
-      return m_storage->saveLedger(key,value);
+    if (block_id_b64.empty())
+      return m_storage->saveLedger(key, value);
 
     std::lock_guard<std::recursive_mutex> lock_guard(m_push_mutex);
-    m_mem_ledger.emplace_back(key,value,block_id_b64);
+    m_mem_ledger.emplace_back(key, value, block_id_b64);
 
     return true;
   }
 
-  template <typename T = std::string, typename V = std::vector<std::string> >
-  std::string readLedgerByKey(T &&key, V&& block_layer = {}){
+  template <typename T = std::string, typename V = std::vector<std::string>>
+  std::string readLedgerByKey(T &&key, V &&block_layer = {}) {
     std::lock_guard<std::recursive_mutex> lock_guard(m_push_mutex);
 
     std::string ret_val;
 
-    for(auto &each_block_id_b64 : block_layer) { // reverse_order
+    for (auto &each_block_id_b64 : block_layer) { // reverse_order
       bool is_found = false;
-      for(auto &record : m_mem_ledger){
+      for (auto &record : m_mem_ledger) {
         if (record.key == key && record.block_id_b64 == each_block_id_b64) {
           ret_val = record.value;
           is_found = true;
           break;
         }
       }
-      if(is_found)
+      if (is_found)
         break;
     }
 
-    if(ret_val.empty())
+    if (ret_val.empty())
       ret_val = m_storage->readLedgerByKey(key);
 
     return ret_val;
   }
 
-  void flushLedger(){
-    m_storage->flushLedger();
-  }
+  void flushLedger() { m_storage->flushLedger(); }
 
-  void clearLedger(){
+  void clearLedger() {
     std::lock_guard<std::recursive_mutex> lock_guard(m_push_mutex);
     m_mem_ledger.clear();
   }
 
-  template <typename T = std::string>
-  void moveToDiskLedger(T&& block_id_b64){
+  template <typename T = std::string> void moveToDiskLedger(T &&block_id_b64) {
     std::lock_guard<std::recursive_mutex> lock_guard(m_push_mutex);
-    for(auto &each_record : m_mem_ledger){
-      if(each_record.block_id_b64 == block_id_b64) {
-        m_storage->saveLedger(each_record.key,each_record.value);
+    for (auto &each_record : m_mem_ledger) {
+      if (each_record.block_id_b64 == block_id_b64) {
+        m_storage->saveLedger(each_record.key, each_record.value);
       }
     }
 
@@ -83,16 +80,14 @@ public:
     dropLedger(block_id_b64);
   }
 
-  template <typename T = std::string>
-  void dropLedger(T&& block_id_b64){
+  template <typename T = std::string> void dropLedger(T &&block_id_b64) {
     std::lock_guard<std::recursive_mutex> lock_guard(m_push_mutex);
-    m_mem_ledger.remove_if([this,&block_id_b64](LedgerRecord &t){
+    m_mem_ledger.remove_if([this, &block_id_b64](LedgerRecord &t) {
       return (t.block_id_b64 == block_id_b64);
     });
   }
-
 };
 
-}
+} // namespace gruut
 
-#endif //GRUUT_ENTERPRISE_MERGER_LAYERED_STORAGE_HPP
+#endif // GRUUT_ENTERPRISE_MERGER_LAYERED_STORAGE_HPP

--- a/src/services/message_proxy.cpp
+++ b/src/services/message_proxy.cpp
@@ -42,7 +42,7 @@ void MessageProxy::deliverInputMessage(InputMsgEntry &input_message) {
     case MessageType::MSG_REQ_CHECK:
     case MessageType::MSG_BLOCK:
     case MessageType::MSG_REQ_BLOCK:
-    case MessageType::MSG_REQ_STATUS:{
+    case MessageType::MSG_REQ_STATUS: {
       Application::app().getBlockProcessor().handleMessage(input_message);
     } break;
     default:

--- a/src/services/signature_requester.cpp
+++ b/src/services/signature_requester.cpp
@@ -32,7 +32,9 @@ void SignatureRequester::waitCollectDone() {
 }
 
 bool SignatureRequester::isNewSigner(Signer &signer) {
-  auto cert = m_cert_ledger.getCertificate(signer.user_id, 0, Application::app().getBlockProcessor().getMostPossibleBlockLayer());
+  auto cert = m_cert_ledger.getCertificate(
+      signer.user_id, 0,
+      Application::app().getBlockProcessor().getMostPossibleBlockLayer());
   return (cert.empty() || cert != signer.pk_cert);
 }
 
@@ -83,9 +85,12 @@ void SignatureRequester::requestSignatures() {
   m_basic_block_info.time = Time::now_int();
   m_basic_block_info.merger_id = setting->getMyId();
   m_basic_block_info.chain_id = setting->getLocalChainId();
-  m_basic_block_info.prev_id_b64 = TypeConverter::encodeBase64(most_possible_link.id);
-  m_basic_block_info.prev_hash_b64 = TypeConverter::encodeBase64(most_possible_link.hash);
-  m_basic_block_info.height = (most_possible_link.height == 0) ? 1 : most_possible_link.height + 1;
+  m_basic_block_info.prev_id_b64 =
+      TypeConverter::encodeBase64(most_possible_link.id);
+  m_basic_block_info.prev_hash_b64 =
+      TypeConverter::encodeBase64(most_possible_link.hash);
+  m_basic_block_info.height =
+      (most_possible_link.height == 0) ? 1 : most_possible_link.height + 1;
   m_basic_block_info.transaction_root = m_merkle_tree.getMerkleTree().back();
   m_basic_block_info.transactions = std::move(transactions);
 

--- a/src/services/signer_pool_manager.hpp
+++ b/src/services/signer_pool_manager.hpp
@@ -48,7 +48,8 @@ public:
 private:
   bool verifySignature(signer_id_type &signer_id, json &message_body_json);
   string signMessage(string, string, string, string, uint64_t);
-  void sendErrorMessage(signer_id_type &recv_id, ErrorMsgType error_type, const std::string &info = "");
+  void sendErrorMessage(signer_id_type &recv_id, ErrorMsgType error_type,
+                        const std::string &info = "");
   bool isJoinable();
 
   bool isTimeout(std::string &signer_id_b64);

--- a/src/services/storage.cpp
+++ b/src/services/storage.cpp
@@ -323,11 +323,14 @@ nth_link_type Storage::getLatestHashAndHeight() {
 
   auto block_id = getValueByKey(DBType::BLOCK_LATEST, "bID");
   if (block_id.empty()) {
-    ret_link_info.hash = TypeConverter::decodeBase64(config::GENESIS_BLOCK_PREV_HASH_B64);
+    ret_link_info.hash =
+        TypeConverter::decodeBase64(config::GENESIS_BLOCK_PREV_HASH_B64);
     ret_link_info.height = 0;
   } else {
-    ret_link_info.hash = TypeConverter::stringToBytes(getValueByKey(DBType::BLOCK_RAW, block_id + "_hash"));
-    ret_link_info.height = Safe::getSize(getValueByKey(DBType::BLOCK_LATEST, "hgt"));
+    ret_link_info.hash = TypeConverter::stringToBytes(
+        getValueByKey(DBType::BLOCK_RAW, block_id + "_hash"));
+    ret_link_info.height =
+        Safe::getSize(getValueByKey(DBType::BLOCK_LATEST, "hgt"));
   }
 
   return ret_link_info;
@@ -344,15 +347,22 @@ nth_link_type Storage::getNthBlockLinkInfo(block_height_type t_height) {
 
   if (!t_block_id_b64.empty()) {
     ret_link_info.id = TypeConverter::decodeBase64(t_block_id_b64);
-    ret_link_info.hash = TypeConverter::stringToBytes(getValueByKey(DBType::BLOCK_RAW, t_block_id_b64 + "_hash"));
-    ret_link_info.prev_id = TypeConverter::decodeBase64(getValueByKey(DBType::BLOCK_HEADER, t_block_id_b64 + "_prevbID"));
-    ret_link_info.prev_hash = TypeConverter::decodeBase64(getValueByKey(DBType::BLOCK_HEADER, t_block_id_b64 + "_prevH"));
-    ret_link_info.height = Safe::getSize(getValueByKey(DBType::BLOCK_HEADER, t_block_id_b64 + "_hgt"));
-    ret_link_info.time = Safe::getTime(getValueByKey(DBType::BLOCK_HEADER, t_block_id_b64 + "_time"));
+    ret_link_info.hash = TypeConverter::stringToBytes(
+        getValueByKey(DBType::BLOCK_RAW, t_block_id_b64 + "_hash"));
+    ret_link_info.prev_id = TypeConverter::decodeBase64(
+        getValueByKey(DBType::BLOCK_HEADER, t_block_id_b64 + "_prevbID"));
+    ret_link_info.prev_hash = TypeConverter::decodeBase64(
+        getValueByKey(DBType::BLOCK_HEADER, t_block_id_b64 + "_prevH"));
+    ret_link_info.height = Safe::getSize(
+        getValueByKey(DBType::BLOCK_HEADER, t_block_id_b64 + "_hgt"));
+    ret_link_info.time = Safe::getTime(
+        getValueByKey(DBType::BLOCK_HEADER, t_block_id_b64 + "_time"));
   } else {
     ret_link_info.height = 0;
-    ret_link_info.hash = TypeConverter::decodeBase64(config::GENESIS_BLOCK_PREV_HASH_B64);
-    ret_link_info.id = TypeConverter::decodeBase64(config::GENESIS_BLOCK_PREV_ID_B64);
+    ret_link_info.hash =
+        TypeConverter::decodeBase64(config::GENESIS_BLOCK_PREV_HASH_B64);
+    ret_link_info.id =
+        TypeConverter::decodeBase64(config::GENESIS_BLOCK_PREV_ID_B64);
     ret_link_info.time = 0;
   }
 
@@ -390,7 +400,7 @@ void Storage::destroyDB() {
   boost::filesystem::remove_all(m_db_path + "/" + config::DB_SUB_DIR_LEDGER);
 }
 
-std::string Storage::getNthBlockIdB64(block_height_type height){
+std::string Storage::getNthBlockIdB64(block_height_type height) {
   std::string block_id_b64 =
       (height == 0) ? getValueByKey(DBType::BLOCK_LATEST, "bID")
                     : getValueByKey(DBType::BLOCK_HEIGHT, to_string(height));
@@ -406,7 +416,7 @@ storage_block_type Storage::readBlock(block_height_type height) {
   else {
     if (height == 0) {
       std::string height_str = getValueByKey(DBType::BLOCK_LATEST, "hgt");
-      if(!height_str.empty())
+      if (!height_str.empty())
         result.height = static_cast<block_height_type>(stoll(height_str));
     }
 
@@ -442,7 +452,7 @@ storage_block_type Storage::readBlock(block_height_type height) {
   return result;
 }
 
-bool Storage::empty(){
+bool Storage::empty() {
   return getValueByKey(DBType::BLOCK_LATEST, "bID").empty();
 }
 

--- a/src/services/transaction_collector.hpp
+++ b/src/services/transaction_collector.hpp
@@ -43,6 +43,7 @@ private:
   BpStatus m_current_tx_status{BpStatus::IN_BOOT_WAIT};
   BpStatus m_next_tx_status{BpStatus::UNKNOWN};
   std::unique_ptr<boost::asio::deadline_timer> m_timer;
+  std::unique_ptr<boost::asio::strand> m_postjob_strand;
   SignatureRequester m_signature_requester;
   std::deque<BpJobStatus> m_bpjob_sequence;
 
@@ -51,7 +52,7 @@ private:
 
   std::map<id_type, std::string> m_cert_map;
 
-  std::atomic<bool> m_timer_running{false};
+  std::once_flag m_timer_once_flag;
 };
 } // namespace gruut
 #endif

--- a/src/utils/bytes_builder.hpp
+++ b/src/utils/bytes_builder.hpp
@@ -33,7 +33,7 @@ public:
     if (len < 0 || len > bytes_val.size())
       len = (int)bytes_val.size();
 
-    if(len == 0)
+    if (len == 0)
       return;
 
     if (m_auto_append) {
@@ -63,7 +63,7 @@ public:
     if (len > 8)
       len = 8;
 
-    if(len == 0)
+    if (len == 0)
       return;
 
     auto int_val = (uint64_t)time_val;
@@ -94,7 +94,7 @@ public:
     if (len > sizeof(uint64_t))
       len = sizeof(uint64_t);
 
-    if(len == 0)
+    if (len == 0)
       return;
 
     std::vector<uint8_t> bytes(len, 0x00);
@@ -112,7 +112,7 @@ public:
     if (len < 0 || len > str_val.size())
       len = (int)str_val.size();
 
-    if(len == 0)
+    if (len == 0)
       return;
 
     std::vector<uint8_t> bytes(str_val.begin(), str_val.begin() + len);
@@ -125,7 +125,7 @@ public:
     if (len < 0)
       len = (int)hex_str_val.size() / 2;
 
-    if(len == 0)
+    if (len == 0)
       return;
 
     std::vector<uint8_t> bytes((size_t)len);

--- a/src/utils/safe.hpp
+++ b/src/utils/safe.hpp
@@ -54,7 +54,7 @@ public:
 
   template <typename S = nlohmann::json, typename K = std::string>
   static size_t getSize(S &&json_obj, K &&key) {
-    return getSize(getString(json_obj,key));
+    return getSize(getString(json_obj, key));
   }
 
   template <typename K = std::string> static size_t getSize(K &&size_str) {

--- a/src/utils/time.hpp
+++ b/src/utils/time.hpp
@@ -25,6 +25,14 @@ public:
     auto now = now_int();
     return now + seconds;
   }
+
+  static uint64_t now_ms() {
+    auto milliseconds_since_epoch = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count());
+    return milliseconds_since_epoch;
+  }
 };
 
 #endif


### PR DESCRIPTION
### 이것은?!
- 금일 오전에 리포팅된 double free of corruption 버그에 대한 패치입니다

### 수정
- clear된 tx pool이 clear가 완료되지 않은 상황에서 clear가 일어날 때 발생합니다.
- 호출 시점상 이렇게 될리가 없기 때문에, 당황스럽지만, 이런 오류가 발생할 수 있는 가능성은 tx collector에서 expire_at을 사용하는 함수에서 현재와 동일한 시점을 호출하여 핸들러가 복수개 생성되는 경우라고 생각합니다. 또한 이런 것이 가능한 경우는 시스템 시간이 이동하는 경우 발생할 수 있습니다. 또한 MSG_PING을 보내거나 받을 때,  flag를 무시(!)하고, turnOnTimer가 호출되면 이런 일이 벌어집니다.
- 이를 방지하기 위해서 ms 단위의 시간을 사용하고, strand를 이용하여 어떤 경우더라도 clear가 순차적으로 발생토록 수정하였습니다. 또한 turnOnTimer에 call_once를 사용해서 복수로 타이머가 핸들러를 생성하는 일을 막았습니다.

### 기타
- clang-format이 적용되지 않았던 수많은 파일들이 같이 수정되었습니다.