### PR TITLE
# EDIT - possible link 에서 추가정보를 가져 올 수 있도록 함.

### DIFF
--- a/src/modules/block_processor/block_processor.cpp
+++ b/src/modules/block_processor/block_processor.cpp
@@ -31,8 +31,9 @@ BlockProcessor::BlockProcessor() {
 void BlockProcessor::start() {
   auto last_block_info = m_storage->getNthBlockLinkInfo();
 
-  m_unresolved_block_pool.setPool(last_block_info.id, last_block_info.hash,
-                                  last_block_info.height, last_block_info.time);
+  m_unresolved_block_pool.setPool(
+      last_block_info.id, last_block_info.prev_id, last_block_info.hash,
+      last_block_info.prev_hash, last_block_info.height, last_block_info.time);
 
   m_unresolved_block_pool.restorePool();
 

--- a/src/modules/block_processor/block_processor.cpp
+++ b/src/modules/block_processor/block_processor.cpp
@@ -242,7 +242,7 @@ block_height_type BlockProcessor::handleMsgBlock(InputMsgEntry &entry) {
     OutputMsgEntry msg_chain_info;
     msg_chain_info.type = MessageType::MSG_CHAIN_INFO;
     msg_chain_info.body["msgID"] = to_string((int)MessageType::MSG_CHAIN_INFO);
-    msg_chain_info.body["mID"] = Safe::getString(entry.body, "mID");
+    msg_chain_info.body["mID"] = m_my_id_b64;
     msg_chain_info.body["cID"] = m_my_chain_id_b64;
     msg_chain_info.body["time"] = to_string(possible_link.time);
     msg_chain_info.body["hgt"] = to_string(possible_link.height);

--- a/src/modules/block_processor/unresolved_block_pool.cpp
+++ b/src/modules/block_processor/unresolved_block_pool.cpp
@@ -22,11 +22,15 @@ bool UnresolvedBlockPool::hasUnresolvedBlocks() {
 }
 
 void UnresolvedBlockPool::setPool(const block_id_type &last_block_id,
+                                  const block_id_type &prev_block_id,
                                   const hash_t &last_hash,
+                                  const hash_t &prev_hash,
                                   block_height_type last_height,
                                   timestamp_t last_time) {
   m_last_block_id = last_block_id;
+  m_prev_block_id = prev_block_id;
   m_last_hash = last_hash;
+  m_prev_block_id = prev_hash;
   m_last_height = last_height;
   m_last_time = last_time;
   m_height_range_max = last_height;
@@ -276,6 +280,9 @@ void UnresolvedBlockPool::getResolvedBlocks(
         if (!is_after)
           return;
 
+        m_prev_block_id = m_last_block_id;
+        m_prev_hash = m_last_hash;
+
         m_last_block_id =
             m_block_pool[0][resolved_block_idx].block.getBlockId();
         m_last_hash = m_block_pool[0][resolved_block_idx].block.getHash();
@@ -443,6 +450,9 @@ nth_link_type UnresolvedBlockPool::getMostPossibleLink() {
   ret_link.height = m_last_height;
   ret_link.id = m_last_block_id;
   ret_link.hash = m_last_hash;
+  ret_link.prev_id = m_prev_block_id;
+  ret_link.prev_hash = m_prev_hash;
+  ret_link.time = m_last_time;
 
   if (m_block_pool.empty()) {
     m_cache_possible_link = ret_link;
@@ -462,6 +472,9 @@ nth_link_type UnresolvedBlockPool::getMostPossibleLink() {
       ret_link.height = t_block.block.getHeight();
       ret_link.id = t_block.block.getBlockId();
       ret_link.hash = t_block.block.getHash();
+      ret_link.prev_hash = t_block.block.getPrevBlockId();
+      ret_link.prev_id = t_block.block.getPrevHash();
+      ret_link.time = t_block.block.getTime();
     }
   }
 

--- a/src/modules/block_processor/unresolved_block_pool.hpp
+++ b/src/modules/block_processor/unresolved_block_pool.hpp
@@ -44,7 +44,9 @@ private:
   std::recursive_mutex m_push_mutex;
 
   block_id_type m_last_block_id;
+  block_id_type m_prev_block_id;
   hash_t m_last_hash;
+  hash_t m_prev_hash;
   std::atomic<block_height_type> m_last_height;
   timestamp_t m_last_time;
 
@@ -67,8 +69,10 @@ public:
   inline size_t size() { return m_block_pool.size(); }
   inline bool empty() { return m_block_pool.empty(); }
   inline void clear() { m_block_pool.clear(); }
-  void setPool(const block_id_type &last_block_id, const hash_t &last_hash,
-               block_height_type last_height, timestamp_t last_time);
+  void setPool(const block_id_type &last_block_id,
+               const block_id_type &prev_block_id, const hash_t &last_hash,
+               const hash_t &prev_hash, block_height_type last_height,
+               timestamp_t last_time);
   bool prepareBins(block_height_type t_height);
   void invalidateCaches();
   unblk_push_result_type push(Block &block, bool is_restore = false);


### PR DESCRIPTION
 ### 수정사항
- Possible link에서 prevHash, prevbID, block 생성 시간 을 가져 읽어 올 수 있도록 함. 
( 이전에 해당 정보들을 가져올 수 없어서 Tracker에 정상적으로 정보가 업데이트 되지 않음)

 ### 기타수정
- MSG_CHAIN_INFO를 보낼 때 자신의 id가 아닌 block 생성자의 id를 적어서 보내 tracker에서 업데이트가 정상적으로 이뤄지지 않던점 수정