### PR TITLE
 # FIX - possible link block info 가 초기화되지 않는 문제

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -109,9 +109,9 @@ void Application::setup() {
   if (Setting::getInstance()->getDBCheck())
     registerModule(m_block_health_checker, 0, true);
 
+  registerModule(m_block_processor, 1);
   registerModule(m_communication, 1, true);
 
-  registerModule(m_block_processor, 2);
   registerModule(m_out_message_fetcher, 2);
   registerModule(m_bootstraper, 2, true);
 


### PR DESCRIPTION
- BlockProcessor보다 Communication 실행이 먼저 되어 초기화 되지
않은 possible link 의 값을 읽어와서 사용하여, 비어있는 값을 사용함

- BlockProcessor 의 실행 순서를 올림