### PR TITLE
#EDIT - fine ledger control

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -97,14 +97,13 @@ void Application::setup() {
   m_thread_group = make_shared<std::vector<std::thread>>();
 
   m_bp_scheduler = make_shared<BpScheduler>();
+  m_custom_ledger_manager = make_shared<CustomLedgerManager>();
   m_block_processor = make_shared<BlockProcessor>();
   m_bootstraper = make_shared<Bootstrapper>();
   m_block_health_checker = make_shared<BlockHealthChecker>();
   m_communication = make_shared<Communication>();
   m_out_message_fetcher = make_shared<OutMessageFetcher>();
   m_message_fetcher = make_shared<MessageFetcher>();
-
-  m_custom_ledger_manager = make_shared<CustomLedgerManager>();
 
   // step 2 - running scenario
   if (Setting::getInstance()->getDBCheck())

--- a/src/chain/block.hpp
+++ b/src/chain/block.hpp
@@ -264,14 +264,18 @@ public:
           TypeConverter::encodeBase64(m_merkle_tree_node[i]));
     }
 
-    std::vector<json> txs;
+    return json({{"mtree", mtree_node_b64},
+                 {"txCnt", to_string(m_transactions.size())},
+                 {"tx", getBlockTXsAsJson()}});
+  }
+
+  json getBlockTXsAsJson() {
+    json txs = json::array();
     for (auto &each_tx : m_transactions) {
       txs.push_back(each_tx.getJson());
     }
 
-    return json({{"mtree", mtree_node_b64},
-                 {"txCnt", to_string(m_transactions.size())},
-                 {"tx", txs}});
+    return txs;
   }
 
   block_height_type getHeight() { return m_height; }

--- a/src/chain/mem_ledger.hpp
+++ b/src/chain/mem_ledger.hpp
@@ -1,6 +1,7 @@
 #ifndef GRUUT_ENTERPRISE_MERGER_MEM_LEDGER_HPP
 #define GRUUT_ENTERPRISE_MERGER_MEM_LEDGER_HPP
 
+#include "easy_logging.hpp"
 #include <list>
 #include <memory>
 #include <mutex>
@@ -31,12 +32,13 @@ private:
   std::mutex m_active_mutex;
 
 public:
-  MemLedger() = default;
+  MemLedger() { el::Loggers::getLogger("MEML"); }
 
   bool push(std::string key, std::string value, std::string block_id_b64) {
     std::lock_guard<std::mutex> lock(m_active_mutex);
     m_ledger.emplace_back(std::move(key), std::move(value),
                           std::move(block_id_b64));
+
     return true;
   }
 

--- a/src/chain/types.hpp
+++ b/src/chain/types.hpp
@@ -51,7 +51,8 @@ enum class MessageType : uint8_t {
   MSG_LEAVE = 0x5B,
 
   MSG_JOIN_MERGER = 0x70,
-  MSG_CHAIN_INFO = 0x71,
+  MSG_NETWORK_INFO = 0x71,
+  MSG_CHAIN_INFO = 0x72,
 
   MSG_TX = 0xB1,
   MSG_REQ_SSIG = 0xB2,

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -61,7 +61,7 @@ const std::string DB_SUB_DIR_LATEST = "latest_block_header";
 const std::string DB_SUB_DIR_TRANSACTION = "transaction";
 const std::string DB_SUB_DIR_IDHEIGHT = "blockid_height";
 const std::string DB_SUB_DIR_LEDGER = "ledger";
-const std::string DB_SUB_DIR_UNRESOLVED_BLOCK = "unresolved_block";
+const std::string DB_SUB_DIR_BACKUP = "backup";
 
 // clang-format on
 

--- a/src/ledger/ledger.hpp
+++ b/src/ledger/ledger.hpp
@@ -28,14 +28,12 @@ public:
                          const block_layer_t &block_layer) = 0;
 
 protected:
-  template <typename T = std::string> void setPrefix(T &&prefix) {
-    m_prefix = prefix;
-  }
+  void setPrefix(std::string prefix) { m_prefix = std::move(prefix); }
 
-  template <typename T = std::string> bool saveLedger(T &&key, T &&value) {
+  bool saveLedger(const std::string &key, const std::string &value,
+                  const std::string &block_id_b64 = "") {
     std::string wrap_key = m_prefix + key;
-    // CLOG(INFO, "LEDG") << "Save ledger (key=" << wrap_key << ")";
-    m_layered_storage->saveLedger(wrap_key, value);
+    m_layered_storage->saveLedger(wrap_key, value, block_id_b64);
     return true;
   }
 
@@ -46,10 +44,14 @@ protected:
     return ret_val;
   }
 
-  template <typename T = std::string, typename V = block_layer_t>
-  std::string readLedgerByKey(T &&key, V &&bloc_layer = {}) {
+  std::string readLedgerByKey(const std::string &key) {
     std::string wrap_key = m_prefix + key;
-    // CLOG(INFO, "LEDG") << "Search ledger (key=" << wrap_key << ")";
+    return m_layered_storage->readLedgerByKey(wrap_key);
+  }
+
+  std::string readLedgerByKeyOnLayer(const std::string &key,
+                                     const block_layer_t &bloc_layer = {}) {
+    std::string wrap_key = m_prefix + key;
     return m_layered_storage->readLedgerByKey(wrap_key, bloc_layer);
   }
 };

