### PR TITLE
 # FIX - Write self-info 문제

### DIFF
--- a/src/modules/bp_scheduler/bp_scheduler.cpp
+++ b/src/modules/bp_scheduler/bp_scheduler.cpp
@@ -336,7 +336,8 @@ void BpScheduler::handleMessage(InputMsgEntry &msg) {
 
       m_conn_manager->setMultiMergerInfo(msg.body["merger"]);
       for (auto &merger_info : msg.body["merger"]) {
-        if (m_my_mid_b64 == merger_id_b64)
+        std::string merger_info_id_b64 = Safe::getString(merger_info, "mID");
+        if (m_my_mid_b64 == merger_info_id_b64)
           continue;
 
         m_conn_manager->writeMergerInfo(merger_info);


### PR DESCRIPTION
 ### 문제점 및 해결
- MSG_WELCOME을 받을 시 자신의 정보도 저장하고 있었음
- MSG_WELCOME에 포함된 Merger들의 ID와 비교하는게 아닌 다른 송신자의
ID와 비교하는게 문제가 되었음.

- ID를 MSG_WELCOME에 포함된 Merger ID로 비교하도록 수정