### PR TITLE
# FIX - Tracker로부터 받은 다른Merger Cert를 Cert pool에 저장 

### DIFF
--- a/src/modules/communication/manage_connection.hpp
+++ b/src/modules/communication/manage_connection.hpp
@@ -112,7 +112,7 @@ public:
     auto max_height = std::max_element(
         m_init_block_hgt_list.begin(), m_init_block_hgt_list.end(),
         [this](merger_height_type &a, merger_height_type &b) {
-          return (a.height > b.height);
+          return (a.height < b.height);
         });
 
     for (auto &info : m_init_block_hgt_list) {

--- a/src/modules/communication/merger_client.cpp
+++ b/src/modules/communication/merger_client.cpp
@@ -59,6 +59,8 @@ void MergerClient::accessToTracker() {
   if (response_msg.find("merger") != response_msg.end() &&
       response_msg.find("se") != response_msg.end()) {
 
+    auto cert_pool = CertificatePool::getInstance();
+
     for (auto &merger : response_msg["merger"]) {
       string merger_id_b64 = Safe::getString(merger, "mID");
       merger_id_type merger_id = TypeConverter::decodeBase64(merger_id_b64);
@@ -75,6 +77,8 @@ void MergerClient::accessToTracker() {
       merger_info.port = Safe::getString(merger, "port");
       merger_info.cert = Safe::getString(merger, "mCert");
 
+      cert_pool->pushCert(merger_id, merger_info.cert);
+
       m_conn_manager->setMergerInfo(merger_info, true);
     }
 
@@ -90,6 +94,8 @@ void MergerClient::accessToTracker() {
       se_info.address = Safe::getString(se, "ip");
       se_info.port = Safe::getString(se, "port");
       se_info.cert = Safe::getString(se, "seCert");
+
+      cert_pool->pushCert(se_id, se_info.cert);
 
       m_conn_manager->setSeInfo(se_info, true);
     }


### PR DESCRIPTION
### 수정사항
- Tracker로 부터 받아온 Merger의 정보 중 Certificate를 Cert pool에
저장하지 않아 block 검증을 실패 하는 문제가 있었음. Cert pool에 저장하도록 하여 문제해결

### 기타수정
- ConnManager의 getMaxBlockHgtMergers()가 "Min" hgt값을 반환하고 있어서 부등호 방향 수정
( 이전에 "min" 값을 반환하여 block sync를 하지 않고 넘어가는 문제가 발생. 하였음)