### PR TITLE
# EDIT - Setting 에서 Tracker 정보 참조

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -110,13 +110,14 @@ void Application::setup() {
   if (Setting::getInstance()->getDBCheck())
     registerModule(m_block_health_checker, 0, true);
 
-  registerModule(m_block_processor, 1);
-  registerModule(m_communication, 1);
-  registerModule(m_out_message_fetcher, 1);
-  registerModule(m_bootstraper, 1, true);
+  registerModule(m_communication, 1, true);
 
-  registerModule(m_message_fetcher, 2);
-  registerModule(m_bp_scheduler, 2);
+  registerModule(m_block_processor, 2);
+  registerModule(m_out_message_fetcher, 2);
+  registerModule(m_bootstraper, 2, true);
+
+  registerModule(m_message_fetcher, 3);
+  registerModule(m_bp_scheduler, 3);
 
   // setp 3 - link services
 

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -121,6 +121,7 @@ void Application::setup() {
 
   // setp 3 - link services
 
+  m_communication->setBlockHealthCheck(m_block_health_checker);
   m_bootstraper->setCommunication(m_communication);
 }
 

--- a/src/config/ecdsa_setting.json
+++ b/src/config/ecdsa_setting.json
@@ -51,6 +51,33 @@
       "-----END CERTIFICATE-----"
     ]
   },
