### PR TITLE
 # FIX - Block Synchronizer sync_flag 로 인한 문제 수정

### DIFF
--- a/src/modules/bootstraper/block_synchronizer.cpp
+++ b/src/modules/bootstraper/block_synchronizer.cpp
@@ -105,6 +105,7 @@ void BlockSynchronizer::messageFetch() {
     if (pushed_block_height > 0) {
 
       std::lock_guard<std::mutex> guard(m_sync_flags_mutex);
+
       if (pushed_block_height > m_link_from.height) {
         size_t req_map_size = pushed_block_height - m_link_from.height;
         if (m_sync_flags.size() < req_map_size)
@@ -112,6 +113,7 @@ void BlockSynchronizer::messageFetch() {
 
         m_sync_flags[req_map_size - 1] = true; // last or this
       }
+
       m_sync_flags_mutex.unlock();
     }
   } break;
@@ -210,9 +212,14 @@ void BlockSynchronizer::sendRequestLastBlock() {
   if (last_block_height > m_link_from.height) {
     sendRequestBlock(last_block_height, last_block_hash_b64,
                      TypeConverter::decodeBase64(t_merger_id_b64));
+
+    std::lock_guard<std::mutex> guard(m_sync_flags_mutex);
+
     size_t req_map_size = last_block_height - m_link_from.height;
     if (m_sync_flags.size() < req_map_size)
       m_sync_flags.resize(req_map_size, false);
+
+    m_sync_flags_mutex.unlock();
   }
 
   m_is_sync_begin = true;

--- a/src/modules/bootstraper/block_synchronizer.cpp
+++ b/src/modules/bootstraper/block_synchronizer.cpp
@@ -104,6 +104,7 @@ void BlockSynchronizer::messageFetch() {
         Application::app().getBlockProcessor().handleMsgBlock(input_msg_entry);
     if (pushed_block_height > 0) {
 
+      std::lock_guard<std::mutex> guard(m_sync_flags_mutex);
       if (pushed_block_height > m_link_from.height) {
         size_t req_map_size = pushed_block_height - m_link_from.height;
         if (m_sync_flags.size() < req_map_size)
@@ -111,6 +112,7 @@ void BlockSynchronizer::messageFetch() {
 
         m_sync_flags[req_map_size - 1] = true; // last or this
       }
+      m_sync_flags_mutex.unlock();
     }
   } break;
 

--- a/src/modules/bootstraper/block_synchronizer.hpp
+++ b/src/modules/bootstraper/block_synchronizer.hpp
@@ -59,6 +59,7 @@ private:
   std::map<std::string, OtherStatusData> m_chain_status;
 
   std::mutex m_chain_mutex;
+  std::mutex m_sync_flags_mutex;
 
 public:
   BlockSynchronizer();


### PR DESCRIPTION
- sync flag가 공유자원으로 thread safe하지 않아서, mutex를 사용하도록 함