### PR TITLE
# EDIT - changed default db health check to be disabled

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -107,7 +107,8 @@ void Application::setup() {
   m_custom_ledger_manager = make_shared<CustomLedgerManager>();
 
   // step 2 - running scenario
-  registerModule(m_block_health_checker, 0, true);
+  if(Setting::getInstance()->getDBCheck())
+    registerModule(m_block_health_checker, 0, true);
 
   registerModule(m_block_processor, 1);
   registerModule(m_communication, 1);

--- a/src/chain/mem_ledger.hpp
+++ b/src/chain/mem_ledger.hpp
@@ -2,6 +2,7 @@
 #define GRUUT_ENTERPRISE_MERGER_MEM_LEDGER_HPP
 
 #include <list>
+#include <string>
 
 namespace gruut {
 

--- a/src/modules/health_checker/block_health_checker.cpp
+++ b/src/modules/health_checker/block_health_checker.cpp
@@ -33,12 +33,10 @@ void BlockHealthChecker::startHealthCheck() {
   std::string prev_block_id_b64 = config::GENESIS_BLOCK_PREV_ID_B64;
   size_t last_healty_block = 0;
 
-  CLOG(INFO, "BHCH") << "Checking ... 0/" << latest_block_info.height;
-
   size_t unit_step =
       (latest_block_info.height < 10) ? 1 : latest_block_info.height / 10;
 
-  for (size_t i = 1; i < latest_block_info.height; ++i) {
+  for (size_t i = 1; i <= latest_block_info.height; ++i) {
 
     if (i % unit_step == 0)
       CLOG(INFO, "BHCH") << "Checking ... " << i << "/"

--- a/src/services/argv_parser.hpp
+++ b/src/services/argv_parser.hpp
@@ -25,17 +25,17 @@ public:
   bool parse(int argc, char *argv[]) {
 
     json setting_json;
-
+    // clang-format off
     cxxopts::Options options(argv[0], config::APP_NAME + "\n");
-    options.add_options("basic")("help", "Print help description")(
-        "in", "Location of setting file",
-        cxxopts::value<string>()->default_value("./setting.json"))(
-        "pass", "Password to decrypt secret key",
-        cxxopts::value<string>()->default_value(""))(
-        "port", "Port number", cxxopts::value<string>()->default_value(""))(
-        "dbpath", "Location where LevelDB stores data",
-        cxxopts::value<string>()->default_value(config::DEFAULT_DB_PATH))(
-        "dbclear", "To wipe out the existing LevelDB");
+    options.add_options("basic")
+    ("help", "Print help description")
+    ("in", "Location of setting file", cxxopts::value<string>()->default_value("./setting.json"))
+    ("pass", "Password to decrypt secret key", cxxopts::value<string>()->default_value(""))
+    ("port", "Port number", cxxopts::value<string>()->default_value(""))
+    ("dbpath", "Location where LevelDB stores data", cxxopts::value<string>()->default_value(config::DEFAULT_DB_PATH))
+    ("dbclear", "To wipe out the existing LevelDB")
+    ("dbcheck", "Perform DB health check before running");
+    // clang-format on
 
     if (argc == 1) {
       std::cout << options.help({"", "basic"}) << std::endl;
@@ -122,7 +122,12 @@ public:
 
       if (result.count("dbclear")) {
         Storage::getInstance()->destroyDB();
-        CLOG(INFO, "ARGV") << "THE EXISTING DB HAS BEEN CLEARED.";
+        CLOG(INFO, "ARGV") << "EXISTING DB HAS BEEN CLEARED.";
+      }
+
+      if(result.count("dbcheck")) {
+        setting->setDBCheck();
+        CLOG(INFO, "ARGV") << "DB HEALTH CHECKING IS ENABLED.";
       }
 
     } catch (json::parse_error &e) {

--- a/src/services/setting.hpp
+++ b/src/services/setting.hpp
@@ -145,6 +145,7 @@ private:
   GruutAuthorityInfo m_gruut_authority;
   std::vector<ServiceEndpointInfo> m_service_endpoints;
   std::vector<MergerInfo> m_mergers;
+  bool m_db_check{false};
 
 public:
   Setting()
@@ -161,6 +162,14 @@ public:
 
   ~Setting() {
     // TODO :: wipe-out m_sk securely
+  }
+
+  void setDBCheck(){
+    m_db_check = true;
+  }
+
+  bool getDBCheck(){
+    return m_db_check;
   }
 
   bool setJson(json &setting_json) {


### PR DESCRIPTION
### 수정
- 머저를 구동할 때, 기본 DB health check를 끔 (블록이 많아지면, 이를 모두 검사하는데 걸리는 시간이 지나치게 오래 걸림)
- dbcheck 옵션을 주면 머저 구동시 DB health check를 수행