### PR TITLE
 # FIX - getBlockLayer() 함수에 loop 범위 문제

### DIFF
--- a/src/modules/block_processor/unresolved_block_pool.cpp
+++ b/src/modules/block_processor/unresolved_block_pool.cpp
@@ -399,7 +399,7 @@ UnresolvedBlockPool::getBlockLayer(const std::string &block_id_b64) {
 
   if (!block_id_b64.empty()) {
     for (size_t i = 0; i < m_block_pool.size(); ++i) {
-      for (size_t j = 0; j < m_block_pool[j].size(); ++j) {
+      for (size_t j = 0; j < m_block_pool[i].size(); ++j) {
 
         if (block_id_b64 == m_block_pool[i][j].block.getBlockIdB64()) {
           bin_idx = static_cast<int>(i);


### PR DESCRIPTION
- getBlockLayer 함수에서 for loop의 범위가 잘 못 되어있는 문제 해결