### PR TITLE
# EDIT - fixed comm and bootstrapper modules as related tracker

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -121,7 +121,6 @@ void Application::setup() {
 
   // setp 3 - link services
 
-  m_communication->setBlockHealthCheck(m_block_health_checker);
   m_bootstraper->setCommunication(m_communication);
 }
 

--- a/src/chain/types.hpp
+++ b/src/chain/types.hpp
@@ -49,13 +49,15 @@ enum class MessageType : uint8_t {
   MSG_SUCCESS = 0x58,
   MSG_ACCEPT = 0x59,
   MSG_LEAVE = 0x5B,
+
+  MSG_JOIN_MERGER = 0x70,
+  MSG_CHAIN_INFO = 0x71,
+
   MSG_TX = 0xB1,
   MSG_REQ_SSIG = 0xB2,
   MSG_SSIG = 0xB3,
   MSG_BLOCK = 0xB4,
   MSG_HEADER = 0xB5,
-  // TODO: MSG_CHAIN_INFO 번호는 변경 될 수 있습니다.
-  MSG_CHAIN_INFO = 0xB7,
   MSG_ERROR = 0xFF,
   MSG_REQ_CHECK = 0xC0,
   MSG_RES_CHECK = 0xC1
@@ -139,8 +141,19 @@ using signature_type = bytes;
 using header_length_type = uint32_t;
 using content_type = std::string;
 using hmac_key_type = Botan::secure_vector<uint8_t>;
-
 using block_layer_t = std::vector<std::string>;
+
+// All of the blows are the same type. Use them according to the context.
+// If you cannot distinguish it, just use id_type
+using requestor_id_type = bytes;
+using merger_id_type = bytes;
+using signer_id_type = bytes;
+using servend_id_type = bytes;
+using id_type = bytes;
+
+// Message
+using message_version_type = uint8_t;
+
 
 using proof_type = struct _proof_type {
   std::string block_id_b64;
@@ -173,16 +186,12 @@ using unblk_push_result_type = struct _unblk_push_result_type {
   block_layer_t block_layer;
 };
 
-// All of the blows are the same type. Use them according to the context.
-// If you cannot distinguish it, just use id_type
-using requestor_id_type = bytes;
-using merger_id_type = bytes;
-using signer_id_type = bytes;
-using servend_id_type = bytes;
-using id_type = bytes;
 
-// Message
-using message_version_type = uint8_t;
+using merger_height_type = struct _merger_height_type{
+  id_type merger_id;
+  block_height_type height;
+  _merger_height_type(id_type merger_id_, block_height_type height_) : merger_id(std::move(merger_id_)), height(height_){}
+};
 
 } // namespace gruut
 #endif

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -47,6 +47,7 @@ constexpr size_t SIGNATURE_COLLECTION_CHECK_INTERVAL = 500;
 constexpr int RPC_CHECK_INTERVAL = 1000;
 constexpr int HTTP_CHECK_INTERVAL = 5000;
 constexpr size_t TIME_MAX_DIFF_SEC = 3;
+constexpr size_t MAX_WAIT_CONNECT_OTHERS_BSYNC_SEC = 5;
 
 // KNOWLEDGE
 

--- a/src/modules/bootstraper/block_synchronizer.cpp
+++ b/src/modules/bootstraper/block_synchronizer.cpp
@@ -156,40 +156,6 @@ void BlockSynchronizer::startBlockSync(std::function<void(ExitCode)> callback) {
 
   CLOG(INFO, "BSYN") << "BLOCK SYNCHRONIZATION ---- START";
 
-  // TODO : MAX BLOCK HEIGHT 를 가진 Merger들과 연결 될 수 있을때, loop를 빠져
-  // 나간다. 사용자로 부터 입력을 받아 처리 할 수 도 있도록 수정 될 수 있음.
-  auto conn_manager = ConnManager::getInstance();
-  auto max_hgt_merger_list = conn_manager->getMaxBlockHgtMergers();
-  uint64_t max_hgt = 0;
-
-  bool conn_check = false;
-
-  if (max_hgt_merger_list.empty())
-    conn_check = true;
-  else
-    max_hgt = max_hgt_merger_list[0].first;
-
-  bool have_max_hgt = false;
-  for (auto &check_id : max_hgt_merger_list) {
-    if (m_my_id == check_id.second) {
-      have_max_hgt = true;
-      break;
-    }
-  }
-
-  if (max_hgt != 0 && !have_max_hgt) {
-    CLOG(INFO, "BSYN") << "Waiting Mergers that have max height block";
-    while (!conn_check) {
-      for (auto &merger : max_hgt_merger_list) {
-        conn_check |= conn_manager->getMergerStatus(merger.second);
-      }
-      // TODO: 500ms 임시값.
-      std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    }
-  }
-
-  conn_manager->clearBlockHgtList();
-
   m_link_from = Application::app().getBlockProcessor().getMostPossibleLink();
 
   sendRequestStatus();

--- a/src/modules/bootstraper/bootstrapper.cpp
+++ b/src/modules/bootstraper/bootstrapper.cpp
@@ -40,22 +40,60 @@ void Bootstrapper::selfCheckUp() {
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }
 
-  CLOG(INFO, "BOOT") << "[2] Waiting connection check (in 5 sec)";
-  std::this_thread::sleep_for(std::chrono::seconds(5));
+  CLOG(INFO, "BOOT") << "[2] Waiting connection check";
 
-  // TODO :: do jobs for self check-up
+  std::this_thread::sleep_for(std::chrono::seconds(config::MAX_WAIT_CONNECT_OTHERS_BSYNC_SEC));
 
-  CLOG(INFO, "BOOT") << "[3] Starting block synchronization";
+  auto last_block_status = Application::app().getBlockProcessor().getMostPossibleLink();
+  auto conn_manager = ConnManager::getInstance();
+  auto max_height_mids = conn_manager->getMaxBlockHgtMergers();
+  conn_manager->clearBlockHgtList();
 
-  m_block_synchronizer.startBlockSync(
-      std::bind(&Bootstrapper::endSync, this, std::placeholders::_1));
+  block_height_type max_block_height = max_height_mids.first;
+
+  if(max_height_mids.second.empty()) {
+    CLOG(INFO, "BOOT") << "[3] Starting block synchronization (not sure)";
+    m_block_synchronizer.startBlockSync(std::bind(&Bootstrapper::endSync, this, std::placeholders::_1));
+    return;
+  } else {
+    if(last_block_status.height >= max_block_height) {
+      CLOG(INFO, "BOOT") << "[3] Skip block synchronization (no need)";
+      endSync(ExitCode::NORMAL);
+      return;
+    }
+  }
+
+  CLOG(INFO, "BOOT") << "[3] Waiting connection to highest merger";
+
+  bool conn_check = false;
+  timestamp_t start_time = Time::now_int();
+
+  while (!conn_check) {
+    for (auto &merger_id : max_height_mids.second) {
+      conn_check |= conn_manager->getMergerStatus(merger_id);
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    if ((Time::now_int() - start_time) > config::MAX_WAIT_CONNECT_OTHERS_BSYNC_SEC)
+      break;
+  }
+
+  if(conn_check) {
+    CLOG(INFO, "BOOT") << "[4] Starting block synchronization";
+    m_block_synchronizer.startBlockSync(std::bind(&Bootstrapper::endSync, this, std::placeholders::_1));
+  } else {
+    CLOG(INFO, "BOOT") << "[4] Skip block synchronization (no connection)";
+    endSync(ExitCode::ERROR_SYNC_ALONE);
+  }
 }
 
 void Bootstrapper::endSync(ExitCode exit_code) {
 
-  // TODO : rewrite these codes after fixing boot-hang bug
-  sendMsgUp();
-  stageOver(exit_code);
+  std::call_once(m_endsync_flag,[this, &exit_code](){
+    sendMsgUp();
+    stageOver(exit_code);
+  });
 }
 
 } // namespace gruut

--- a/src/modules/bootstraper/bootstrapper.hpp
+++ b/src/modules/bootstraper/bootstrapper.hpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <mutex>
 
 namespace gruut {
 
@@ -31,6 +32,7 @@ private:
   localchain_id_type m_my_localchain_id;
   MessageProxy m_msg_proxy;
   std::shared_ptr<Communication> m_communication;
+  std::once_flag m_endsync_flag;
 
 public:
   Bootstrapper();

--- a/src/modules/communication/communication.hpp
+++ b/src/modules/communication/communication.hpp
@@ -12,10 +12,6 @@ class Communication : public Module {
 public:
   Communication();
 
-  void setBlockHealthCheck(std::shared_ptr<BlockHealthChecker> health_checker) {
-    m_health_checker = health_checker;
-  }
-
   void start() override;
 
   inline bool isStarted() { return m_merger_server.isStarted(); }
@@ -24,7 +20,6 @@ private:
   void setUpConnList();
   void checkUpTracker();
 
-  std::shared_ptr<BlockHealthChecker> m_health_checker;
   MergerServer m_merger_server;
   MergerClient m_merger_client;
   std::string m_port_num;

--- a/src/modules/communication/merger_client.cpp
+++ b/src/modules/communication/merger_client.cpp
@@ -20,13 +20,15 @@ MergerClient::MergerClient() {
 
 void MergerClient::accessToTracker() {
   auto setting = Setting::getInstance();
-
-  auto &block_processor = Application::app().getBlockProcessor();
-  auto most_possible_link = block_processor.getMostPossibleLink();
+  auto most_possible_link = Application::app().getBlockProcessor().getMostPossibleLink();
 
   std::string my_id_b64 = TypeConverter::encodeBase64(setting->getMyId());
+  std::string my_chain_id_b64 = TypeConverter::encodeBase64(setting->getLocalChainId());
+
   json request_msg;
+  request_msg["msgID"] = to_string((int) MessageType::MSG_JOIN_MERGER);
   request_msg["mID"] = my_id_b64;
+  request_msg["cID"] = my_chain_id_b64;
   request_msg["ip"] = setting->getMyAddress();
   request_msg["port"] = setting->getMyPort();
   request_msg["mCert"] = setting->getMyCert();
@@ -48,7 +50,7 @@ void MergerClient::accessToTracker() {
       http_client.postAndGetReply(request_msg.dump(), response_msg);
 
   if (status != CURLE_OK) {
-    CLOG(ERROR, "MCLN") << "Could not get Merger informations from Tracker";
+    CLOG(ERROR, "MCLN") << "Could not get Merger information from Tracker";
     return;
   }
 


### PR DESCRIPTION
### 수정
- block synchronizer에서 트래커로 연결 하던 루틴을 bootstrapper로 이동 
- 불필요한 경우 block synchronizer를 호출하지 않도록 수정
- communication에서 block health check를 대기하도록 한 부분 삭제 (필요없음)