### PR TITLE
# ADD - MSG_REQ_HEADER 처리 로직 추가

### DIFF
--- a/src/modules/block_processor/block_processor.cpp
+++ b/src/modules/block_processor/block_processor.cpp
@@ -100,6 +100,9 @@ void BlockProcessor::handleMessage(InputMsgEntry &entry) {
   case MessageType::MSG_REQ_STATUS:
     handleMsgReqStatus(entry);
     break;
+  case MessageType::MSG_REQ_HEADER:
+    handleMsgRequestHeader(entry);
+    break;
   default:
     break;
   }
@@ -187,6 +190,50 @@ void BlockProcessor::handleMsgReqBlock(InputMsgEntry &entry) {
                      << ",#tx=" << ret_block.getNumTransactions() << ")";
 
   m_msg_proxy.deliverOutputMessage(msg_block);
+}
+
+void BlockProcessor::handleMsgRequestHeader(InputMsgEntry &entry) {
+  auto sender_id = Safe::getBytesFromB64<id_type>(entry.body, "rID");
+
+  if (m_unresolved_block_pool.empty() && m_storage->empty()) {
+    CLOG(ERROR, "BPRO") << "Storage is empty (height=" << req_block_height
+                        << ")";
+    sendErrorMessage(ErrorMsgType::NO_SUCH_BLOCK, sender_id);
+    return;
+  }
+
+  block_height_type req_block_height = Safe::getInt(entry.body, "hgt");
+
+  bool found_block = false;
+  Block ret_block;
+  if (m_unresolved_block_pool.getBlock(req_block_height, ret_block)) {
+    found_block = true;
+  }
+
+  if (!found_block) { // no block in unresolved block pool, then try storage
+    storage_block_type saved_block = m_storage->readBlock(req_block_height);
+    if (saved_block.height > 0) {
+      found_block = true;
+      ret_block.initialize(saved_block);
+    }
+  }
+
+  if (!found_block) {
+    CLOG(ERROR, "BPRO") << "No such block (height=" << req_block_height
+                        << ")";
+    sendErrorMessage(ErrorMsgType::NO_SUCH_BLOCK, sender_id);
+    return;
+  }
+
+  OutputMsgEntry msg_header_msg;
+  msg_header_msg.type = MessageType::MSG_REQ_HEADER;
+  msg_header_msg.body["blockraw"] = ret_block.getBlockHeaderJson();
+  msg_header_msg.receivers = std::vector<id_type>{};
+
+  CLOG(INFO, "BPRO") << "Send MSG_HEADER (height=" << ret_block.getHeight()
+                     << ",#tx=" << ret_block.getNumTransactions() << ")";
+
+  m_msg_proxy.deliverOutputMessage(msg_header_msg);
 }
 
 block_height_type BlockProcessor::handleMsgBlock(InputMsgEntry &entry) {

--- a/src/modules/block_processor/block_processor.hpp
+++ b/src/modules/block_processor/block_processor.hpp
@@ -67,6 +67,7 @@ public:
 private:
   void periodicTask();
   void handleMsgReqBlock(InputMsgEntry &entry);
+  void handleMsgRequestHeader(InputMsgEntry &entry);
   void handleMsgReqCheck(InputMsgEntry &entry);
   void handleMsgReqStatus(InputMsgEntry &entry);
   void sendErrorMessage(ErrorMsgType t_error_typem, id_type &recv_id);

--- a/src/modules/block_processor/unresolved_block_pool.cpp
+++ b/src/modules/block_processor/unresolved_block_pool.cpp
@@ -229,6 +229,41 @@ bool UnresolvedBlockPool::getBlock(block_height_type t_height,
   return is_some;
 }
 
+bool UnresolvedBlockPool::getBlock(block_height_type t_height, Block &ret_block) {
+  std::lock_guard<std::recursive_mutex> guard(m_push_mutex);
+
+  if (m_block_pool.empty()) {
+    return false;
+  }
+
+  if (t_height <= m_last_height ||
+      m_last_height + m_block_pool.size() < t_height) {
+    return false;
+  }
+
+  int bin_pos = static_cast<int>(t_height - m_last_height) - 1;
+
+  if (t_height == 0) {
+    nth_link_type most_possible_link = getMostPossibleLink();
+    bin_pos = static_cast<int>(most_possible_link.height - m_last_height) - 1;
+  }
+
+  if (bin_pos < 0) // something wrong
+    return false;
+
+  auto it = std::find_if(m_block_pool[bin_pos].begin(), m_block_pool[bin_pos].end(), [&t_height](UnresolvedBlock &unresolvedBlock) {
+    return unresolvedBlock.block.getHeight() == t_height;
+  });
+
+  if(it != m_block_pool[bin_pos].end()) {
+    ret_block = (*it).block;
+    return true;
+  }
+  else {
+    return false;
+  }
+}
+
 // flushing out resolved blocks
 void UnresolvedBlockPool::getResolvedBlocks(
     std::vector<UnresolvedBlock> &resolved_blocks,

--- a/src/modules/block_processor/unresolved_block_pool.hpp
+++ b/src/modules/block_processor/unresolved_block_pool.hpp
@@ -74,6 +74,7 @@ public:
   unblk_push_result_type push(Block &block, bool is_restore = false);
   bool getBlock(block_height_type t_height, const hash_t &t_prev_hash,
                 const hash_t &t_hash, Block &ret_block);
+  bool getBlock(block_height_type t_height, Block &ret_block);
   void getResolvedBlocks(std::vector<UnresolvedBlock> &resolved_blocks,
                          std::vector<std::string> &drop_blocks);
   nth_link_type getUnresolvedLowestLink();

--- a/src/services/message_proxy.cpp
+++ b/src/services/message_proxy.cpp
@@ -43,7 +43,8 @@ void MessageProxy::deliverInputMessage(InputMsgEntry &input_message) {
     case MessageType::MSG_REQ_CHECK:
     case MessageType::MSG_BLOCK:
     case MessageType::MSG_REQ_BLOCK:
-    case MessageType::MSG_REQ_STATUS: {
+    case MessageType::MSG_REQ_STATUS:
+    case MessageType::MSG_REQ_HEADER: {
       Application::app().getBlockProcessor().handleMessage(input_message);
     } break;
     default:

--- a/src/services/message_validator.hpp
+++ b/src/services/message_validator.hpp
@@ -87,7 +87,7 @@ const std::vector<std::tuple<MessageType, std::string, EntryType, EntryLength>> 
 
     {MessageType::MSG_REQ_HEADER, "rID", EntryType::BASE64, EntryLength::ID},
     {MessageType::MSG_REQ_HEADER, "time", EntryType::TIMESTAMP, EntryLength::NOT_LIMITED},
-    {MessageType::MSG_REQ_HEADER, "rCert", EntryType::STRING, EntryLength::ID},
+    {MessageType::MSG_REQ_HEADER, "rCert", EntryType::STRING, EntryLength::NOT_LIMITED},
     {MessageType::MSG_REQ_HEADER, "hgt", EntryType::UINT, EntryLength::NOT_LIMITED},
     {MessageType::MSG_REQ_HEADER, "rSig", EntryType::BASE64, EntryLength::NOT_LIMITED},
 
@@ -136,7 +136,7 @@ private:
     case EntryType::BASE64: {
       std::string temp = Safe::getString(msg_body, key);
       std::regex rgx(
-          "([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)");
+          "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$");
 
       if (!temp.empty() && std::regex_match(temp, rgx))
         return true;


### PR DESCRIPTION
## 추가사항
- BlockProcessor#handleMsgRequestHeader
  * Block이 존재하는지 검사해서 있으면 SE에게 보내도록 함
- UnresolvedBlockPool 에서 block을 height로 찾기 위해 getBlock 오버로딩
- MessageValidator에서 Base64 검사하는 regex 수정
  * capturing group 을 사용할 이유가 없어서 non capturing group으로 변경
  * 엄밀한 검사를 위해 ^, $ 추가