### PR TITLE
#ADD - added MSG_TX forwarding

### DIFF
--- a/src/modules/bp_scheduler/bp_scheduler.cpp
+++ b/src/modules/bp_scheduler/bp_scheduler.cpp
@@ -37,7 +37,7 @@ BpScheduler::BpScheduler() {
 void BpScheduler::start() {
 
   m_up_slot = Time::now_int() / config::BP_INTERVAL;
-  updateRecvStatus(m_my_mid_b64, m_up_slot, BpStatus::IN_BOOT_WAIT);
+  updateRecvStatus(m_my_mid, m_up_slot, BpStatus::IN_BOOT_WAIT);
 
   m_lock_scheduler.runTaskOnTime();
   m_ping_scheduler.runTaskOnTime();
@@ -74,7 +74,7 @@ void BpScheduler::reschedule() {
 
   BpRecvStatusInfo my_bp_status;
   for (BpRecvStatusInfo &item : m_recv_status) {
-    if (m_my_mid_b64 == std::get<0>(item)) {
+    if (m_my_mid == std::get<0>(item)) {
       my_bp_status = item;
       break;
     }
@@ -89,7 +89,7 @@ void BpScheduler::reschedule() {
   }
 
   size_t my_pos = 0;
-  std::vector<std::tuple<std::string, BpStatus, BpStatus>> possible_merger_list;
+  std::vector<std::tuple<merger_id_type, BpStatus, BpStatus>> possible_merger_list;
   bool is_all_idle = true;
   for (BpRecvStatusInfo &item : m_recv_status) {
     size_t time_slot = std::get<1>(item);
@@ -104,20 +104,23 @@ void BpScheduler::reschedule() {
       is_all_idle = false;
     }
 
-    if (m_my_mid_b64 == std::get<0>(item)) {
+    if (m_my_mid == std::get<0>(item)) {
       my_pos = possible_merger_list.size() - 1;
     }
   }
 
   size_t num_possible_mergers = possible_merger_list.size();
 
-  if (num_possible_mergers ==
-      0) { // in this case, we cannot determine current status
+  if (num_possible_mergers == 0) {
+    // in this case, we cannot determine current status
     return;
   }
 
+  m_block_producers.clear();
+
   if (num_possible_mergers == 1) { // I am the only merger
     m_current_status = BpStatus::PRIMARY;
+    m_block_producers.emplace_back(m_my_mid);
     return;
   }
 
@@ -129,6 +132,11 @@ void BpScheduler::reschedule() {
       m_current_status = BpStatus::SECONDARY;
     else
       m_current_status = BpStatus::IDLE;
+
+    m_block_producers.emplace_back(std::get<0>(possible_merger_list[0]));
+    if(num_possible_mergers >= 2){
+      m_block_producers.emplace_back(std::get<0>(possible_merger_list[1]));
+    }
 
     return;
   }
@@ -159,10 +167,14 @@ void BpScheduler::reschedule() {
     }
   }
 
+
   // step 2) find SECONDARY
 
   size_t secondary_pos = (primary_pos + 1) % num_possible_mergers;
   std::get<2>(possible_merger_list[secondary_pos]) = BpStatus::SECONDARY;
+
+  m_block_producers.emplace_back(std::get<0>(possible_merger_list[primary_pos]));
+  m_block_producers.emplace_back(std::get<0>(possible_merger_list[secondary_pos]));
 
   // step 3) all others will be IDLE
 
@@ -181,7 +193,7 @@ void BpScheduler::reschedule() {
 void BpScheduler::lockStatus() {
   m_is_lock = true; // lock to update status
   Application::app().getTransactionCollector().setTxCollectStatus(
-      m_current_status);
+      m_current_status, m_block_producers);
 }
 
 void BpScheduler::sendPingMessage() {
@@ -215,17 +227,17 @@ void BpScheduler::sendPingMessage() {
                      << "," << statusToString(m_current_status) << ")";
 
   m_is_lock = false; // unlock to update status
-  updateRecvStatus(m_my_mid_b64, current_slot, m_current_status);
+  updateRecvStatus(m_my_mid, current_slot, m_current_status);
 }
 
-void BpScheduler::updateRecvStatus(const std::string &id_b64, size_t timeslot,
+void BpScheduler::updateRecvStatus(const merger_id_type &merger_id, size_t timeslot,
                                    BpStatus stat) {
 
   // NO-BAKGGU table!
 
   bool is_updatable = false;
   for (BpRecvStatusInfo &item : m_recv_status) {
-    if (std::get<0>(item) == id_b64) {
+    if (std::get<0>(item) == merger_id) {
       std::lock_guard<std::mutex> lock(m_recv_status_mutex);
       is_updatable = true;
       std::get<1>(item) = timeslot;
@@ -237,7 +249,7 @@ void BpScheduler::updateRecvStatus(const std::string &id_b64, size_t timeslot,
 
   if (!is_updatable) {
     std::lock_guard<std::mutex> lock(m_recv_status_mutex);
-    m_recv_status.emplace_back(make_tuple(id_b64, timeslot, stat));
+    m_recv_status.emplace_back(make_tuple(merger_id, timeslot, stat));
     std::sort(m_recv_status.begin(), m_recv_status.end(),
               [](const BpRecvStatusInfo &a, const BpRecvStatusInfo &b) {
                 return get<0>(a) < get<0>(b);
@@ -253,6 +265,7 @@ void BpScheduler::handleMessage(InputMsgEntry &msg) {
     return; // wrong chain
 
   std::string merger_id_b64 = Safe::getString(msg.body, "mID");
+  merger_id_type merger_id = Safe::getBytesFromB64<merger_id_type>(msg.body, "mID");
   timestamp_t merger_time = Safe::getTime(msg.body, "time");
   size_t timeslot = merger_time / config::BP_INTERVAL;
 
@@ -269,19 +282,19 @@ void BpScheduler::handleMessage(InputMsgEntry &msg) {
     BpStatus status = stringToStatus(Safe::getString(msg.body, "stat"));
     if (num_singers < config::MIN_SIGNATURE_COLLECT_SIZE)
       status = BpStatus::ERROR_ON_SIGNERS;
-    updateRecvStatus(merger_id_b64, timeslot, status);
+    updateRecvStatus(merger_id, timeslot, status);
 
   } break;
   case MessageType::MSG_UP: {
 
     MergerInfo merger_info;
-    merger_info.id = TypeConverter::decodeBase64(merger_id_b64);
+    merger_info.id = merger_id;
     merger_info.address = Safe::getString(msg.body, "ip");
     merger_info.port = Safe::getString(msg.body, "port");
     merger_info.cert = Safe::getString(msg.body, "mCert");
     m_conn_manager->setMergerInfo(merger_info, true);
 
-    updateRecvStatus(merger_id_b64, timeslot, BpStatus::IN_BOOT_WAIT);
+    updateRecvStatus(merger_id, timeslot, BpStatus::IN_BOOT_WAIT);
 
     OutputMsgEntry output_msg;
     output_msg.type = MessageType::MSG_WELCOME;
@@ -289,7 +302,7 @@ void BpScheduler::handleMessage(InputMsgEntry &msg) {
     output_msg.body["cID"] = m_my_cid_b64;
     output_msg.body["time"] = Time::now();
     output_msg.body["val"] = true;
-    output_msg.receivers = {TypeConverter::decodeBase64(merger_id_b64)};
+    output_msg.receivers = {merger_id};
 
     MessageProxy msg_proxy;
     msg_proxy.deliverOutputMessage(output_msg);

--- a/src/modules/bp_scheduler/bp_scheduler.hpp
+++ b/src/modules/bp_scheduler/bp_scheduler.hpp
@@ -31,7 +31,7 @@ const std::map<BpStatus, std::string> STATUS_STRING = {
     {BpStatus::UNKNOWN, "UNKNOWN"},
 };
 
-using BpRecvStatusInfo = std::tuple<std::string, size_t, BpStatus>;
+using BpRecvStatusInfo = std::tuple<merger_id_type, size_t, BpStatus>;
 
 class BpScheduler : public Module {
 public:
@@ -44,7 +44,7 @@ private:
   void sendPingMessage();
   void lockStatus();
 
-  void updateRecvStatus(const std::string &id_b64, size_t timeslot,
+  void updateRecvStatus(const merger_id_type &merger_id, size_t timeslot,
                         BpStatus stat);
   void reschedule();
 
@@ -63,6 +63,7 @@ private:
   std::atomic<bool> m_welcome{true};
 
   std::vector<BpRecvStatusInfo> m_recv_status;
+  std::vector<merger_id_type> m_block_producers;
 
   std::mutex m_recv_status_mutex;
 

--- a/src/modules/communication/merger_client.cpp
+++ b/src/modules/communication/merger_client.cpp
@@ -351,6 +351,7 @@ bool MergerClient::checkMergerMsgType(MessageType msg_type) {
   return (
       msg_type == MessageType::MSG_UP ||
       msg_type == MessageType::MSG_PING ||
+      msg_type == MessageType::MSG_TX ||
       msg_type == MessageType::MSG_REQ_BLOCK ||
       msg_type == MessageType::MSG_WELCOME ||
       msg_type == MessageType::MSG_REQ_STATUS ||

--- a/src/services/message_proxy.cpp
+++ b/src/services/message_proxy.cpp
@@ -14,43 +14,40 @@ void MessageProxy::deliverInputMessage(InputMsgEntry &input_message) {
   if (input_message.type != MessageType::MSG_TX)
     CLOG(INFO, "MPRX") << "MSG IN: 0x" << std::hex << (int)input_message.type;
 
-  auto message_type = input_message.type;
-  auto message_body_json = input_message.body;
+  //auto message_type = input_message.type;
+  //auto message_body_json = input_message.body;
 
-  MessageValidator validator;
-
-  if (validator.validate(input_message)) {
-    switch (message_type) {
-    case MessageType::MSG_JOIN:
-    case MessageType::MSG_RESPONSE_1:
-    case MessageType::MSG_SUCCESS:
-    case MessageType::MSG_LEAVE: {
-      Application::app().getSignerPoolManager().handleMessage(
-          message_type, message_body_json);
-    } break;
-    case MessageType::MSG_TX: {
-      Application::app().getTransactionCollector().handleMessage(
-          message_body_json);
-    } break;
-    case MessageType::MSG_SSIG: {
-      Application::app().getSignaturePool().handleMessage(message_body_json);
-    } break;
-    case MessageType::MSG_PING:
-    case MessageType::MSG_UP:
-    case MessageType::MSG_WELCOME: {
-      Application::app().getBpScheduler().handleMessage(input_message);
-    } break;
-    case MessageType::MSG_REQ_CHECK:
-    case MessageType::MSG_BLOCK:
-    case MessageType::MSG_REQ_BLOCK:
-    case MessageType::MSG_REQ_STATUS: {
-      Application::app().getBlockProcessor().handleMessage(input_message);
-    } break;
-    default:
-      break;
-    }
-  } else {
+  if (m_validator.validate(input_message)) {
     CLOG(ERROR, "MPRX") << "Incomming message is not valid";
+    return;
+  }
+
+  switch (input_message.type) {
+  case MessageType::MSG_JOIN:
+  case MessageType::MSG_RESPONSE_1:
+  case MessageType::MSG_SUCCESS:
+  case MessageType::MSG_LEAVE: {
+    Application::app().getSignerPoolManager().handleMessage(input_message);
+  } break;
+  case MessageType::MSG_TX: {
+    Application::app().getTransactionCollector().handleMessage(input_message);
+  } break;
+  case MessageType::MSG_SSIG: {
+    Application::app().getSignaturePool().handleMessage(input_message);
+  } break;
+  case MessageType::MSG_PING:
+  case MessageType::MSG_UP:
+  case MessageType::MSG_WELCOME: {
+    Application::app().getBpScheduler().handleMessage(input_message);
+  } break;
+  case MessageType::MSG_REQ_CHECK:
+  case MessageType::MSG_BLOCK:
+  case MessageType::MSG_REQ_BLOCK:
+  case MessageType::MSG_REQ_STATUS: {
+    Application::app().getBlockProcessor().handleMessage(input_message);
+  } break;
+  default:
+    break;
   }
 }
 

--- a/src/services/message_proxy.cpp
+++ b/src/services/message_proxy.cpp
@@ -14,7 +14,7 @@ void MessageProxy::deliverInputMessage(InputMsgEntry &input_message) {
   if (input_message.type != MessageType::MSG_TX)
     CLOG(INFO, "MPRX") << "MSG IN: 0x" << std::hex << (int)input_message.type;
 
-  if (m_validator.validate(input_message)) {
+  if (!m_validator.validate(input_message)) {
     CLOG(ERROR, "MPRX") << "Incomming message is not valid";
     return;
   }

--- a/src/services/message_proxy.hpp
+++ b/src/services/message_proxy.hpp
@@ -20,6 +20,7 @@ public:
 
 private:
   OutputQueueAlt *m_output_queue;
+  MessageValidator m_validator;
 };
 } // namespace gruut
 

--- a/src/services/signature_pool.cpp
+++ b/src/services/signature_pool.cpp
@@ -12,20 +12,20 @@ SignaturePool::SignaturePool() {
   el::Loggers::getLogger("SPOL");
 }
 
-void SignaturePool::handleMessage(json &msg_body_json) {
+void SignaturePool::handleMessage(InputMsgEntry &input_message) {
   if (!m_enabled) {
     CLOG(ERROR, "SPOL") << "Support Signature dropped (disabled pool)";
     return;
   }
 
-  signer_id_type signer_id = Safe::getBytesFromB64(msg_body_json, "sID");
+  signer_id_type signer_id = Safe::getBytesFromB64(input_message.body, "sID");
 
-  if (verifySignature(signer_id, msg_body_json)) {
+  if (verifySignature(signer_id, input_message.body)) {
     Signature ssig;
 
     ssig.signer_id = signer_id;
     ssig.height = m_height;
-    ssig.signer_signature = Safe::getBytesFromB64(msg_body_json, "sig");
+    ssig.signer_signature = Safe::getBytesFromB64(input_message.body, "sig");
 
     push(ssig);
 

--- a/src/services/signature_pool.hpp
+++ b/src/services/signature_pool.hpp
@@ -23,7 +23,7 @@ class SignaturePool {
 public:
   SignaturePool();
 
-  void handleMessage(json &);
+  void handleMessage(InputMsgEntry &input_message);
 
   void push(Signature &signature);
 

--- a/src/services/signer_pool_manager.hpp
+++ b/src/services/signer_pool_manager.hpp
@@ -43,7 +43,7 @@ struct JoinTemporaryData {
 class SignerPoolManager {
 public:
   SignerPoolManager();
-  void handleMessage(MessageType &message_type, json &message_body_json);
+  void handleMessage(InputMsgEntry &input_message);
 
 private:
   bool verifySignature(signer_id_type &signer_id, json &message_body_json);

--- a/src/services/transaction_collector.hpp
+++ b/src/services/transaction_collector.hpp
@@ -32,13 +32,17 @@ enum class BpJobStatus { DO, DONT, UNKNOWN };
 class TransactionCollector {
 public:
   TransactionCollector();
-  void handleMessage(json &msg_body_json);
-  void setTxCollectStatus(BpStatus status);
+  void handleMessage(InputMsgEntry &input_message);
+  void setTxCollectStatus(BpStatus status, std::vector<merger_id_type> &block_producers);
 
 private:
   bool isRunnable();
   void turnOnTimer();
   void checkBpJob();
+
+  void forwardMessage(merger_id_type &block_producer, InputMsgEntry &input_message);
+
+  std::vector<merger_id_type> m_block_producers;
 
   BpStatus m_current_tx_status{BpStatus::IN_BOOT_WAIT};
   BpStatus m_next_tx_status{BpStatus::UNKNOWN};
@@ -46,12 +50,17 @@ private:
   SignatureRequester m_signature_requester;
   std::deque<BpJobStatus> m_bpjob_sequence;
 
+  std::vector<merger_id_type> m_current_block_producers;
+  std::vector<merger_id_type> m_next_block_producers;
+
   Storage *m_storage;
   CertificatePool *m_cert_pool;
 
   std::map<id_type, std::string> m_cert_map;
 
   std::once_flag m_timer_once_flag;
+
+  MessageProxy m_msg_proxy;
 };
 } // namespace gruut
 #endif


### PR DESCRIPTION
### 추가
- IDLE 상태일 때 받은 MSG_TX 를 primary block producer에게 포워딩하는 기능 추가
- argument로 기능을 켜고 끌 수 있도록 수정 (옵션 --txforward)

### 테스트
- JJJ가 수행
- 포워딩하려는 순간 BP 슬롯이 바뀌면서 포워딩을 했는데, 해당 머저가 더이상 primary가 아니게 되어, 2번 포워딩하는 경우가 있음
- 이게 막아야 하는지 허용해야 하는지 판단이 서지 않아, 그냥 허용하는 걸로 놔둠

### 주의
- 머저의 수가 적을 때, SE가 모든 머저에게 보내므로 duplicated TX로 드럽되는 경우가 발생할 것으로 예상
- 하지만, 머저의 수가 늘어나게 되면, SE가 모든 머저에게 보내는 것이 부담되므로 포워딩 방식이 더 나음.