### PR TITLE
# ADD - 파일로 Merger 정보 저장

### DIFF
--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -62,6 +62,7 @@ const std::string DB_SUB_DIR_TRANSACTION = "transaction";
 const std::string DB_SUB_DIR_IDHEIGHT = "blockid_height";
 const std::string DB_SUB_DIR_LEDGER = "ledger";
 const std::string DB_SUB_DIR_BACKUP = "backup";
+const std::string DB_SUB_DIR_MERGER_INFO = "merger_info";
 
 // clang-format on
 

--- a/src/modules/bp_scheduler/bp_scheduler.cpp
+++ b/src/modules/bp_scheduler/bp_scheduler.cpp
@@ -296,6 +296,7 @@ void BpScheduler::handleMessage(InputMsgEntry &msg) {
     merger_info.port = Safe::getString(msg.body, "port");
     merger_info.cert = Safe::getString(msg.body, "mCert");
     m_conn_manager->setMergerInfo(merger_info, true);
+    m_conn_manager->writeMergerInfo(msg.body);
 
     updateRecvStatus(merger_id, timeslot, BpStatus::IN_BOOT_WAIT);
 
@@ -330,6 +331,9 @@ void BpScheduler::handleMessage(InputMsgEntry &msg) {
         msg.body.find("se") != msg.body.end()) {
 
       m_conn_manager->setMultiMergerInfo(msg.body["merger"]);
+      for(auto &merger_info : msg.body["merger"])
+        m_conn_manager->writeMergerInfo(merger_info);
+
       m_conn_manager->setMultiSeInfo(msg.body["se"]);
     }
 

--- a/src/modules/bp_scheduler/bp_scheduler.cpp
+++ b/src/modules/bp_scheduler/bp_scheduler.cpp
@@ -331,9 +331,11 @@ void BpScheduler::handleMessage(InputMsgEntry &msg) {
         msg.body.find("se") != msg.body.end()) {
 
       m_conn_manager->setMultiMergerInfo(msg.body["merger"]);
-      for(auto &merger_info : msg.body["merger"])
+      for (auto &merger_info : msg.body["merger"]) {
+        if (m_my_mid_b64 == merger_id_b64)
+          continue;
         m_conn_manager->writeMergerInfo(merger_info);
-
+      }
       m_conn_manager->setMultiSeInfo(msg.body["se"]);
     }
 

--- a/src/modules/bp_scheduler/bp_scheduler.cpp
+++ b/src/modules/bp_scheduler/bp_scheduler.cpp
@@ -296,6 +296,10 @@ void BpScheduler::handleMessage(InputMsgEntry &msg) {
     merger_info.port = Safe::getString(msg.body, "port");
     merger_info.cert = Safe::getString(msg.body, "mCert");
     m_conn_manager->setMergerInfo(merger_info, true);
+
+    msg.body.erase("time");
+    msg.body.erase("ver");
+    msg.body.erase("cID");
     m_conn_manager->writeMergerInfo(msg.body);
 
     updateRecvStatus(merger_id, timeslot, BpStatus::IN_BOOT_WAIT);
@@ -334,6 +338,7 @@ void BpScheduler::handleMessage(InputMsgEntry &msg) {
       for (auto &merger_info : msg.body["merger"]) {
         if (m_my_mid_b64 == merger_id_b64)
           continue;
+
         m_conn_manager->writeMergerInfo(merger_info);
       }
       m_conn_manager->setMultiSeInfo(msg.body["se"]);

--- a/src/modules/communication/communication.cpp
+++ b/src/modules/communication/communication.cpp
@@ -61,5 +61,7 @@ void Communication::setUpConnList() {
   for (auto &se_info : se_list) {
     conn_manager->setSeInfo(se_info, true);
   }
+
+  conn_manager->readMergerInfo();
 }
 } // namespace gruut

--- a/src/modules/communication/manage_connection.hpp
+++ b/src/modules/communication/manage_connection.hpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <atomic>
 #include <boost/filesystem.hpp>
+#include <iomanip>
 #include <iostream>
 #include <map>
 #include <mutex>
@@ -277,7 +278,7 @@ public:
     std::string file_name = m_merger_info_path + "/" + merger_id_b64 + ".json";
 
     std::ofstream ofs(file_name);
-    ofs << merger_info;
+    ofs << std::setw(4) << merger_info << std::endl;
   }
 
 private:

--- a/src/modules/communication/manage_connection.hpp
+++ b/src/modules/communication/manage_connection.hpp
@@ -4,17 +4,26 @@
 #include "../../services/setting.hpp"
 #include "../../utils/template_singleton.hpp"
 #include "../../utils/type_converter.hpp"
+
 #include <algorithm>
 #include <atomic>
+#include <boost/filesystem.hpp>
+#include <iostream>
 #include <map>
 #include <mutex>
 #include <thread>
+
+using namespace boost::filesystem;
 
 namespace gruut {
 
 class ConnManager : public TemplateSingleton<ConnManager> {
 public:
-  ConnManager() = default;
+  ConnManager() {
+    m_setting = Setting::getInstance();
+    m_merger_info_path =
+        m_setting->getMyDbPath() + "/" + config::DB_SUB_DIR_MERGER_INFO;
+  }
 
   void setTrackerInfo(TrackerInfo &tracker_info, bool conn_status = false) {
     std::string tk_id_b64 = TypeConverter::encodeBase64(tracker_info.id);
@@ -69,8 +78,8 @@ public:
   void setMultiMergerInfo(json &merger_list) {
 
     auto cert_pool = CertificatePool::getInstance();
-    auto setting = Setting::getInstance();
-    std::string my_id_b64 = TypeConverter::encodeBase64(setting->getMyId());
+
+    std::string my_id_b64 = TypeConverter::encodeBase64(m_setting->getMyId());
     for (auto &merger : merger_list) {
 
       std::string merger_id_b64 = Safe::getString(merger, "mID");
@@ -244,7 +253,31 @@ public:
 
   void clearBlockHgtList() { m_init_block_hgt_list.clear(); }
 
+  void readMergerInfo() {
+
+    if (exists(m_merger_info_path))
+      return;
+
+    json merger_list = json::array();
+    for (const auto &entry : directory_iterator(m_merger_info_path)) {
+      std::ifstream ifs(entry.path().string());
+      json merger_info = json::parse(ifs);
+
+      merger_list.emplace_back(merger_info);
+    }
+    setMultiMergerInfo(merger_list);
+  }
+
+  void writeMergerInfo() {
+
+    if (!exists(m_merger_info_path))
+      create_directories(m_merger_info_path);
+  }
+
 private:
+  Setting *m_setting;
+  std::string m_merger_info_path;
+
   TrackerInfo m_tracker_info;
   std::map<string, MergerInfo> m_merger_info;
   std::map<string, ServiceEndpointInfo> m_se_info;

--- a/src/modules/communication/manage_connection.hpp
+++ b/src/modules/communication/manage_connection.hpp
@@ -255,7 +255,7 @@ public:
 
   void readMergerInfo() {
 
-    if (exists(m_merger_info_path))
+    if (!exists(m_merger_info_path))
       return;
 
     json merger_list = json::array();

--- a/src/modules/communication/merger_client.cpp
+++ b/src/modules/communication/merger_client.cpp
@@ -61,6 +61,7 @@ void MergerClient::accessToTracker() {
       if (my_id_b64 == merger_id_b64)
         continue;
 
+      merger_info.erase("hgt");
       m_conn_manager->writeMergerInfo(merger_info);
     }
 

--- a/src/modules/communication/merger_client.cpp
+++ b/src/modules/communication/merger_client.cpp
@@ -56,6 +56,9 @@ void MergerClient::accessToTracker() {
       response_msg.find("se") != response_msg.end()) {
 
     m_conn_manager->setMultiMergerInfo(response_msg["merger"]);
+    for(auto& merger_info : response_msg["merger"])
+      m_conn_manager->writeMergerInfo(merger_info);
+
     m_conn_manager->setMultiSeInfo(response_msg["se"]);
   }
 

--- a/src/modules/communication/merger_client.cpp
+++ b/src/modules/communication/merger_client.cpp
@@ -56,8 +56,13 @@ void MergerClient::accessToTracker() {
       response_msg.find("se") != response_msg.end()) {
 
     m_conn_manager->setMultiMergerInfo(response_msg["merger"]);
-    for(auto& merger_info : response_msg["merger"])
+    for (auto &merger_info : response_msg["merger"]) {
+      std::string merger_id_b64 = Safe::getString(merger_info, "mID");
+      if (my_id_b64 == merger_id_b64)
+        continue;
+
       m_conn_manager->writeMergerInfo(merger_info);
+    }
 
     m_conn_manager->setMultiSeInfo(response_msg["se"]);
   }
@@ -187,6 +192,8 @@ void MergerClient::sendToSE(std::vector<id_type> &receiver_list,
     }
   } else {
     for (auto &receiver_id : receiver_list) {
+      if (!m_conn_manager->hasSeInfo(receiver_id))
+        continue;
       auto service_endpoint = m_conn_manager->getSeInfo(receiver_id);
       if (service_endpoint.conn_status) {
         std::string address =


### PR DESCRIPTION
 ### 추가사항 
- Tracker에서 얻은 Merger들의 정보를 json 파일로 저장
- MSG_UP / MSG_WELCOME 에서 받은 Merger 정보를  json 파일로 저장
- Merger 정보 read/write 함수 추가

 ### 테스트 사항
- dbpath에 merger_info directory가 생성되고 해당 directory에 다른 merger들의 정보가 json  형태로 저장 되는 것 확인. 
- Tracker에 접근 하지 못하거나 비활성화되어 다른 Merger들의 정보를 받아오지 못할 경우 해당 파일을 읽어 다른 Merger와 통신 하는 것 확인.

 ### 기타 수정사항
- MSG_ERROR는  Merger 뿐만 아니라 SE로도 보내게 되어있다.
receiver id를 찾아 해당되는 곳으로만 보내면 된다. 이때  SE receiver_id가 아니면 SE에게는 보내지 않도록 함.