+  "TK" : {
+    "id": "R0VOVFRLLTE=",
+    "address" : "13.125.221.27",
+    "port" : "80",
+    "cert" : [
+      "-----BEGIN CERTIFICATE-----",
+      "MIIDMDCCAZigAwIBAgIRALnUPxp3k7kOffbr+pUUkX8wDQYJKoZIhvcNAQELBQAw",
+      "PTEVMBMGA1UEAxMMLy8vLy8vLy8vLzg9MQswCQYDVQQGEwJLUjEXMBUGA1UEChMO",
+      "R3J1dXQgTmV0d29ya3MwHhcNMTkwMTI0MDExMzA0WhcNMjkwMTIxMDExMzA0WjA9",
+      "MRUwEwYDVQQDEwxSMFZPVkZSTExURT0xCzAJBgNVBAYTAktSMRcwFQYDVQQKEw5H",
+      "cnV1dCBOZXR3b3JrczBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNKB3TbGZpLc",
+      "YD4eRuNs3cm472MllJpo12wbsyCSH0D+UBMZc5ZrB169Ciwn5Sa4R9kuzrfZ33mx",
+      "iGMWO5V+ZA6jdjB0MCEGA1UdDgQaBBgYAvpXJ0AD5LrCWgajRrVEnrT+kFzKVnAw",
+      "HAYDVR0RBBUwE4ERY29udGFjdEBncnV1dC5uZXQwDAYDVR0TAQH/BAIwADAjBgNV",
+      "HSMEHDAagBgYJqo0iW9v/30tECWTkkYcGNgp5t6Ms/0wDQYJKoZIhvcNAQELBQAD",
+      "ggGBAIACPOHF1LmeQcL+kYl2cwWUHLO3Y8tf7UO7ZsFbWHwTHt0xkfSFpT+pV20F",
+      "YhEdCNFJYnHLhl6Sd+wiHesTCPqoOXzDkxzRGql0H2D4H5Cx0H11gPLJN7lCP/3M",
+      "9DHlV9Hu8OhhSxT0D5arg3c3wljo7Um6JHXgzxKRMBtlhIoMDaJS1d/xbtfx/sGO",
+      "IDpEgzBj0aQ+334RmiJnOikFwoHeAIQt+C1lRYCBq++kk3I0a5nbxgR/w2KqHimz",
+      "ZbicqqdaWMqTcV3nLSl9bN+7gW95OMbtbyB6dliJdkQjj4euXrHHBP3Z7Ip8L3UI",
+      "SJPJ2oxlZ2eJh77WU6iHZE3LRijvfHA/qqDKdvb2GBtSSD54Yd8xn9tNh/wtMRcQ",
+      "xhXAnZuvMhztXmf5hI+jS2srka8rcJPHEeG/eGR3osENS5c5JVnEW+4/2EShPCms",
+      "x9dEOPgwyfdY6IjaVCbQWc/1Zk1I0fRk8TyaQgBrlqpOl0OlbTs5eiSGeEBCe/+Z",
+      "R/ydyQ==",
+      "-----END CERTIFICATE-----"
+    ]
+  },
   "SE" : [
     {
       "id": "R0VOVFNFLTE=",

--- a/src/modules/block_processor/block_processor.cpp
+++ b/src/modules/block_processor/block_processor.cpp
@@ -245,12 +245,15 @@ block_height_type BlockProcessor::handleMsgBlock(InputMsgEntry &entry) {
     OutputMsgEntry msg_chain_info;
     msg_chain_info.type = MessageType::MSG_CHAIN_INFO; // MSG_CHAIN_INFO = 0xB7
     msg_chain_info.body["mID"] = Safe::getString(entry.body, "mID");
-    msg_chain_info.body["time"] = Time::now();
+    msg_chain_info.body["time"] = to_string(possible_link.time);
     msg_chain_info.body["hgt"] = to_string(possible_link.height);
     msg_chain_info.body["bID"] = TypeConverter::encodeBase64(possible_link.id);
-    msg_chain_info.body["prevbID"] = TypeConverter::encodeBase64(possible_link.prev_id);
-    msg_chain_info.body["hash"] = TypeConverter::encodeBase64(possible_link.hash);
-    msg_chain_info.body["prevHash"] = TypeConverter::encodeBase64(possible_link.prev_hash);
+    msg_chain_info.body["prevbID"] =
+        TypeConverter::encodeBase64(possible_link.prev_id);
+    msg_chain_info.body["hash"] =
+        TypeConverter::encodeBase64(possible_link.hash);
+    msg_chain_info.body["prevHash"] =
+        TypeConverter::encodeBase64(possible_link.prev_hash);
     // TODO : mSig 는 임시.
     msg_chain_info.body["mSig"] = "";
 

--- a/src/modules/communication/communication.cpp
+++ b/src/modules/communication/communication.cpp
@@ -15,7 +15,6 @@ Communication::Communication() {
 };
 
 void Communication::start() {
-  // TODO : Tracker에 접속하지 못하였을때 처리 필요.
   m_merger_client.accessToTracker();
   m_merger_client.checkRpcConnection();
   m_merger_client.checkHttpConnection();
@@ -28,9 +27,14 @@ void Communication::setUpConnList() {
   auto setting = Setting::getInstance();
   auto merger_list = setting->getMergerInfo();
   auto se_list = setting->getServiceEndpointInfo();
+
+  auto tracker_info = setting->getTrackerInfo();
+
   merger_id_type my_id = setting->getMyId();
 
   auto conn_manager = ConnManager::getInstance();
+
+  conn_manager->setTrackerInfo(tracker_info, true);
 
   for (auto &merger_info : merger_list) {
     if (merger_info.id == my_id)

--- a/src/modules/communication/communication.cpp
+++ b/src/modules/communication/communication.cpp
@@ -20,6 +20,8 @@ void Communication::start() {
 
   auto &io_service = Application::app().getIoService();
   io_service.post([this]() { m_merger_server.runServer(m_port_num); });
+
+  stageOver(ExitCode::NORMAL);
 }
 
 void Communication::setUpConnList() {

--- a/src/modules/communication/communication.hpp
+++ b/src/modules/communication/communication.hpp
@@ -3,6 +3,7 @@
 
 #include "../communication/merger_client.hpp"
 #include "../communication/merger_server.hpp"
+#include "../health_checker/block_health_checker.hpp"
 #include "../module.hpp"
 
 namespace gruut {
@@ -10,13 +11,20 @@ namespace gruut {
 class Communication : public Module {
 public:
   Communication();
+
+  void setBlockHealthCheck(std::shared_ptr<BlockHealthChecker> health_checker) {
+    m_health_checker = health_checker;
+  }
+
   void start() override;
 
   inline bool isStarted() { return m_merger_server.isStarted(); }
 
 private:
   void setUpConnList();
+  void checkUpTracker();
 
+  std::shared_ptr<BlockHealthChecker> m_health_checker;
   MergerServer m_merger_server;
   MergerClient m_merger_client;
   std::string m_port_num;

--- a/src/modules/communication/manage_connection.hpp
+++ b/src/modules/communication/manage_connection.hpp
@@ -124,6 +124,13 @@ public:
     return m_se_info.find(se_id_b64) != m_se_info.end();
   }
 
+  bool getTrackerStatus() {
+    if (!m_enabled_tracker)
+      return false;
+
+    return m_tracker_info.conn_status;
+  }
+
   bool getMergerStatus(merger_id_type &merger_id) {
     if (!m_enabled_merger_check)
       return true;
@@ -139,6 +146,7 @@ public:
     std::string se_id_b64 = TypeConverter::encodeBase64(se_id);
     return m_se_info[se_id_b64].conn_status;
   }
+  void disableTracker() { m_enabled_tracker = false; }
 
   void disableMergerCheck() { m_enabled_merger_check = false; }
 
@@ -155,6 +163,7 @@ private:
   std::mutex m_se_mutex;
   std::mutex m_tk_mutex;
 
+  std::atomic<bool> m_enabled_tracker{true};
   std::atomic<bool> m_enabled_merger_check{true};
   std::atomic<bool> m_enabled_se_check{true};
 };

--- a/src/modules/communication/merger_client.cpp
+++ b/src/modules/communication/merger_client.cpp
@@ -20,9 +20,9 @@ MergerClient::MergerClient() {
 
 void MergerClient::accessToTracker() {
   auto setting = Setting::getInstance();
-  auto storage = Storage::getInstance();
 
-  auto latest_block_info = storage->getNthBlockLinkInfo();
+  auto &block_processor = Application::app().getBlockProcessor();
+  auto most_possible_link = block_processor.getMostPossibleLink();
 
   std::string my_id_b64 = TypeConverter::encodeBase64(setting->getMyId());
   json request_msg;
@@ -30,14 +30,14 @@ void MergerClient::accessToTracker() {
   request_msg["ip"] = setting->getMyAddress();
   request_msg["port"] = setting->getMyPort();
   request_msg["mCert"] = setting->getMyCert();
-  request_msg["time"] = to_string(latest_block_info.time);
-  request_msg["hgt"] = latest_block_info.height;
-  request_msg["bID"] = TypeConverter::encodeBase64(latest_block_info.id);
-  request_msg["hash"] = TypeConverter::encodeBase64(latest_block_info.hash);
+  request_msg["time"] = to_string(most_possible_link.time);
+  request_msg["hgt"] = most_possible_link.height;
+  request_msg["bID"] = TypeConverter::encodeBase64(most_possible_link.id);
+  request_msg["hash"] = TypeConverter::encodeBase64(most_possible_link.hash);
   request_msg["prevHash"] =
-      TypeConverter::encodeBase64(latest_block_info.prev_hash);
+      TypeConverter::encodeBase64(most_possible_link.prev_hash);
   request_msg["prevbID"] =
-      TypeConverter::encodeBase64(latest_block_info.prev_id);
+      TypeConverter::encodeBase64(most_possible_link.prev_id);
 
   CLOG(INFO, "MCLN") << "ACCESS TO TRACKER";
   json response_msg;

--- a/src/modules/communication/merger_client.hpp
+++ b/src/modules/communication/merger_client.hpp
@@ -37,6 +37,7 @@ public:
 private:
   RpcReceiverList *m_rpc_receiver_list;
   ConnManager *m_conn_manager;
+  bool m_disable_tracker{false};
 
   PeriodicTask m_rpc_check_scheduler;
   PeriodicTask m_http_check_scheduler;

--- a/src/modules/health_checker/block_health_checker.cpp
+++ b/src/modules/health_checker/block_health_checker.cpp
@@ -11,6 +11,8 @@ void BlockHealthChecker::start() {
   io_service.post([this]() { startHealthCheck(); });
 }
 
+bool BlockHealthChecker::isFinished() { return m_finish; }
+
 void BlockHealthChecker::startHealthCheck() {
 
   auto storage = Storage::getInstance();
@@ -116,6 +118,7 @@ void BlockHealthChecker::startHealthCheck() {
 }
 
 void BlockHealthChecker::endCheck(ExitCode exit_code) {
+  m_finish = true;
   stageOver(exit_code);
 } // keep running post handler
 

--- a/src/modules/health_checker/block_health_checker.hpp
+++ b/src/modules/health_checker/block_health_checker.hpp
@@ -21,9 +21,12 @@ public:
   BlockHealthChecker();
   void start() override;
 
+  bool isFinished();
+
 private:
   void startHealthCheck();
   void endCheck(ExitCode exit_code);
+  std::atomic<bool> m_finish{false};
 };
 
 } // namespace gruut

--- a/src/services/argv_parser.hpp
+++ b/src/services/argv_parser.hpp
@@ -34,7 +34,8 @@ public:
     ("port", "Port number", cxxopts::value<string>()->default_value(""))
     ("dbpath", "Location where LevelDB stores data", cxxopts::value<string>()->default_value(config::DEFAULT_DB_PATH))
     ("dbclear", "To wipe out the existing LevelDB")
-    ("dbcheck", "Perform DB health check before running");
+    ("dbcheck", "Perform DB health check before running")
+    ("disableTK", "Merger do not access to tracker anymore");
     // clang-format on
 
     if (argc == 1) {
@@ -128,6 +129,11 @@ public:
       if (result.count("dbcheck")) {
         setting->setDBCheck();
         CLOG(INFO, "ARGV") << "DB HEALTH CHECKING IS ENABLED.";
+      }
+
+      if (result.count("disableTK")) {
+        setting->setDisableTracker();
+        CLOG(INFO, "ARGV") << "MERGER DO NOT ACCESS TO TRACKER ANYMORE.";
       }
 
     } catch (json::parse_error &e) {

--- a/src/services/setting.hpp
+++ b/src/services/setting.hpp
@@ -43,6 +43,14 @@ struct MergerInfo {
   bool conn_status;
 };
 
+struct TrackerInfo {
+  id_type id;
+  std::string address;
+  std::string port;
+  std::string cert;
+  bool conn_status;
+};
+
 const json SCHEMA_SETTING = R"(
 {
   "title": "Setting",
@@ -84,6 +92,21 @@ const json SCHEMA_SETTING = R"(
       "required": [
         "id",
         "address",
+        "cert"
+      ]
+    },
+    "TK": {
+      "type":"object",
+      "properties" : {
+        "id" : {"type":"string"},
+        "address" : {"type":"string"},
+        "port" : {"type":"string"},
+        "cert" : {"type":"array"}
+      },
+      "required": [
+        "id",
+        "address",
+        "port",
         "cert"
       ]
     },
@@ -145,6 +168,7 @@ private:
   std::string m_db_path;
 
   GruutAuthorityInfo m_gruut_authority;
+  TrackerInfo m_tracker;
   std::vector<ServiceEndpointInfo> m_service_endpoints;
   std::vector<MergerInfo> m_mergers;
   bool m_db_check{false};
@@ -194,9 +218,15 @@ public:
         Safe::getBytesFromB64<id_type>(setting_json["GA"], "id");
     m_gruut_authority.address = Safe::getString(setting_json["GA"], "address");
     m_gruut_authority.cert = joinMultiLine(setting_json["GA"]["cert"]);
-
     //
     cert_pool->pushCert(m_gruut_authority.id, m_gruut_authority.cert);
+
+    m_tracker.id = Safe::getBytesFromB64<id_type>(setting_json["TK"], "id");
+    m_tracker.address = Safe::getString(setting_json["TK"], "address");
+    m_tracker.port = Safe::getString(setting_json["TK"], "port");
+    m_tracker.cert = joinMultiLine(setting_json["TK"]["cert"]);
+    //
+    cert_pool->pushCert(m_tracker.id, m_tracker.cert);
 
     m_service_endpoints.clear();
     for (size_t i = 0; i < setting_json["SE"].size(); ++i) {
@@ -255,6 +285,8 @@ public:
   inline GruutAuthorityInfo getGruutAuthorityInfo() {
     return m_gruut_authority;
   }
+
+  inline TrackerInfo getTrackerInfo() { return m_tracker; }
 
   inline std::vector<MergerInfo> getMergerInfo() { return m_mergers; }
 

--- a/src/services/setting.hpp
+++ b/src/services/setting.hpp
@@ -172,6 +172,7 @@ private:
   std::vector<ServiceEndpointInfo> m_service_endpoints;
   std::vector<MergerInfo> m_mergers;
   bool m_db_check{false};
+  bool m_disable_tracker{false};
 
 public:
   Setting()
@@ -189,6 +190,9 @@ public:
   ~Setting() {
     // TODO :: wipe-out m_sk securely
   }
+  void setDisableTracker() { m_disable_tracker = true; }
+
+  bool getDisableTracker() { return m_disable_tracker; }
 
   void setDBCheck() { m_db_check = true; }
 


### PR DESCRIPTION
 ### 수정
- @setting.hpp 수정 (Tracker의 정보를 읽을 수 있도록 함)
- Communication module이 시작 될 때, Tracker의 정보도 읽어서 ConnManger에서 관리
- 코드에 하드코딩 되어있던 Tracker 주소를 ConnManager에서 읽어오도록 수정
- checkHttpConnection()에서 SE 와의 연결 뿐아니라 Tracker와의 연결도 관리
- 실행시 인자로 "--disableTK" 를 넣으면 Tracker와 통신하지 않습니다. 
ex) ./gruut_enterprise_merger --in my_setting.json --port 50052 --dbpath db2 --disableTK

 ### 기타수정
- 처음 Tracker에 접속 할때 및 MSG_CHAIN_INFO를 보낼 때 "time" 값은 block 생성 시간으로 변경
- Communication Module 실행 순서 변경 
(block Health Check가 끝나면 실행하도록 함, BootStraper보다 먼저 실행 시키도록 단계를 변경)
- accessToTracker()에서 최신 관련 블록 정보를 MostPossibleLink에서 받아오도록 함.

 ### 기타
- 읽을 setting 파일은 @ecdsa_setting.json 과 같아야 합니다. Tracker의 정보를 추가 하였습니다.
Tracker ID 는 "R0VOVFRLLTE=" ( GENTTK-1 base64 encoding )
- Tracker의 cert는 GA 의 key를 통해 생성하였습니다.