### PR TITLE
# EDIT - tried to solve double free of TX pool

### DIFF
--- a/src/chain/transaction.hpp
+++ b/src/chain/transaction.hpp
@@ -75,6 +75,14 @@ public:
 
   tx_id_type getId() { return m_transaction_id; }
 
+  std::string getIdB64() {
+    return TypeConverter::encodeBase64(m_transaction_id);
+  }
+
+  std::string getIdStr(){
+    return TypeConverter::arrayToString<TRANSACTION_ID_TYPE_SIZE>(m_transaction_id);
+  }
+
   void setTime(timestamp_t sent_time) { m_sent_time = sent_time; }
 
   timestamp_t getTime() { return m_sent_time; }

--- a/src/services/transaction_pool.cpp
+++ b/src/services/transaction_pool.cpp
@@ -5,11 +5,9 @@ TransactionPool::TransactionPool() {
   m_transaction_pool.reserve(config::MAX_COLLECT_TRANSACTION_SIZE * 2);
 }
 
-bool TransactionPool::push(Transaction &transaction) {
+bool TransactionPool::push(Transaction transaction) {
 
-  std::string tx_id_str =
-      TypeConverter::arrayToString<TRANSACTION_ID_TYPE_SIZE>(
-          transaction.getId());
+  std::string tx_id_str = transaction.getIdStr();
   std::lock_guard<std::mutex> lock(m_push_mutex);
   if (!m_txid_pool.has(tx_id_str)) {
     m_txid_pool.set(tx_id_str, true);
@@ -30,8 +28,7 @@ bool TransactionPool::isDuplicated(tx_id_type &&tx_id) {
   return isDuplicated(tx_id);
 }
 bool TransactionPool::isDuplicated(tx_id_type &tx_id) {
-  return m_txid_pool.has(
-      TypeConverter::arrayToString<TRANSACTION_ID_TYPE_SIZE>(tx_id));
+  return m_txid_pool.has(TypeConverter::arrayToString<TRANSACTION_ID_TYPE_SIZE>(tx_id));
 }
 
 bool TransactionPool::pop(Transaction &transaction) {
@@ -40,9 +37,7 @@ bool TransactionPool::pop(Transaction &transaction) {
 
   bool success = false;
   for (int i = (int)m_transaction_pool.size() - 1; i >= 0; --i) {
-    std::string tx_id_str =
-        TypeConverter::arrayToString<TRANSACTION_ID_TYPE_SIZE>(
-            m_transaction_pool[i].getId());
+    std::string tx_id_str = m_transaction_pool[i].getIdStr();
     if (m_txid_pool.get_copy_or_default(tx_id_str, false)) {
       transaction = m_transaction_pool[i];
       m_txid_pool.unset(tx_id_str);
@@ -59,9 +54,7 @@ std::vector<Transaction> TransactionPool::fetchLastN(size_t n) {
   std::vector<Transaction> transactions;
 
   for (int i = (int)m_transaction_pool.size() - 1; i >= 0; --i) {
-    std::string tx_id_str =
-        TypeConverter::arrayToString<TRANSACTION_ID_TYPE_SIZE>(
-            m_transaction_pool[i].getId());
+    std::string tx_id_str = m_transaction_pool[i].getIdStr();
     if (m_txid_pool.get_copy_or_default(tx_id_str, false)) {
       transactions.emplace_back(m_transaction_pool[i]);
       m_txid_pool.unset(tx_id_str);

--- a/src/services/transaction_pool.hpp
+++ b/src/services/transaction_pool.hpp
@@ -14,7 +14,7 @@ namespace gruut {
 class TransactionPool {
 public:
   TransactionPool();
-  bool push(Transaction &transaction);
+  bool push(Transaction transaction);
   bool isDuplicated(tx_id_type &&tx_id);
   bool isDuplicated(tx_id_type &tx_id);
   bool pop(Transaction &transaction);


### PR DESCRIPTION
### 추정 원인
- STL vector를 clear 할 때, double free or corruption 증상이 뜨는 이유는 clear()가 중복으로 호출되기 때문은 아님.
- 문제는 STL vector에 reference로 어떠한 값이 넘어갔고, 이 reference가 이미 외부에서 해제가 된 상태라면 double free or corruption 에러가 뜸.
- 정상적인 경우라면 reference 카운터가 올라가서 해제가 되어서는 안되는데, 구조적인 문제가 있을 수도 있음
예를 들어, 동일한 TX가 pool에 중복해서 들어갔다면, 문제가 될 수 있음.
- 따라서, 메모리를 더 사용하더라도, STL vector에 넣는 값들은 복사를 기본으로 해야함.

### 수정
- TX pool push를 call-by-reference에서 call-by-value로 수정