--- a/src/modules/block_processor/block_processor.cpp
+++ b/src/modules/block_processor/block_processor.cpp
@@ -12,13 +12,6 @@ BlockProcessor::BlockProcessor() {
   m_my_id_b64 = TypeConverter::encodeBase64(setting->getMyId());
   m_my_chain_id_b64 = TypeConverter::encodeBase64(setting->getLocalChainId());
 
-  auto last_block_info = m_storage->getNthBlockLinkInfo();
-
-  m_unresolved_block_pool.setPool(last_block_info.id, last_block_info.hash,
-                                  last_block_info.height, last_block_info.time);
-
-  m_unresolved_block_pool.restorePool();
-
   auto &io_service = Application::app().getIoService();
   m_task_scheduler.setIoService(io_service);
 
@@ -26,6 +19,13 @@ BlockProcessor::BlockProcessor() {
 }
 
 void BlockProcessor::start() {
+  auto last_block_info = m_storage->getNthBlockLinkInfo();
+
+  m_unresolved_block_pool.setPool(last_block_info.id, last_block_info.hash,
+                                  last_block_info.height, last_block_info.time);
+
+  m_unresolved_block_pool.restorePool();
+
   m_task_scheduler.setTaskFunction([this]() { periodicTask(); });
   m_task_scheduler.setInterval(config::BROC_PROCESSOR_TASK_INTERVAL);
   m_task_scheduler.setStrandMod();

--- a/src/modules/block_processor/block_processor.cpp
+++ b/src/modules/block_processor/block_processor.cpp
@@ -10,6 +10,7 @@ BlockProcessor::BlockProcessor() {
 
   auto setting = Setting::getInstance();
   m_my_id_b64 = TypeConverter::encodeBase64(setting->getMyId());
+  m_my_chain_id_b64 = TypeConverter::encodeBase64(setting->getLocalChainId());
 
   auto last_block_info = m_storage->getNthBlockLinkInfo();
 
@@ -224,20 +225,14 @@ block_height_type BlockProcessor::handleMsgBlock(InputMsgEntry &entry) {
 
   m_request_mutex.unlock();
 
-  // if not linked initially, we cannot interpret this block because of previous
-  // missing blocks!
   if (block_push_result.linked) {
     auto possible_link = getMostPossibleLink();
 
-    Application::app().getCustomLedgerManager().procLedgerBlock(
-        entry.body["tx"], recv_block.getBlockIdB64(),
-        block_push_result.block_layer);
-
-    invalidateBlockLayer();
-
     OutputMsgEntry msg_chain_info;
-    msg_chain_info.type = MessageType::MSG_CHAIN_INFO; // MSG_CHAIN_INFO = 0xB7
+    msg_chain_info.type = MessageType::MSG_CHAIN_INFO;
+    msg_chain_info.body["msgID"] = to_string((int)MessageType::MSG_CHAIN_INFO);
     msg_chain_info.body["mID"] = Safe::getString(entry.body, "mID");
+    msg_chain_info.body["cID"] = m_my_chain_id_b64;
     msg_chain_info.body["time"] = to_string(possible_link.time);
     msg_chain_info.body["hgt"] = to_string(possible_link.height);
     msg_chain_info.body["bID"] = TypeConverter::encodeBase64(possible_link.id);
@@ -247,7 +242,6 @@ block_height_type BlockProcessor::handleMsgBlock(InputMsgEntry &entry) {
         TypeConverter::encodeBase64(possible_link.hash);
     msg_chain_info.body["prevHash"] =
         TypeConverter::encodeBase64(possible_link.prev_hash);
-    // TODO : mSig 는 임시.
     msg_chain_info.body["mSig"] = "";
 
     m_msg_proxy.deliverOutputMessage(msg_chain_info);
@@ -256,17 +250,12 @@ block_height_type BlockProcessor::handleMsgBlock(InputMsgEntry &entry) {
   Application::app().getTransactionPool().removeDuplicatedTransactions(
       recv_block.getTxIds());
 
-  resolveBlocks();
+  resolveBlocksIf();
 
   return block_push_result.height;
 }
 
-void BlockProcessor::invalidateBlockLayer() {
-  LayeredStorage::getInstance()->setBlockLayer(
-      m_unresolved_block_pool.getMostPossibleBlockLayer());
-}
-
-void BlockProcessor::resolveBlocks() {
+void BlockProcessor::resolveBlocksIf() {
   std::vector<UnresolvedBlock> resolved_blocks;
   std::vector<std::string> drop_blocks;
 
@@ -290,16 +279,6 @@ void BlockProcessor::resolveBlocks() {
       json block_header = each_block.block.getBlockHeaderJson();
       bytes block_raw = each_block.block.getBlockRaw();
       json block_body = each_block.block.getBlockBodyJson();
-
-      if (each_block.linked) {
-        // this block was not interpreted into the ledger because of link
-        // failure
-        Application::app().getCustomLedgerManager().procLedgerBlock(
-            block_body["tx"], each_block.block.getBlockIdB64(),
-            each_block.block_layer);
-
-        invalidateBlockLayer();
-      }
 
       m_storage->saveBlock(block_raw, block_header, block_body);
       m_layered_storage->moveToDiskLedger(each_block.block.getBlockIdB64());

--- a/src/modules/block_processor/block_processor.hpp
+++ b/src/modules/block_processor/block_processor.hpp
@@ -45,6 +45,7 @@ private:
   Storage *m_storage;
   LayeredStorage *m_layered_storage;
   std::string m_my_id_b64;
+  std::string m_my_chain_id_b64;
   UnresolvedBlockPool m_unresolved_block_pool;
   std::list<BlockRequestRecord> m_request_list;
   std::recursive_mutex m_request_mutex;
@@ -69,8 +70,7 @@ private:
   void handleMsgReqCheck(InputMsgEntry &entry);
   void handleMsgReqStatus(InputMsgEntry &entry);
   void sendErrorMessage(ErrorMsgType t_error_typem, id_type &recv_id);
-  void resolveBlocks();
-  void invalidateBlockLayer();
+  void resolveBlocksIf();
 };
 } // namespace gruut
 

--- a/src/modules/block_processor/unresolved_block_pool.cpp
+++ b/src/modules/block_processor/unresolved_block_pool.cpp
@@ -1,0 +1,640 @@
+#include "unresolved_block_pool.hpp"
+#include "../../application.hpp"
+#include "easy_logging.hpp"
+
+namespace gruut {
+
+UnresolvedBlockPool::UnresolvedBlockPool() {
+  m_layered_storage = LayeredStorage::getInstance();
+  el::Loggers::getLogger("URBK");
+}
+
+void UnresolvedBlockPool::invalidateCaches() {
+  m_cache_link_valid = false;
+  m_cache_layer_valid = false;
+  m_cache_pos_valid = false;
+}
+
+bool UnresolvedBlockPool::hasUnresolvedBlocks() {
+  CLOG(INFO, "URBK") << "Unresolved block pool status = (" << m_last_height
+                     << "," << m_height_range_max << ")";
+  return m_force_unresolved;
+}
+
+void UnresolvedBlockPool::setPool(const block_id_type &last_block_id,
+                                  const hash_t &last_hash,
+                                  block_height_type last_height,
+                                  timestamp_t last_time) {
+  m_last_block_id = last_block_id;
+  m_last_hash = last_hash;
+  m_last_height = last_height;
+  m_last_time = last_time;
+  m_height_range_max = last_height;
+}
+
+bool UnresolvedBlockPool::prepareBins(block_height_type t_height) {
+  std::lock_guard<std::recursive_mutex> guard(m_push_mutex);
+  if (m_last_height >= t_height) {
+    return false;
+  }
+
+  if ((Time::now_int() - m_last_time) <
+      (t_height - m_last_height - 1) * config::BP_INTERVAL) {
+    return false;
+  }
+
+  int bin_pos =
+      static_cast<int>(t_height - m_last_height) - 1; // e.g., 0 = 2 - 1 - 1
+
+  if (m_block_pool.size() < bin_pos + 1) {
+    m_block_pool.resize(bin_pos + 1);
+  }
+
+  return true;
+}
+
+// we assume this block has valid structure at least
+unblk_push_result_type UnresolvedBlockPool::push(Block &block,
+                                                 bool is_restore) {
+  unblk_push_result_type ret_val;
+  ret_val.height = 0;
+  ret_val.linked = false;
+  ret_val.block_layer = {};
+
+  std::lock_guard<std::recursive_mutex> guard(m_push_mutex);
+
+  block_height_type block_height = block.getHeight();
+  int bin_idx =
+      static_cast<int>(block_height - m_last_height) - 1; // e.g., 0 = 2 - 1 - 1
+  if (!prepareBins(block_height))
+    return ret_val;
+
+  for (auto &each_block : m_block_pool[bin_idx]) {
+    if (each_block.block == block) {
+      return ret_val;
+    }
+  }
+
+  int prev_queue_idx = -1; // no previous
+
+  if (bin_idx > 0) { // if there is previous bin
+    size_t idx = 0;
+    for (auto &each_block : m_block_pool[bin_idx - 1]) {
+      if (each_block.block.getBlockId() == block.getPrevBlockId() &&
+          each_block.block.getHash() == block.getPrevHash()) {
+        prev_queue_idx = static_cast<int>(idx);
+        break;
+      }
+      ++idx;
+    }
+  } else { // no previous
+    if (block.getPrevBlockId() == m_last_block_id &&
+        block.getPrevHash() == m_last_hash) {
+      prev_queue_idx = 0;
+    } else {
+      // drop block -- this is not linkable block!
+      return ret_val;
+    }
+  }
+
+  int queue_idx = m_block_pool[bin_idx].size();
+
+  m_block_pool[bin_idx].emplace_back(block, prev_queue_idx, 0, false);
+
+  block_layer_t block_layer_of_this;
+  if (bin_idx > 0)
+    block_layer_of_this = getBlockLayer(block.getBlockIdB64());
+
+  ret_val.height = block_height;
+  ret_val.linked = (bin_idx == 0) ? true : !block_layer_of_this.empty();
+  ret_val.block_layer = block_layer_of_this;
+
+  m_block_pool[bin_idx][queue_idx].block_layer = block_layer_of_this;
+  m_block_pool[bin_idx][queue_idx].linked = ret_val.linked;
+
+  if (!is_restore)
+    backupPool();
+
+  if (bin_idx + 1 < m_block_pool.size()) { // if there is next bin
+    for (auto &each_block : m_block_pool[bin_idx + 1]) {
+      if (each_block.block.getPrevBlockId() == block.getBlockId() &&
+          each_block.block.getPrevHash() == block.getHash()) {
+        if (each_block.prev_vector_idx < 0) {
+          each_block.prev_vector_idx = queue_idx;
+        }
+      }
+    }
+  }
+
+  if (ret_val.linked) {
+    forwardBlocksToLedgerFrom(bin_idx, queue_idx);
+  }
+
+  if (m_height_range_max < block_height) {
+    m_height_range_max = block_height;
+  }
+
+  invalidateCaches();
+
+  m_layered_storage->setBlockLayer(getMostPossibleBlockLayer());
+
+  m_push_mutex.unlock();
+
+  return ret_val;
+}
+
+block_layer_t UnresolvedBlockPool::forwardBlockToLedgerAt(int bin_idx,
+                                                          int vector_idx) {
+  if (bin_idx < 0 || m_block_pool.size() < bin_idx + 1 ||
+      m_block_pool[bin_idx].size() < vector_idx + 1)
+    return {};
+
+  auto &t_block = m_block_pool[bin_idx][vector_idx];
+  Application::app().getCustomLedgerManager().procLedgerBlock(
+      t_block.block.getBlockBodyJson(), t_block.block.getBlockIdB64(),
+      t_block.block_layer);
+
+  return t_block.block_layer;
+}
+
+void UnresolvedBlockPool::forwardBlocksToLedgerFrom(int bin_idx,
+                                                    int vector_idx) {
+
+  if (bin_idx < 0 || m_block_pool.size() < bin_idx + 1 ||
+      m_block_pool[bin_idx].size() < vector_idx + 1)
+    return;
+
+  std::function<void(size_t, size_t, block_layer_t)> recBlockToLedger;
+  recBlockToLedger = [this, &recBlockToLedger](size_t bin_idx,
+                                               size_t prev_vector_idx,
+                                               block_layer_t block_layer) {
+    if (bin_idx < 0 || m_block_pool.size() < bin_idx + 1)
+      return;
+
+    for (size_t i = 0; i < m_block_pool[bin_idx].size(); ++i) {
+      auto &each_block = m_block_pool[bin_idx][i];
+      if (each_block.prev_vector_idx == prev_vector_idx) {
+        each_block.block_layer = block_layer;
+        block_layer.emplace_back(each_block.block.getBlockIdB64());
+        forwardBlockToLedgerAt(bin_idx, i);
+        recBlockToLedger(bin_idx + 1, i, block_layer);
+      }
+    }
+  };
+
+  block_layer_t block_layer = forwardBlockToLedgerAt(bin_idx, vector_idx);
+  recBlockToLedger(bin_idx + 1, vector_idx, block_layer);
+}
+
+bool UnresolvedBlockPool::getBlock(block_height_type t_height,
+                                   const hash_t &t_prev_hash,
+                                   const hash_t &t_hash, Block &ret_block) {
+
+  std::lock_guard<std::recursive_mutex> guard(m_push_mutex);
+  if (m_block_pool.empty()) {
+    return false;
+  }
+
+  if (t_height <= m_last_height ||
+      m_last_height + m_block_pool.size() < t_height) {
+    return false;
+  }
+
+  int bin_pos = static_cast<int>(t_height - m_last_height) - 1;
+
+  hash_t block_hash = t_hash;
+  hash_t prev_hash = t_prev_hash;
+
+  if (t_height == 0) {
+    nth_link_type most_possible_link = getMostPossibleLink();
+    bin_pos = static_cast<int>(most_possible_link.height - m_last_height) - 1;
+    prev_hash = most_possible_link.prev_hash;
+    block_hash = most_possible_link.hash;
+  }
+
+  if (bin_pos < 0) // something wrong
+    return false;
+
+  bool is_some = false;
+  for (auto &each_block : m_block_pool[bin_pos]) {
+    if ((prev_hash.empty() || each_block.block.getPrevHash() == prev_hash) &&
+        (block_hash.empty() || each_block.block.getHash() == block_hash)) {
+      ret_block = each_block.block;
+      is_some = true;
+      break;
+    }
+  }
+
+  return is_some;
+}
+
+// flushing out resolved blocks
+void UnresolvedBlockPool::getResolvedBlocks(
+    std::vector<UnresolvedBlock> &resolved_blocks,
+    std::vector<std::string> &drop_blocks) {
+  resolved_blocks.clear();
+  drop_blocks.clear();
+
+  std::lock_guard<std::recursive_mutex> guard(m_push_mutex);
+
+  size_t num_resolved_block = 0;
+
+  auto resolveBlocksStepByStep =
+      [this](std::vector<UnresolvedBlock> &resolved_blocks,
+             std::vector<std::string> &drop_blocks) {
+        updateConfirmLevel();
+
+        if (m_block_pool.size() < 2 || m_block_pool[0].empty() ||
+            m_block_pool[1].empty())
+          return;
+
+        size_t highest_confirm_level = 0;
+        int resolved_block_idx = -1;
+
+        for (size_t i = 0; i < m_block_pool[0].size(); ++i) {
+          if (m_block_pool[0][i].prev_vector_idx == 0 &&
+              m_block_pool[0][i].confirm_level > highest_confirm_level) {
+            highest_confirm_level = m_block_pool[0][i].confirm_level;
+            resolved_block_idx = static_cast<int>(i);
+          }
+        }
+
+        if (resolved_block_idx < 0 ||
+            highest_confirm_level < config::BLOCK_CONFIRM_LEVEL)
+          return; // nothing to do
+
+        bool is_after = false;
+        for (auto &each_block : m_block_pool[1]) {
+          if (each_block.prev_vector_idx ==
+              resolved_block_idx) { // some block links this block
+            is_after = true;
+            break;
+          }
+        }
+
+        if (!is_after)
+          return;
+
+        m_last_block_id =
+            m_block_pool[0][resolved_block_idx].block.getBlockId();
+        m_last_hash = m_block_pool[0][resolved_block_idx].block.getHash();
+        m_last_height = m_block_pool[0][resolved_block_idx].block.getHeight();
+
+        resolved_blocks.emplace_back(m_block_pool[0][resolved_block_idx]);
+
+        // clear this height list
+
+        auto leyered_storage = LayeredStorage::getInstance();
+
+        if (m_block_pool[0].size() > 1) {
+          for (auto &each_block : m_block_pool[0]) {
+            if (each_block.block.getBlockId() != m_last_block_id) {
+              drop_blocks.emplace_back(each_block.block.getBlockIdB64());
+            }
+          }
+          CLOG(INFO, "URBK") << "Dropped out " << m_block_pool[0].size() - 1
+                             << " unresolved block(s)";
+        }
+
+        m_block_pool.pop_front();
+
+        if (m_block_pool.empty())
+          return;
+
+        for (auto &each_block : m_block_pool[0]) {
+          if (each_block.block.getPrevBlockId() == m_last_block_id &&
+              each_block.block.getPrevHash() == m_last_hash) {
+            each_block.prev_vector_idx = 0;
+          } else {
+            // this block is unlinkable => to be deleted
+            each_block.prev_vector_idx = -1;
+          }
+        }
+      };
+
+  do {
+    num_resolved_block = resolved_blocks.size();
+    resolveBlocksStepByStep(resolved_blocks, drop_blocks);
+  } while (num_resolved_block < resolved_blocks.size());
+
+  m_push_mutex.unlock();
+
+  auto storage = Storage::getInstance();
+
+  json id_array = readBackupIds();
+
+  if (id_array.empty() || !id_array.is_array())
+    return;
+
+  json del_id_array = json::array();
+  json new_id_array = json::array();
+
+  for (auto &each_id : id_array) {
+    bool is_dux = false;
+    std::string block_id_b64 = Safe::getString(each_id);
+    if (block_id_b64.empty())
+      continue;
+
+    for (auto &each_block : resolved_blocks) {
+      if (block_id_b64 == each_block.block.getBlockIdB64()) {
+        is_dux = true;
+        break;
+      }
+    }
+
+    if (!is_dux) {
+      new_id_array.push_back(block_id_b64);
+    } else {
+      del_id_array.push_back(block_id_b64);
+    }
+  }
+
+  storage->saveBackup(
+      UNRESOLVED_BLOCK_IDS_KEY,
+      TypeConverter::bytesToString(json::to_cbor(new_id_array)));
+
+  for (auto &each_id : del_id_array) {
+    std::string block_id_b64 = Safe::getString(each_id);
+    storage->delBackup(block_id_b64);
+  }
+
+  storage->flushBackup();
+}
+
+nth_link_type UnresolvedBlockPool::getUnresolvedLowestLink() {
+  BlockPosOnMap longest_pos = getLongestBlockPos();
+
+  nth_link_type ret_link;
+  ret_link.height = 0; // no unresolved block or invalid link info
+
+  if (m_last_height <= longest_pos.height &&
+      longest_pos.height < m_block_pool.size() + m_last_height) {
+
+    int bin_idx = static_cast<int>(longest_pos.height - m_last_height) - 1;
+
+    if (longest_pos.height == m_last_height) {
+      ret_link.height = m_last_height + 1;
+      ret_link.prev_hash = m_last_hash;
+    } else if (bin_idx >= 0) {
+      ret_link.height =
+          m_block_pool[bin_idx][longest_pos.vector_idx].block.getHeight() + 1;
+      ret_link.prev_hash =
+          m_block_pool[bin_idx][longest_pos.vector_idx].block.getHash();
+    }
+  }
+
+  return ret_link;
+}
+
+block_layer_t
+UnresolvedBlockPool::getBlockLayer(const std::string &block_id_b64) {
+  block_layer_t block_layer_of_this;
+  int bin_idx = -1;
+  int queue_idx = -1;
+
+  if (!block_id_b64.empty()) {
+    for (size_t i = 0; i < m_block_pool.size(); ++i) {
+      for (size_t j = 0; j < m_block_pool[j].size(); ++j) {
+
+        if (block_id_b64 == m_block_pool[i][j].block.getBlockIdB64()) {
+          bin_idx = static_cast<int>(i);
+          queue_idx = static_cast<int>(j);
+          break;
+        }
+      }
+      if (bin_idx >= 0 && queue_idx >= 0)
+        break;
+    }
+
+    for (int i = bin_idx; i >= 0; --i) {
+      std::string new_block_id_b64 =
+          m_block_pool[i][queue_idx].block.getBlockIdB64();
+      if (block_id_b64 != new_block_id_b64)
+        block_layer_of_this.emplace_back(new_block_id_b64);
+
+      queue_idx = m_block_pool[i][queue_idx].prev_vector_idx;
+      if (queue_idx < 0) {
+        block_layer_of_this.clear();
+        break;
+      }
+    }
+  }
+
+  return block_layer_of_this;
+}
+
+nth_link_type UnresolvedBlockPool::getMostPossibleLink() {
+
+  if (m_cache_link_valid)
+    return m_cache_possible_link;
+
+  nth_link_type ret_link;
+
+  std::lock_guard<std::recursive_mutex> guard(m_push_mutex);
+
+  // when resolved situation, the blow are the same with storage
+  // unless, they are faster than storage
+
+  ret_link.height = m_last_height;
+  ret_link.id = m_last_block_id;
+  ret_link.hash = m_last_hash;
+
+  if (m_block_pool.empty()) {
+    m_cache_possible_link = ret_link;
+    m_cache_link_valid = true;
+    return ret_link;
+  }
+
+  BlockPosOnMap longest_pos = getLongestBlockPos();
+
+  if (ret_link.height < longest_pos.height) {
+
+    // must be larger or equal to 0
+    int deque_idx = static_cast<int>(longest_pos.height - m_last_height) - 1;
+
+    if (deque_idx >= 0) {
+      auto &t_block = m_block_pool[deque_idx][longest_pos.vector_idx];
+      ret_link.height = t_block.block.getHeight();
+      ret_link.id = t_block.block.getBlockId();
+      ret_link.hash = t_block.block.getHash();
+    }
+  }
+
+  m_cache_possible_link = ret_link;
+  m_cache_link_valid = true;
+
+  return ret_link;
+}
+
+// reverse order
+block_layer_t UnresolvedBlockPool::getMostPossibleBlockLayer() {
+
+  if (m_cache_layer_valid) {
+    return m_cache_possible_block_layer;
+  }
+
+  auto t_block_pos = getLongestBlockPos();
+  std::vector<std::string> ret_block_layer;
+
+  int queue_idx = static_cast<int>(t_block_pos.vector_idx);
+
+  int bin_end = static_cast<int>(t_block_pos.height - m_last_height) - 1;
+
+  for (int i = bin_end; i >= 0; --i) {
+    ret_block_layer.emplace_back(
+        m_block_pool[i][queue_idx].block.getBlockIdB64());
+    queue_idx = m_block_pool[i][queue_idx].prev_vector_idx;
+  }
+
+  m_cache_possible_block_layer = ret_block_layer;
+  m_cache_layer_valid = true;
+  return ret_block_layer;
+}
+
+void UnresolvedBlockPool::restorePool() {
+
+  json id_array = readBackupIds();
+  if (id_array.empty() || !id_array.is_array())
+    return;
+
+  auto storage = Storage::getInstance();
+
+  size_t num_pused_block = 0;
+
+  for (auto &id_each : id_array) {
+    std::string block_id_b64 = Safe::getString(id_each);
+    if (!block_id_b64.empty()) {
+      std::string serialized_block = storage->readBackup(block_id_b64);
+      if (serialized_block.empty()) {
+        CLOG(ERROR, "URBK") << "Failed to read block [" << block_id_b64 << "]";
+        continue;
+      }
+
+      Block new_block;
+      if (!new_block.deserialize(serialized_block)) {
+        CLOG(ERROR, "URBK")
+            << "Failed to deserialize block [" << block_id_b64 << "]";
+        continue;
+      }
+
+      auto push_result = push(new_block, true);
+      if (push_result.height == 0) {
+        CLOG(ERROR, "URBK")
+            << "Failed to restore block [" << block_id_b64 << "]";
+      } else {
+        ++num_pused_block;
+      }
+    }
+  }
+
+  CLOG(INFO, "URBK") << num_pused_block
+                     << " unresolved block(s) have been restored.";
+}
+
+json UnresolvedBlockPool::readBackupIds() {
+  json id_array = json::array();
+
+  auto storage = Storage::getInstance();
+  std::string backup_block_ids = storage->readBackup(UNRESOLVED_BLOCK_IDS_KEY);
+  if (backup_block_ids.empty())
+    return id_array;
+
+  try {
+    id_array = json::from_cbor(backup_block_ids);
+  } catch (json::exception &e) {
+    CLOG(ERROR, "URBK") << "Failed to restore unresolved pool - " << e.what();
+    return id_array;
+  }
+
+  return id_array;
+}
+
+void UnresolvedBlockPool::backupPool() {
+
+  json id_array = json::array();
+  auto storage = Storage::getInstance();
+
+  for (auto &each_level : m_block_pool) {
+    for (auto &each_block : each_level) {
+      std::string key = each_block.block.getBlockIdB64();
+      storage->saveBackup(key, each_block.block.serialize());
+      id_array.push_back(key);
+    }
+  }
+
+  storage->saveBackup(UNRESOLVED_BLOCK_IDS_KEY,
+                      TypeConverter::bytesToString(json::to_cbor(id_array)));
+
+  storage->flushBackup();
+}
+
+BlockPosOnMap UnresolvedBlockPool::getLongestBlockPos() {
+  if (m_cache_pos_valid)
+    return m_cache_possible_pos;
+
+  // search prev_level
+  std::function<void(size_t, size_t, BlockPosOnMap &)> recSearchLongestLink;
+  recSearchLongestLink = [this, &recSearchLongestLink](
+                             size_t bin_idx, size_t prev_vector_idx,
+                             BlockPosOnMap &longest_pos) {
+    if (m_block_pool.size() < bin_idx + 1)
+      return;
+
+    // if this level is empty, it will automatically stop to search
+    for (size_t i = 0; i < m_block_pool[bin_idx].size(); ++i) {
+      auto &each_block = m_block_pool[bin_idx][i];
+      if (each_block.prev_vector_idx == prev_vector_idx) {
+        if (each_block.block.getHeight() > longest_pos.height) { // relaxation
+          longest_pos.height = each_block.block.getHeight();
+          longest_pos.vector_idx = i;
+        }
+
+        recSearchLongestLink(bin_idx + 1, i, longest_pos);
+      }
+    }
+  };
+
+  BlockPosOnMap longest_pos(0, 0);
+
+  if (!m_block_pool.empty()) {
+    for (size_t i = 0; i < m_block_pool[0].size(); ++i) {
+      if (m_block_pool[0][i].prev_vector_idx == 0) {
+
+        if (m_block_pool[0][i].block.getHeight() >
+            longest_pos.height) { // relaxation
+          longest_pos.height = m_block_pool[0][i].block.getHeight();
+          longest_pos.vector_idx = i;
+        }
+
+        recSearchLongestLink(1, i, longest_pos); // recursive call
+      }
+    }
+  }
+
+  m_cache_possible_pos = longest_pos;
+  m_cache_pos_valid = true;
+
+  return longest_pos;
+}
+
+void UnresolvedBlockPool::updateConfirmLevel() {
+  if (m_block_pool.empty())
+    return;
+
+  for (auto &each_level : m_block_pool) {
+    for (auto &each_block : each_level) {
+      each_block.confirm_level = each_block.block.getNumSSigs();
+    }
+  }
+
+  for (int i = (int)m_block_pool.size() - 1; i > 0; --i) {
+    for (auto &each_block : m_block_pool[i]) { // for vector
+      if (each_block.prev_vector_idx >= 0 &&
+          m_block_pool[i - 1].size() > each_block.prev_vector_idx) {
+        m_block_pool[i - 1][each_block.prev_vector_idx].confirm_level +=
+            each_block.confirm_level;
+      }
+    }
+  }
+}
+} // namespace gruut

--- a/src/modules/block_processor/unresolved_block_pool.cpp
+++ b/src/modules/block_processor/unresolved_block_pool.cpp
@@ -175,7 +175,8 @@ void UnresolvedBlockPool::forwardBlocksToLedgerFrom(int bin_idx,
       auto &each_block = m_block_pool[bin_idx][i];
       if (each_block.prev_vector_idx == prev_vector_idx) {
         each_block.block_layer = block_layer;
-        block_layer.emplace_back(each_block.block.getBlockIdB64());
+        block_layer.insert(block_layer.begin(),
+                           each_block.block.getBlockIdB64());
         forwardBlockToLedgerAt(bin_idx, i);
         recBlockToLedger(bin_idx + 1, i, block_layer);
       }

--- a/src/modules/block_processor/unresolved_block_pool.hpp
+++ b/src/modules/block_processor/unresolved_block_pool.hpp
@@ -51,13 +51,13 @@ private:
   std::atomic<size_t> m_height_range_max{0};
   std::atomic<bool> m_force_unresolved{false};
 
-  std::atomic<bool> m_cache_link_valid{false};
+  std::atomic<bool> m_has_cache_link{false};
   nth_link_type m_cache_possible_link;
 
-  std::atomic<bool> m_cache_layer_valid{false};
+  std::atomic<bool> m_has_cache_block_layer{false};
   std::vector<std::string> m_cache_possible_block_layer;
 
-  std::atomic<bool> m_cache_pos_valid{false};
+  std::atomic<bool> m_has_cache_pos{false};
   BlockPosOnMap m_cache_possible_pos;
 
   LayeredStorage *m_layered_storage;

--- a/src/modules/block_processor/unresolved_block_pool.hpp
+++ b/src/modules/block_processor/unresolved_block_pool.hpp
@@ -1,12 +1,11 @@
 #ifndef GRUUT_ENTERPRISE_MERGER_UNRESOLVED_BLOCK_POOL_HPP
 #define GRUUT_ENTERPRISE_MERGER_UNRESOLVED_BLOCK_POOL_HPP
 
-#include "easy_logging.hpp"
-
 #include "../../config/config.hpp"
 
 #include "../../chain/block.hpp"
 #include "../../chain/types.hpp"
+#include "../../services/layered_storage.hpp"
 #include "../../utils/type_converter.hpp"
 
 #include <deque>
@@ -18,30 +17,30 @@ namespace gruut {
 const std::string UNRESOLVED_BLOCK_IDS_KEY = "UNRESOLVED_BLOCK_IDS_KEY";
 
 struct UnresolvedBlock {
-public:
-  Block block;
-  int prev_queue_idx{-1};
-  bool linked{false}; // This is for unresolved block because of previous
-                      // missing blocks!
+  int prev_vector_idx{-1};
+  bool linked{false};
   size_t confirm_level{0};
   block_layer_t block_layer;
+  Block block;
 
   UnresolvedBlock() = default;
   UnresolvedBlock(Block &block_, int prev_queue_idx_, size_t confirm_level_,
                   bool init_linked_)
-      : block(block_), prev_queue_idx(prev_queue_idx_),
+      : block(block_), prev_vector_idx(prev_queue_idx_),
         confirm_level(confirm_level_), linked(init_linked_) {}
 };
 
 struct BlockPosOnMap {
-  size_t height;
-  size_t vector_idx;
+  size_t height{0};
+  size_t vector_idx{0};
+  BlockPosOnMap() = default;
+  BlockPosOnMap(size_t height_, size_t vector_idx_)
+      : height(height_), vector_idx(vector_idx_) {}
 };
 
 class UnresolvedBlockPool {
 private:
   std::deque<std::vector<UnresolvedBlock>> m_block_pool; // bin structure
-
   std::recursive_mutex m_push_mutex;
 
   block_id_type m_last_block_id;
@@ -61,585 +60,36 @@ private:
   std::atomic<bool> m_cache_pos_valid{false};
   BlockPosOnMap m_cache_possible_pos;
 
+  LayeredStorage *m_layered_storage;
+
 public:
-  UnresolvedBlockPool() { el::Loggers::getLogger("URBK"); };
-
-  size_t size() { return m_block_pool.size(); }
-
-  bool empty() { return m_block_pool.empty(); }
-
-  void clear() { m_block_pool.clear(); }
-
+  UnresolvedBlockPool();
+  inline size_t size() { return m_block_pool.size(); }
+  inline bool empty() { return m_block_pool.empty(); }
+  inline void clear() { m_block_pool.clear(); }
   void setPool(const block_id_type &last_block_id, const hash_t &last_hash,
-               block_height_type last_height, timestamp_t last_time) {
-    m_last_block_id = last_block_id;
-    m_last_hash = last_hash;
-    m_last_height = last_height;
-    m_last_time = last_time;
-    m_height_range_max = last_height;
-  }
-
-  bool prepareBins(block_height_type t_height) {
-    std::lock_guard<std::recursive_mutex> guard(m_push_mutex);
-    if (m_last_height >= t_height) {
-      return false;
-    }
-
-    if ((Time::now_int() - m_last_time) <
-        (t_height - m_last_height - 1) * config::BP_INTERVAL) {
-      return false;
-    }
-
-    int bin_pos = t_height - m_last_height - 1; // e.g., 0 = 2 - 1 - 1
-
-    if (m_block_pool.size() < bin_pos + 1) {
-      m_block_pool.resize(bin_pos + 1);
-    }
-
-    return true;
-  }
-
-  void invalidateCaches() {
-    m_cache_link_valid = false;
-    m_cache_layer_valid = false;
-    m_cache_pos_valid = false;
-  }
-
-  // we assume this block has valid structure at least
-  unblk_push_result_type push(Block &block, bool is_restore = false) {
-    unblk_push_result_type ret_val;
-    ret_val.height = 0;
-    ret_val.linked = false;
-    ret_val.block_layer = {};
-
-    std::lock_guard<std::recursive_mutex> guard(m_push_mutex);
-
-    block_height_type block_height = block.getHeight();
-    int bin_idx = block_height - m_last_height - 1; // e.g., 0 = 2 - 1 - 1
-    if (!prepareBins(block_height))
-      return ret_val;
-
-    for (auto &each_block : m_block_pool[bin_idx]) {
-      if (each_block.block == block) {
-        return ret_val;
-      }
-    }
-
-    int prev_queue_idx = -1; // no previous
-
-    if (bin_idx > 0) { // if there is previous bin
-      size_t idx = 0;
-      for (auto &each_block : m_block_pool[bin_idx - 1]) {
-        if (each_block.block.getBlockId() == block.getPrevBlockId() &&
-            each_block.block.getHash() == block.getPrevHash()) {
-          prev_queue_idx = static_cast<int>(idx);
-          break;
-        }
-        ++idx;
-      }
-    } else { // no previous
-      if (block.getPrevBlockId() == m_last_block_id &&
-          block.getPrevHash() == m_last_hash) {
-        prev_queue_idx = 0;
-      } else {
-        // drop block -- this is not linkable block!
-        return ret_val;
-      }
-    }
-
-    int queue_idx = m_block_pool[bin_idx].size();
-
-    m_block_pool[bin_idx].emplace_back(block, prev_queue_idx, 0, false);
-
-    block_layer_t block_layer_of_this;
-    if (bin_idx > 0)
-      block_layer_of_this = getBlockLayer(block.getBlockIdB64());
-
-    ret_val.height = block_height;
-    ret_val.linked = (bin_idx == 0) ? true : !block_layer_of_this.empty();
-    ret_val.block_layer = block_layer_of_this;
-
-    m_block_pool[bin_idx][queue_idx].block_layer = block_layer_of_this;
-    m_block_pool[bin_idx][queue_idx].linked = ret_val.linked;
-
-    if (!is_restore)
-      backupPool();
-
-    if (bin_idx + 1 < m_block_pool.size()) { // if there is next bin
-      for (auto &each_block : m_block_pool[bin_idx + 1]) {
-        if (each_block.block.getPrevBlockId() == block.getBlockId() &&
-            each_block.block.getPrevHash() == block.getHash()) {
-          if (each_block.prev_queue_idx < 0) // now linked previous one
-            each_block.block_layer =
-                getBlockLayer(each_block.block.getPrevBlockIdB64());
-          each_block.prev_queue_idx = queue_idx;
-        }
-      }
-    }
-
-    if (m_height_range_max < block_height) {
-      m_height_range_max = block_height;
-    }
-
-    invalidateCaches();
-
-    m_push_mutex.unlock();
-
-    return ret_val;
-  }
-
-  template <typename T = std::string, typename H = hash_t>
-  bool getBlock(block_height_type t_height, H &&t_prev_hash, H &&t_hash,
-                Block &ret_block) {
-    std::lock_guard<std::recursive_mutex> guard(m_push_mutex);
-    if (m_block_pool.empty()) {
-      return false;
-    }
-
-    if (t_height <= m_last_height ||
-        m_last_height + m_block_pool.size() < t_height) {
-      return false;
-    }
-
-    int bin_pos = t_height - m_last_height - 1;
-
-    hash_t block_hash = t_hash;
-    hash_t prev_hash = t_prev_hash;
-
-    if (t_height == 0) {
-      nth_link_type most_possible_link = getMostPossibleLink();
-      bin_pos = most_possible_link.height - m_last_height - 1;
-      prev_hash = most_possible_link.prev_hash;
-      block_hash = most_possible_link.hash;
-    }
-
-    if (bin_pos < 0) // something wrong
-      return false;
-
-    bool is_some = false;
-    for (auto &each_block : m_block_pool[bin_pos]) {
-      if ((prev_hash.empty() || each_block.block.getPrevHash() == prev_hash) &&
-          (block_hash.empty() || each_block.block.getHash() == block_hash)) {
-        ret_block = each_block.block;
-        is_some = true;
-        break;
-      }
-    }
-
-    return is_some;
-  }
-
-  // flushing out resolved blocks
+               block_height_type last_height, timestamp_t last_time);
+  bool prepareBins(block_height_type t_height);
+  void invalidateCaches();
+  unblk_push_result_type push(Block &block, bool is_restore = false);
+  bool getBlock(block_height_type t_height, const hash_t &t_prev_hash,
+                const hash_t &t_hash, Block &ret_block);
   void getResolvedBlocks(std::vector<UnresolvedBlock> &resolved_blocks,
-                         std::vector<std::string> &drop_blocks) {
-    resolved_blocks.clear();
-    drop_blocks.clear();
-
-    std::lock_guard<std::recursive_mutex> guard(m_push_mutex);
-
-    size_t num_resolved_block = 0;
-
-    do {
-      num_resolved_block = resolved_blocks.size();
-      resolveBlocksStepByStep(resolved_blocks, drop_blocks);
-    } while (num_resolved_block < resolved_blocks.size());
-
-    m_push_mutex.unlock();
-
-    auto storage = Storage::getInstance();
-
-    json id_array = readBackupIds();
-
-    if (id_array.empty() || !id_array.is_array())
-      return;
-
-    json del_id_array = json::array();
-    json new_id_array = json::array();
-
-    for (auto &each_id : id_array) {
-      bool is_dux = false;
-      std::string block_id_b64 = Safe::getString(each_id);
-      if (block_id_b64.empty())
-        continue;
-
-      for (auto &each_block : resolved_blocks) {
-        if (block_id_b64 == each_block.block.getBlockIdB64()) {
-          is_dux = true;
-          break;
-        }
-      }
-
-      if (!is_dux) {
-        new_id_array.push_back(block_id_b64);
-      } else {
-        del_id_array.push_back(block_id_b64);
-      }
-    }
-
-    storage->saveUnresolvedBlocks(
-        UNRESOLVED_BLOCK_IDS_KEY,
-        TypeConverter::bytesToString(json::to_cbor(new_id_array)));
-    storage->flushBackup();
-
-    for (auto &each_id : del_id_array) {
-      std::string block_id_b64 = Safe::getString(each_id);
-      storage->delBackup(block_id_b64);
-    }
-
-    storage->flushBackup();
-  }
-
-  nth_link_type getUnresolvedLowestLink() {
-    BlockPosOnMap longest_pos = getLongestBlockPos();
-
-    nth_link_type ret_link;
-    ret_link.height = 0; // no unresolved block or invalid link info
-
-    if (m_last_height <= longest_pos.height &&
-        longest_pos.height < m_block_pool.size() + m_last_height) {
-
-      int bin_idx = longest_pos.height - m_last_height - 1;
-
-      if (longest_pos.height == m_last_height) {
-        ret_link.height = m_last_height + 1;
-        ret_link.prev_hash = m_last_hash;
-      } else if (bin_idx >= 0) {
-        ret_link.height =
-            m_block_pool[bin_idx][longest_pos.vector_idx].block.getHeight() + 1;
-        ret_link.prev_hash =
-            m_block_pool[bin_idx][longest_pos.vector_idx].block.getHash();
-      }
-    }
-
-    return ret_link;
-  }
-
-  block_layer_t getBlockLayer(const std::string &block_id_b64) {
-    block_layer_t block_layer_of_this;
-    int bin_idx = -1;
-    int queue_idx = -1;
-    for (size_t i = 0; i < m_block_pool.size(); ++i) {
-      for (size_t j = 0; j < m_block_pool[j].size(); ++j) {
-
-        if (block_id_b64 == m_block_pool[i][j].block.getBlockIdB64()) {
-          bin_idx = i;
-          queue_idx = j;
-          break;
-        }
-      }
-      if (bin_idx >= 0 && queue_idx >= 0)
-        break;
-    }
-
-    for (int i = bin_idx; i >= 0; --i) {
-      block_layer_of_this.emplace_back(
-          m_block_pool[i][queue_idx].block.getBlockIdB64());
-      queue_idx = m_block_pool[i][queue_idx].prev_queue_idx;
-      if (queue_idx < 0) {
-        block_layer_of_this.clear();
-        break;
-      }
-    }
-
-    return block_layer_of_this;
-  }
-
-  nth_link_type getMostPossibleLink() {
-
-    if (m_cache_link_valid)
-      return m_cache_possible_link;
-
-    nth_link_type ret_link;
-
-    std::lock_guard<std::recursive_mutex> guard(m_push_mutex);
-
-    // when resolved situation, the blow are the same with storage
-    // unless, they are faster than storage
-
-    ret_link.height = m_last_height;
-    ret_link.id = m_last_block_id;
-    ret_link.hash = m_last_hash;
-
-    if (m_block_pool.empty()) {
-      m_cache_possible_link = ret_link;
-      m_cache_link_valid = true;
-      return ret_link;
-    }
-
-    BlockPosOnMap longest_pos = getLongestBlockPos();
-
-    if (ret_link.height < longest_pos.height) {
-
-      // must be larger or equal to 0
-      int deque_idx = longest_pos.height - m_last_height - 1;
-
-      if (deque_idx >= 0) {
-        auto &t_block = m_block_pool[deque_idx][longest_pos.vector_idx];
-        ret_link.height = t_block.block.getHeight();
-        ret_link.id = t_block.block.getBlockId();
-        ret_link.hash = t_block.block.getHash();
-      }
-    }
-
-    m_cache_possible_link = ret_link;
-    m_cache_link_valid = true;
-
-    return ret_link;
-  }
-
-  // reverse order
-  block_layer_t getMostPossibleBlockLayer() {
-
-    if (m_cache_layer_valid) {
-      return m_cache_possible_block_layer;
-    }
-
-    auto t_block_pos = getLongestBlockPos();
-    std::vector<std::string> ret_block_layer;
-
-    int queue_idx = t_block_pos.vector_idx;
-
-    int bin_end = t_block_pos.height - m_last_height - 1;
-
-    for (int i = bin_end; i >= 0; --i) {
-      ret_block_layer.emplace_back(
-          m_block_pool[i][queue_idx].block.getBlockIdB64());
-      queue_idx = m_block_pool[i][queue_idx].prev_queue_idx;
-    }
-
-    m_cache_possible_block_layer = ret_block_layer;
-    m_cache_layer_valid = true;
-    return ret_block_layer;
-  }
-
-  bool hasUnresolvedBlocks() {
-    CLOG(INFO, "URBK") << "Unresolved block pool status = (" << m_last_height
-                       << "," << m_height_range_max << ")";
-    return m_force_unresolved;
-  }
-
-  void restorePool() {
-
-    json id_array = readBackupIds();
-    if (id_array.empty() || !id_array.is_array())
-      return;
-
-    auto storage = Storage::getInstance();
-
-    size_t num_pused_block = 0;
-
-    for (auto &id_each : id_array) {
-      std::string block_id_b64 = Safe::getString(id_each);
-      if (!block_id_b64.empty()) {
-        std::string serialized_block =
-            storage->readUnreslovedBlocks(block_id_b64);
-        if (serialized_block.empty()) {
-          CLOG(ERROR, "URBK")
-              << "Failed to read block [" << block_id_b64 << "]";
-          continue;
-        }
-
-        Block new_block;
-        if (!new_block.deserialize(serialized_block)) {
-          CLOG(ERROR, "URBK")
-              << "Failed to deserialize block [" << block_id_b64 << "]";
-          continue;
-        }
-
-        auto push_result = push(new_block, true);
-        if (push_result.height == 0) {
-          CLOG(ERROR, "URBK")
-              << "Failed to restore block [" << block_id_b64 << "]";
-        } else {
-          ++num_pused_block;
-        }
-      }
-    }
-
-    CLOG(INFO, "URBK") << num_pused_block
-                       << " unresolved block(s) have been restored.";
-  }
+                         std::vector<std::string> &drop_blocks);
+  nth_link_type getUnresolvedLowestLink();
+  block_layer_t getBlockLayer(const std::string &block_id_b64);
+  nth_link_type getMostPossibleLink();
+  block_layer_t getMostPossibleBlockLayer();
+  bool hasUnresolvedBlocks();
+  void restorePool();
 
 private:
-  json readBackupIds() {
-    json id_array = json::array();
-
-    auto storage = Storage::getInstance();
-    std::string backup_block_ids =
-        storage->readUnreslovedBlocks(UNRESOLVED_BLOCK_IDS_KEY);
-    if (backup_block_ids.empty())
-      return id_array;
-
-    try {
-      id_array = json::from_cbor(backup_block_ids);
-    } catch (json::exception &e) {
-      CLOG(ERROR, "URBK") << "Failed to restore unresolved pool - " << e.what();
-      return id_array;
-    }
-
-    return id_array;
-  }
-
-  void backupPool() {
-
-    json id_array = json::array();
-    auto storage = Storage::getInstance();
-
-    for (auto &each_level : m_block_pool) {
-      for (auto &each_block : each_level) {
-        std::string key = each_block.block.getBlockIdB64();
-        storage->saveUnresolvedBlocks(key, each_block.block.serialize());
-        id_array.push_back(key);
-      }
-    }
-
-    storage->saveUnresolvedBlocks(
-        UNRESOLVED_BLOCK_IDS_KEY,
-        TypeConverter::bytesToString(json::to_cbor(id_array)));
-
-    storage->flushBackup();
-  }
-
-  BlockPosOnMap getLongestBlockPos() {
-    if (m_cache_pos_valid)
-      return m_cache_possible_pos;
-
-    BlockPosOnMap longest_pos;
-    longest_pos.height = 0;
-    longest_pos.vector_idx = 0;
-    if (!m_block_pool.empty()) {
-      for (size_t i = 0; i < m_block_pool[0].size(); ++i) {
-        if (m_block_pool[0][i].prev_queue_idx == 0) {
-
-          if (m_block_pool[0][i].block.getHeight() >
-              longest_pos.height) { // relaxation
-            longest_pos.height = m_block_pool[0][i].block.getHeight();
-            longest_pos.vector_idx = i;
-          }
-
-          recSearchLongestLink(0, i, longest_pos); // recursive call
-        }
-      }
-    }
-
-    m_cache_possible_pos = longest_pos;
-    m_cache_pos_valid = true;
-
-    return longest_pos;
-  }
-
-  // search prev_level + 1
-  void recSearchLongestLink(size_t prev_level, size_t prev_node,
-                            BlockPosOnMap &longest_pos) {
-    if (m_block_pool.size() <= prev_level + 1)
-      return;
-
-    // if this level is empty, it will automatically stop to search
-    for (size_t i = 0; i < m_block_pool[prev_level + 1].size(); ++i) {
-      auto &each_block = m_block_pool[prev_level + 1][i];
-      if (each_block.prev_queue_idx == prev_node) {
-        if (each_block.block.getHeight() > longest_pos.height) { // relaxation
-          longest_pos.height = each_block.block.getHeight();
-          longest_pos.vector_idx = i;
-        }
-
-        recSearchLongestLink(prev_level + 1, i, longest_pos);
-      }
-    }
-  }
-
-  void resolveBlocksStepByStep(std::vector<UnresolvedBlock> &resolved_blocks,
-                               std::vector<std::string> &drop_blocks) {
-
-    updateConfirmLevel();
-
-    if (m_block_pool.size() < 2 || m_block_pool[0].empty() ||
-        m_block_pool[1].empty())
-      return;
-
-    size_t highest_confirm_level = 0;
-    int resolved_block_idx = -1;
-
-    for (size_t i = 0; i < m_block_pool[0].size(); ++i) {
-      if (m_block_pool[0][i].prev_queue_idx == 0 &&
-          m_block_pool[0][i].confirm_level > highest_confirm_level) {
-        highest_confirm_level = m_block_pool[0][i].confirm_level;
-        resolved_block_idx = static_cast<int>(i);
-      }
-    }
-
-    if (resolved_block_idx < 0 ||
-        highest_confirm_level < config::BLOCK_CONFIRM_LEVEL)
-      return; // nothing to do
-
-    bool is_after = false;
-    for (auto &each_block : m_block_pool[1]) {
-      if (each_block.prev_queue_idx ==
-          resolved_block_idx) { // some block links this block
-        is_after = true;
-        break;
-      }
-    }
-
-    if (!is_after)
-      return;
-
-    m_last_block_id = m_block_pool[0][resolved_block_idx].block.getBlockId();
-    m_last_hash = m_block_pool[0][resolved_block_idx].block.getHash();
-    m_last_height = m_block_pool[0][resolved_block_idx].block.getHeight();
-
-    resolved_blocks.emplace_back(m_block_pool[0][resolved_block_idx]);
-
-    // clear this height list
-
-    auto leyered_storage = LayeredStorage::getInstance();
-
-    if (m_block_pool[0].size() > 1) {
-      for (auto &each_block : m_block_pool[0]) {
-        if (each_block.block.getBlockId() != m_last_block_id) {
-          drop_blocks.emplace_back(each_block.block.getBlockIdB64());
-        }
-      }
-      CLOG(INFO, "URBK") << "Dropped out " << m_block_pool[0].size() - 1
-                         << " unresolved block(s)";
-    }
-
-    m_block_pool.pop_front();
-
-    if (m_block_pool.empty())
-      return;
-
-    for (auto &each_block : m_block_pool[0]) {
-      if (each_block.block.getPrevBlockId() == m_last_block_id &&
-          each_block.block.getPrevHash() == m_last_hash) {
-        each_block.prev_queue_idx = 0;
-      } else {
-        // this block is unlinkable => to be deleted
-        each_block.prev_queue_idx = -1;
-      }
-    }
-  }
-
-  void updateConfirmLevel() {
-    if (m_block_pool.empty())
-      return;
-
-    for (auto &each_level : m_block_pool) {
-      for (auto &each_block : each_level) {
-        each_block.confirm_level = each_block.block.getNumSSigs();
-      }
-    }
-
-    for (int i = (int)m_block_pool.size() - 1; i > 0; --i) {
-      for (auto &each_block : m_block_pool[i]) { // for vector
-        if (each_block.prev_queue_idx >= 0 &&
-            m_block_pool[i - 1].size() > each_block.prev_queue_idx) {
-          m_block_pool[i - 1][each_block.prev_queue_idx].confirm_level +=
-              each_block.confirm_level;
-        }
-      }
-    }
-  }
+  block_layer_t forwardBlockToLedgerAt(int bin_idx, int vector_idx);
+  void forwardBlocksToLedgerFrom(int bin_idx, int vector_idx);
+  json readBackupIds();
+  void backupPool();
+  BlockPosOnMap getLongestBlockPos();
+  void updateConfirmLevel();
 };
 } // namespace gruut
 

--- a/src/modules/communication/merger_client.cpp
+++ b/src/modules/communication/merger_client.cpp
@@ -190,7 +190,8 @@ json MergerClient::sendToTracker(OutputMsgEntry &output_msg) {
   auto tk_info = m_conn_manager->getTrackerInfo();
   std::string address = tk_info.address + ":" + tk_info.port + "/src";
 
-  if (output_msg.type == MessageType::MSG_CHAIN_INFO) {
+  if (output_msg.type == MessageType::MSG_CHAIN_INFO ||
+      output_msg.type == MessageType::MSG_JOIN_MERGER) {
     address += "/ChainInfo.php";
     HttpClient http_client(address);
     http_client.post(send_msg);
@@ -382,7 +383,12 @@ bool MergerClient::checkSEMsgType(MessageType msg_type) {
 }
 
 bool MergerClient::checkTrackerMsgType(gruut::MessageType msg_type) {
-  return (msg_type == MessageType::MSG_CHAIN_INFO);
+  // clang-format off
+  return (
+    msg_type == MessageType::MSG_CHAIN_INFO ||
+    msg_type == MessageType::MSG_JOIN_MERGER
+    );
+  // clang-format on
 }
 
 std::string MergerClient::getApiPath(MessageType msg_type) {

--- a/src/services/layered_storage.hpp
+++ b/src/services/layered_storage.hpp
@@ -25,8 +25,10 @@ public:
     return true;
   }
 
-  template <typename T = std::string>
-  bool saveLedger(T &&key, T &&value, T &&block_id_b64 = "") {
+  bool saveLedger(const std::string &key, const std::string &value,
+                  const std::string &block_id_b64 = "") {
+
+    CLOG(INFO, "LAYS") << "new record : " << key << "[" << block_id_b64 << "]";
 
     if (block_id_b64.empty())
       return m_storage->saveLedger(key, value);

--- a/src/services/layered_storage.hpp
+++ b/src/services/layered_storage.hpp
@@ -3,7 +3,7 @@
 
 #include "../chain/mem_ledger.hpp"
 #include "../utils/template_singleton.hpp"
-
+#include "easy_logging.hpp"
 #include "storage.hpp"
 
 namespace gruut {
@@ -15,7 +15,10 @@ private:
   std::vector<std::string> m_block_layer;
 
 public:
-  LayeredStorage() { m_storage = Storage::getInstance(); }
+  LayeredStorage() {
+    el::Loggers::getLogger("LAYS");
+    m_storage = Storage::getInstance();
+  }
 
   bool saveLedger(mem_ledger_t &mem_ledger, const std::string &prefix = "") {
     m_mem_ledger.append(mem_ledger, prefix);

--- a/src/services/storage.cpp
+++ b/src/services/storage.cpp
@@ -536,12 +536,12 @@ bool Storage::isDuplicatedTx(const std::string &txid_b64) {
   return !block_id_b64.empty();
 }
 
-bool Storage::saveLedger(std::string &key, std::string &ledger) {
-  addBatch(DBType::LEDGER, key, ledger);
+bool Storage::saveLedger(const std::string &key, const std::string &value) {
+  addBatch(DBType::LEDGER, key, value);
   return true;
 }
 
-std::string Storage::readLedgerByKey(std::string &key) {
+std::string Storage::readLedgerByKey(const std::string &key) {
   return getValueByKey(DBType::LEDGER, key);
 }
 

--- a/src/services/storage.cpp
+++ b/src/services/storage.cpp
@@ -24,7 +24,7 @@ Storage::Storage() {
   errorOnCritical(leveldb::DB::Open(m_options, m_db_path + "/" + config::DB_SUB_DIR_TRANSACTION, &m_db_transaction));
   errorOnCritical(leveldb::DB::Open(m_options, m_db_path + "/" + config::DB_SUB_DIR_IDHEIGHT, &m_db_blockid_height));
   errorOnCritical(leveldb::DB::Open(m_options, m_db_path + "/" + config::DB_SUB_DIR_LEDGER, &m_db_ledger));
-  errorOnCritical(leveldb::DB::Open(m_options, m_db_path + "/" + config::DB_SUB_DIR_UNRESOLVED_BLOCK,&m_db_block_backup));
+  errorOnCritical(leveldb::DB::Open(m_options, m_db_path + "/" + config::DB_SUB_DIR_BACKUP,&m_db_backup));
   // clang-format on
 }
 
@@ -35,7 +35,7 @@ Storage::~Storage() {
   delete m_db_transaction;
   delete m_db_blockid_height;
   delete m_db_ledger;
-  delete m_db_block_backup;
+  delete m_db_backup;
 
   m_db_block_header = nullptr;
   m_db_block_raw = nullptr;
@@ -43,7 +43,7 @@ Storage::~Storage() {
   m_db_transaction = nullptr;
   m_db_blockid_height = nullptr;
   m_db_ledger = nullptr;
-  m_db_block_backup = nullptr;
+  m_db_backup = nullptr;
 }
 
 bool Storage::saveBlock(bytes &block_raw, json &block_header,
@@ -107,7 +107,7 @@ bool Storage::addBatch(DBType what, const string &base_suffix_key,
     m_batch_ledger.Put(key, value);
     break;
   case DBType::BLOCK_BACKUP:
-    m_batch_block_backup.Put(key, value);
+    m_batch_backup.Put(key, value);
     break;
   default:
     break;
@@ -288,7 +288,7 @@ std::string Storage::getValueByKey(DBType what,
     status = m_db_ledger->Get(m_read_options, key, &value);
     break;
   case DBType::BLOCK_BACKUP:
-    status = m_db_block_backup->Get(m_read_options, key, &value);
+    status = m_db_backup->Get(m_read_options, key, &value);
     break;
   default:
     break;
@@ -399,7 +399,7 @@ void Storage::destroyDB() {
   boost::filesystem::remove_all(m_db_path + "/" + config::DB_SUB_DIR_TRANSACTION);
   boost::filesystem::remove_all(m_db_path + "/" + config::DB_SUB_DIR_IDHEIGHT);
   boost::filesystem::remove_all(m_db_path + "/" + config::DB_SUB_DIR_LEDGER);
-  boost::filesystem::remove_all(m_db_path + "/" + config::DB_SUB_DIR_UNRESOLVED_BLOCK);
+  boost::filesystem::remove_all(m_db_path + "/" + config::DB_SUB_DIR_BACKUP);
   // clang-format on
 }
 
@@ -552,25 +552,24 @@ void Storage::flushLedger() {
   clearLedger();
 }
 
-void Storage::saveUnresolvedBlocks(const std::string &key,
-                                   const std::string &value) {
+void Storage::saveBackup(const std::string &key, const std::string &value) {
   addBatch(DBType::BLOCK_BACKUP, key, value);
 }
 
-void Storage::flushBackup() {
-  m_db_block_backup->Write(m_write_options, &m_batch_block_backup);
-  clearBackup();
-}
-
-void Storage::clearBackup() { m_batch_block_backup.Clear(); }
-
-std::string Storage::readUnreslovedBlocks(const std::string &key) {
+std::string Storage::readBackup(const std::string &key) {
   return getValueByKey(DBType::BLOCK_BACKUP, key);
 }
 
+void Storage::flushBackup() {
+  m_db_backup->Write(m_write_options, &m_batch_backup);
+  clearBackup();
+}
+
+void Storage::clearBackup() { m_batch_backup.Clear(); }
+
 void Storage::delBackup(const std::string &block_id_b64) {
   if (!block_id_b64.empty())
-    m_batch_block_backup.Delete(block_id_b64);
+    m_batch_backup.Delete(block_id_b64);
 }
 
 } // namespace gruut

--- a/src/services/storage.hpp
+++ b/src/services/storage.hpp
@@ -64,8 +64,8 @@ public:
   proof_type getProof(const std::string &txid_b64);
   bool isDuplicatedTx(const std::string &txid_b64);
 
-  bool saveLedger(std::string &key, std::string &ledger);
-  std::string readLedgerByKey(std::string &key);
+  bool saveLedger(const std::string &key, const std::string &value);
+  std::string readLedgerByKey(const std::string &key);
   void clearLedger();
   void flushLedger();
   bool empty();

--- a/src/services/storage.hpp
+++ b/src/services/storage.hpp
@@ -63,13 +63,15 @@ public:
   storage_block_type readBlock(block_height_type height);
   proof_type getProof(const std::string &txid_b64);
   bool isDuplicatedTx(const std::string &txid_b64);
+
   bool saveLedger(std::string &key, std::string &ledger);
   std::string readLedgerByKey(std::string &key);
   void clearLedger();
   void flushLedger();
   bool empty();
-  void saveUnresolvedBlocks(const std::string &key, const std::string &value);
-  std::string readUnreslovedBlocks(const std::string &key);
+
+  void saveBackup(const std::string &key, const std::string &value);
+  std::string readBackup(const std::string &key);
   void flushBackup();
   void clearBackup();
   void delBackup(const std::string &block_id_b64);
@@ -104,7 +106,7 @@ private:
   leveldb::DB *m_db_transaction;
   leveldb::DB *m_db_blockid_height;
   leveldb::DB *m_db_ledger;
-  leveldb::DB *m_db_block_backup;
+  leveldb::DB *m_db_backup;
 
   leveldb::WriteBatch m_batch_block_header;
   leveldb::WriteBatch m_batch_block_raw;
@@ -112,7 +114,7 @@ private:
   leveldb::WriteBatch m_batch_transaction;
   leveldb::WriteBatch m_batch_blockid_height;
   leveldb::WriteBatch m_batch_ledger;
-  leveldb::WriteBatch m_batch_block_backup;
+  leveldb::WriteBatch m_batch_backup;
 };
 } // namespace gruut
 #endif


### PR DESCRIPTION
### 이것은?!
- 기존에는 unresolved block pool이 restore 될때, mem ledger가 만들어지지 않습니다.
- 기존에는 missing block이 발생했을 때, 그 이후의 블록들에 대하여 mem ledger가 만들어지는 타이밍은 블록이 resolved 되었을 때입니다.
- 저장되었던 블록이 restore될때에는 마치 missing block 처럼 풀에 들어갈 우려가 있어, mem ledger가 정상적이지 않을 가능성이 높습니다.

### 수정
- block 에서 ledger 변환을 block processor에서 unresolved block pool에서 수행하도록 변경
- missing block이 도착하였을 때, 그 이후 연결된 모든 블록에 대해서 mem ledger를 만들도록 수정